### PR TITLE
Reg alterations

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -26,6 +26,7 @@ public class GraphQLDataFetchers {
     final TissueTypeRepo tissueTypeRepo;
     final LabwareTypeRepo labwareTypeRepo;
     final MediumRepo mediumRepo;
+    final FixativeRepo fixativeRepo;
     final MouldSizeRepo mouldSizeRepo;
     final HmdmcRepo hmdmcRepo;
 
@@ -33,13 +34,14 @@ public class GraphQLDataFetchers {
     public GraphQLDataFetchers(ObjectMapper objectMapper, SessionConfig sessionConfig,
                                UserRepo userRepo,
                                TissueTypeRepo tissueTypeRepo, LabwareTypeRepo labwareTypeRepo,
-                               MediumRepo mediumRepo, MouldSizeRepo mouldSizeRepo, HmdmcRepo hmdmcRepo) {
+                               MediumRepo mediumRepo, FixativeRepo fixativeRepo, MouldSizeRepo mouldSizeRepo, HmdmcRepo hmdmcRepo) {
         this.objectMapper = objectMapper;
         this.sessionConfig = sessionConfig;
         this.userRepo = userRepo;
         this.tissueTypeRepo = tissueTypeRepo;
         this.labwareTypeRepo = labwareTypeRepo;
         this.mediumRepo = mediumRepo;
+        this.fixativeRepo = fixativeRepo;
         this.mouldSizeRepo = mouldSizeRepo;
         this.hmdmcRepo = hmdmcRepo;
     }
@@ -73,6 +75,10 @@ public class GraphQLDataFetchers {
 
     public DataFetcher<Iterable<Hmdmc>> getHmdmcs() {
         return dfe -> hmdmcRepo.findAll();
+    }
+
+    public DataFetcher<Iterable<Fixative>> getFixatives() {
+        return dfe -> fixativeRepo.findAll();
     }
 
     private boolean requestsField(DataFetchingEnvironment dfe, String childName) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -68,6 +68,7 @@ public class GraphQLProvider {
                         .dataFetcher("hmdmcs", graphQLDataFetchers.getHmdmcs())
                         .dataFetcher("labwareTypes", graphQLDataFetchers.getLabwareTypes())
                         .dataFetcher("mediums", graphQLDataFetchers.getMediums())
+                        .dataFetcher("fixatives", graphQLDataFetchers.getFixatives())
                         .dataFetcher("mouldSizes", graphQLDataFetchers.getMouldSizes())
                 )
                 .type(newTypeWiring("Mutation")

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Fixative.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Fixative.java
@@ -1,0 +1,57 @@
+package uk.ac.sanger.sccp.stan.model;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+/**
+ * @author dr6
+ */
+@Entity
+public class Fixative {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    private String name;
+
+    public Fixative() {}
+
+    public Fixative(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Fixative that = (Fixative) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.name, that.name));
+    }
+
+    @Override
+    public int hashCode() {
+        return (id!=null ? id.hashCode() : name!=null ? name.hashCode() : 0);
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Tissue.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Tissue.java
@@ -24,12 +24,14 @@ public class Tissue {
     @ManyToOne
     private Medium medium;
     @ManyToOne
+    private Fixative fixative;
+    @ManyToOne
     private Hmdmc hmdmc;
 
     public Tissue() {}
 
     public Tissue(Integer id, String externalName, Integer replicate, SpatialLocation spatialLocation, Donor donor,
-                  MouldSize mouldSize, Medium medium, Hmdmc hmdmc) {
+                  MouldSize mouldSize, Medium medium, Fixative fixative, Hmdmc hmdmc) {
         this.id = id;
         this.externalName = externalName;
         this.replicate = replicate;
@@ -37,6 +39,7 @@ public class Tissue {
         this.donor = donor;
         this.mouldSize = mouldSize;
         this.medium = medium;
+        this.fixative = fixative;
         this.hmdmc = hmdmc;
     }
 
@@ -100,6 +103,14 @@ public class Tissue {
         this.medium = medium;
     }
 
+    public Fixative getFixative() {
+        return this.fixative;
+    }
+
+    public void setFixative(Fixative fixative) {
+        this.fixative = fixative;
+    }
+
     public Hmdmc getHmdmc() {
         return this.hmdmc;
     }
@@ -120,7 +131,8 @@ public class Tissue {
                 && Objects.equals(this.mouldSize, that.mouldSize)
                 && Objects.equals(this.medium, that.medium)
                 && Objects.equals(this.donor, that.donor)
-                && Objects.equals(this.hmdmc, that.hmdmc));
+                && Objects.equals(this.hmdmc, that.hmdmc)
+                && Objects.equals(this.fixative, that.fixative));
     }
 
     @Override
@@ -138,6 +150,7 @@ public class Tissue {
                 .add("donor", donor)
                 .add("mouldSize", mouldSize)
                 .add("medium", medium)
+                .add("fixative", fixative)
                 .add("hmdmc", hmdmc)
                 .toString();
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/FixativeRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/FixativeRepo.java
@@ -1,0 +1,10 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.Fixative;
+
+import java.util.Optional;
+
+public interface FixativeRepo extends CrudRepository<Fixative, Integer> {
+    Optional<Fixative> findByName(String name);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/TissueRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/TissueRepo.java
@@ -3,8 +3,10 @@ package uk.ac.sanger.sccp.stan.repo;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.Tissue;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TissueRepo extends CrudRepository<Tissue, Integer> {
-    Optional<Tissue> findByExternalNameAndReplicate(String externalIdentifier, int replicate);
+    Optional<Tissue> findByExternalName(String externalName);
+    List<Tissue> findByDonorIdAndSpatialLocationIdAndReplicate(int donorId, int spatialLocationId, int replicate);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/TissueRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/TissueRepo.java
@@ -3,10 +3,15 @@ package uk.ac.sanger.sccp.stan.repo;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.Tissue;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface TissueRepo extends CrudRepository<Tissue, Integer> {
     Optional<Tissue> findByExternalName(String externalName);
-    List<Tissue> findByDonorIdAndSpatialLocationIdAndReplicate(int donorId, int spatialLocationId, int replicate);
+    Optional<Tissue> findByDonorIdAndSpatialLocationIdAndMediumIdAndFixativeIdAndReplicate(
+            int donorId,
+            int spatialLocationId,
+            int mediumId,
+            int fixativeId,
+            int replicate
+    );
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/BlockRegisterRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/BlockRegisterRequest.java
@@ -21,6 +21,7 @@ public class BlockRegisterRequest {
     private String labwareType;
     private String medium;
     private String mouldSize;
+    private String fixative;
 
     public String getDonorIdentifier() {
         return this.donorIdentifier;
@@ -102,6 +103,14 @@ public class BlockRegisterRequest {
         this.medium = medium;
     }
 
+    public String getFixative() {
+        return this.fixative;
+    }
+
+    public void setFixative(String fixative) {
+        this.fixative = fixative;
+    }
+
     public String getMouldSize() {
         return this.mouldSize;
     }
@@ -125,12 +134,13 @@ public class BlockRegisterRequest {
                 && Objects.equals(this.externalIdentifier, that.externalIdentifier)
                 && Objects.equals(this.labwareType, that.labwareType)
                 && Objects.equals(this.medium, that.medium)
+                && Objects.equals(this.fixative, that.fixative)
                 && Objects.equals(this.mouldSize, that.mouldSize));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(externalIdentifier, replicateNumber);
+        return (externalIdentifier!=null ? externalIdentifier.hashCode() : 0);
     }
 
     @Override
@@ -146,6 +156,7 @@ public class BlockRegisterRequest {
                 .add("highestSection", highestSection)
                 .add("labwareType", labwareType)
                 .add("medium", medium)
+                .add("fixative", fixative)
                 .add("mouldSize", mouldSize)
                 .toString();
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterServiceImp.java
@@ -83,6 +83,7 @@ public class RegisterServiceImp implements RegisterService {
                     donors.get(block.getDonorIdentifier().toUpperCase()),
                     validation.getMouldSize(block.getMouldSize()),
                     validation.getMedium(block.getMedium()),
+                    validation.getFixative(block.getFixative()),
                     validation.getHmdmc(block.getHmdmc()));
             tissue = tissueRepo.save(tissue);
             tissueList.add(tissue);

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidation.java
@@ -18,4 +18,6 @@ public interface RegisterValidation {
     MouldSize getMouldSize(String name);
 
     Medium getMedium(String name);
+
+    Fixative getFixative(String name);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationFactory.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationFactory.java
@@ -23,6 +23,7 @@ public class RegisterValidationFactory {
     private LabwareTypeRepo ltRepo;
     private MouldSizeRepo mouldSizeRepo;
     private MediumRepo mediumRepo;
+    private FixativeRepo fixativeRepo;
     private TissueRepo tissueRepo;
     private Validator<String> donorNameValidation;
     private Validator<String> externalNameValidation;
@@ -30,13 +31,14 @@ public class RegisterValidationFactory {
     @Autowired
     public RegisterValidationFactory(DonorRepo donorRepo, HmdmcRepo hmdmcRepo, TissueTypeRepo ttRepo,
                                      LabwareTypeRepo ltRepo, MouldSizeRepo mouldSizeRepo, MediumRepo mediumRepo,
-                                     TissueRepo tissueRepo) {
+                                     FixativeRepo fixativeRepo, TissueRepo tissueRepo) {
         this.donorRepo = donorRepo;
         this.hmdmcRepo = hmdmcRepo;
         this.ttRepo = ttRepo;
         this.ltRepo = ltRepo;
         this.mouldSizeRepo = mouldSizeRepo;
         this.mediumRepo = mediumRepo;
+        this.fixativeRepo = fixativeRepo;
         this.tissueRepo = tissueRepo;
         Set<CharacterType> charTypes = EnumSet.of(
                 CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT, CharacterType.HYPHEN, CharacterType.UNDERSCORE
@@ -47,6 +49,6 @@ public class RegisterValidationFactory {
 
     public RegisterValidation createRegisterValidation(RegisterRequest request) {
         return new RegisterValidationImp(request, donorRepo, hmdmcRepo, ttRepo, ltRepo, mouldSizeRepo, mediumRepo,
-                tissueRepo, donorNameValidation, externalNameValidation);
+                fixativeRepo, tissueRepo, donorNameValidation, externalNameValidation);
     }
 }

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -131,6 +131,23 @@
     </changeSet>
 
     <changeSet id="9" author="dr6">
+        <createTable tableName="fixative">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(64)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="10" author="dr6">
         <createTable tableName="spatial_location">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -161,7 +178,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="10" author="dr6">
+    <changeSet id="11" author="dr6">
         <createTable tableName="labware_type">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -187,7 +204,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="11" author="dr6">
+    <changeSet id="12" author="dr6">
         <createTable tableName="donor">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -207,7 +224,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="12" author="dr6">
+    <changeSet id="13" author="dr6">
         <createTable tableName="tissue">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -219,10 +236,10 @@
                 <constraints nullable="false"/>
             </column>
             <column name="medium_id" type="INT">
-                <constraints nullable="true" foreignKeyName="tissue_fk_medium" referencedTableName="medium" referencedColumnNames="id"/>
+                <constraints nullable="false" foreignKeyName="tissue_fk_medium" referencedTableName="medium" referencedColumnNames="id"/>
             </column>
             <column name="mould_size_id" type="INT">
-                <constraints nullable="true" foreignKeyName="tissue_fk_mould_size" referencedTableName="mould_size" referencedColumnNames="id"/>
+                <constraints nullable="false" foreignKeyName="tissue_fk_mould_size" referencedTableName="mould_size" referencedColumnNames="id"/>
             </column>
             <column name="spatial_location_id" type="INT">
                 <constraints nullable="false" foreignKeyName="tissue_fk_spatial_location" referencedTableName="spatial_location" referencedColumnNames="id"/>
@@ -233,6 +250,9 @@
             <column name="donor_id" type="INT">
                 <constraints nullable="false" foreignKeyName="tissue_fk_donor" referencedTableName="donor" referencedColumnNames="id"/>
             </column>
+            <column name="fixative_id" type="INT">
+                <constraints nullable="false" foreignKeyName="tissue_fk_fixative" referencedTableName="fixative" referencedColumnNames="id"/>
+            </column>
             <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
@@ -240,10 +260,11 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <createIndex tableName="tissue" indexName="tissue_key_donor_spatial_location_medium_replicate" unique="true">
+        <createIndex tableName="tissue" indexName="tissue_key_donor_spatial_location_medium_fixative_replicate" unique="true">
             <column name="donor_id"/>
             <column name="spatial_location_id"/>
             <column name="medium_id"/>
+            <column name="fixative_id"/>
             <column name="replicate"/>
         </createIndex>
         <rollback>
@@ -252,7 +273,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="13" author="dr6">
+    <changeSet id="14" author="dr6">
         <createTable tableName="sample">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -272,7 +293,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="14" author="dr6">
+    <changeSet id="15" author="dr6">
         <createTable tableName="labware">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -292,7 +313,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="15" author="dr6">
+    <changeSet id="16" author="dr6">
         <createTable tableName="slot">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -324,7 +345,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="16" author="dr6">
+    <changeSet id="17" author="dr6">
         <createTable tableName="slot_sample">
             <column name="slot_id" type="INT">
                 <constraints nullable="false" foreignKeyName="slot_sample_fk_slot" referencedTableName="slot" referencedColumnNames="id"/>
@@ -346,7 +367,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="17" author="dr6">
+    <changeSet id="18" author="dr6">
         <createTable tableName="block_info">
             <column name="slot_id" type="INT">
                 <constraints nullable="false" foreignKeyName="block_info_fk_slot" referencedTableName="slot" referencedColumnNames="id"/>
@@ -371,7 +392,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="18" author="dr6">
+    <changeSet id="19" author="dr6">
         <createTable tableName="operation">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -394,7 +415,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="19" author="dr6">
+    <changeSet id="20" author="dr6">
         <createTable tableName="action">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -430,7 +451,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="20" author="dr6">
+    <changeSet id="21" author="dr6">
         <createTable tableName="barcode_seed">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -438,13 +459,13 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="21" author="dr6">
+    <changeSet id="101" author="dr6">
         <loadData tableName="operation_type" file="db/operationtypes.csv">
             <column name="name" header="name" type="string"/>
         </loadData>
     </changeSet>
 
-    <changeSet id="22" author="dr6">
+    <changeSet id="102" author="dr6">
         <insert tableName="tissue_type">
             <column name="name" value="Unknown"/>
             <column name="code" value="???"/>
@@ -452,25 +473,25 @@
         </insert>
     </changeSet>
 
-    <changeSet id="23" author="dr6">
+    <changeSet id="103" author="dr6">
         <loadData tableName="tissue_type" file="db/tissuetypes.tsv" separator="\t">
             <column name="name" header="name" type="string"/>
             <column name="code" header="code" type="string"/>
         </loadData>
     </changeSet>
 
-    <changeSet id="24" author="dr6">
+    <changeSet id="104" author="dr6">
         <sqlFile path="db/spatiallocations.sql" />
     </changeSet>
 
-    <changeSet id="25" author="dr6">
+    <changeSet id="105" author="dr6">
         <loadData tableName="label_type" file="db/labeltypes.tsv" separator="\t">
             <column name="id" header="id" type="numeric"/>
             <column name="name" header="name" type="string"/>
         </loadData>
     </changeSet>
 
-    <changeSet id="26" author="dr6">
+    <changeSet id="106" author="dr6">
         <loadData tableName="labware_type" file="db/labwaretypes.tsv" separator="\t">
             <column name="name" header="name" type="string"/>
             <column name="label_type_id" header="label_type_id" type="numeric"/>
@@ -479,20 +500,26 @@
         </loadData>
     </changeSet>
 
-    <changeSet id="27" author="dr6">
+    <changeSet id="107" author="dr6">
         <loadData tableName="hmdmc" file="db/hmdmcs.csv">
             <column name="hmdmc" header="hmdmc" type="string"/>
         </loadData>
     </changeSet>
 
-    <changeSet id="28" author="dr6">
+    <changeSet id="108" author="dr6">
         <loadData tableName="mould_size" file="db/mouldsizes.csv">
             <column name="name" header="name" type="string"/>
         </loadData>
     </changeSet>
 
-    <changeSet id="29" author="dr6">
+    <changeSet id="109" author="dr6">
         <loadData tableName="medium" file="db/mediums.csv">
+            <column name="name" header="name" type="string"/>
+        </loadData>
+    </changeSet>
+
+    <changeSet id="110" author="dr6">
+        <loadData tableName="fixative" file="db/fixatives.csv">
             <column name="name" header="name" type="string"/>
         </loadData>
     </changeSet>

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -213,7 +213,7 @@
                 <constraints nullable="false" primaryKey="true"/>
             </column>
             <column name="external_name" type="VARCHAR(64)">
-                <constraints nullable="false"/>
+                <constraints nullable="false" unique="true"/>
             </column>
             <column name="replicate" type="INT">
                 <constraints nullable="false"/>
@@ -240,8 +240,10 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <createIndex tableName="tissue" indexName="tissue_key_external_name_replicate" unique="true">
-            <column name="external_name"/>
+        <createIndex tableName="tissue" indexName="tissue_key_donor_spatial_location_medium_replicate" unique="true">
+            <column name="donor_id"/>
+            <column name="spatial_location_id"/>
+            <column name="medium_id"/>
             <column name="replicate"/>
         </createIndex>
         <rollback>

--- a/src/main/resources/db/fixatives.csv
+++ b/src/main/resources/db/fixatives.csv
@@ -1,0 +1,3 @@
+name
+None
+Formalin

--- a/src/main/resources/db/mediums.csv
+++ b/src/main/resources/db/mediums.csv
@@ -1,4 +1,4 @@
 name
-Fresh OCT
-Fixed OCT
+None
+OCT
 Paraffin

--- a/src/main/resources/db/mouldsizes.csv
+++ b/src/main/resources/db/mouldsizes.csv
@@ -1,3 +1,6 @@
 name
-Small mould
-Big mould
+None
+Other
+10x10
+15x15
+30x24

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -12,6 +12,10 @@ type Medium {
     name: String!,
 }
 
+type Fixative {
+    name: String!,
+}
+
 type MouldSize {
     name: String!,
 }
@@ -53,8 +57,9 @@ type Tissue {
     spatialLocation: SpatialLocation!,
     donor: Donor!,
     hmdmc: Hmdmc!,
-    mouldSize: MouldSize,
-    medium: Medium,
+    mouldSize: MouldSize!,
+    medium: Medium!,
+    fixative: Fixative!,
 }
 
 type Address {
@@ -97,8 +102,9 @@ input BlockRegisterRequest {
     externalIdentifier: String!,
     highestSection: Int!,
     labwareType: String!,
-    medium: String,
-    mouldSize: String,
+    medium: String!,
+    fixative: String!,
+    mouldSize: String!,
 }
 
 input RegisterRequest {
@@ -116,6 +122,7 @@ type Query {
     labwareTypes: [LabwareType!]!,
     hmdmcs: [Hmdmc!]!,
     mediums: [Medium!]!,
+    fixatives: [Fixative!]!,
     mouldSizes: [MouldSize!]!,
 }
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
@@ -24,6 +24,7 @@ public class EntityFactory {
     private static Hmdmc hmdmc;
     private static MouldSize mouldSize;
     private static Medium medium;
+    private static Fixative fixative;
     private static int idCounter = 10_000;
 
     public static User getUser() {
@@ -82,7 +83,7 @@ public class EntityFactory {
     public static Tissue getTissue() {
         if (tissue==null) {
             tissue = new Tissue(80, "TISSUE1", 1, getSpatialLocation(), getDonor(),
-                    null, null, getHmdmc());
+                    getMouldSize(), getMedium(), getFixative(), getHmdmc());
         }
         return tissue;
     }
@@ -106,6 +107,13 @@ public class EntityFactory {
             medium = new Medium(160, "Butter");
         }
         return medium;
+    }
+
+    public static Fixative getFixative() {
+        if (fixative==null) {
+            fixative = new Fixative(170, "Formalin");
+        }
+        return fixative;
     }
 
     public static Labware getTube() {

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterService.java
@@ -138,7 +138,9 @@ public class TestRegisterService {
         TissueType tissueType = EntityFactory.getTissueType();
         MouldSize mouldSize = EntityFactory.getMouldSize();
         Medium medium = EntityFactory.getMedium();
+        Fixative fixative = EntityFactory.getFixative();
         Hmdmc[] hmdmcs = {new Hmdmc(20000, "20/000"), new Hmdmc(20001, "20/001")};
+
         BlockRegisterRequest block0 = new BlockRegisterRequest();
         block0.setDonorIdentifier(donor.getDonorName());
         block0.setLifeStage(donor.getLifeStage());
@@ -147,10 +149,12 @@ public class TestRegisterService {
         block0.setHmdmc("20/000");
         block0.setLabwareType(lts[0].getName());
         block0.setMedium(medium.getName());
+        block0.setFixative(fixative.getName());
         block0.setMouldSize(mouldSize.getName());
         block0.setTissueType(tissueType.getName());
         block0.setReplicateNumber(2);
         block0.setSpatialLocation(1);
+
         BlockRegisterRequest block1 = new BlockRegisterRequest();
         block1.setDonorIdentifier(donor.getDonorName());
         block1.setLifeStage(donor.getLifeStage());
@@ -158,6 +162,9 @@ public class TestRegisterService {
         block1.setTissueType(tissueType.getName());
         block1.setSpatialLocation(0);
         block1.setLabwareType(lts[1].getName());
+        block1.setMedium(medium.getName().toUpperCase());
+        block1.setFixative(fixative.getName().toUpperCase());
+        block1.setMouldSize(mouldSize.getName().toUpperCase());
         block1.setHighestSection(0);
         block1.setExternalIdentifier("TISSUE1");
         block1.setHmdmc("20/001");
@@ -174,6 +181,7 @@ public class TestRegisterService {
                 .thenReturn(sls[1]);
         when(mockValidation.getMouldSize(eqCi(mouldSize.getName()))).thenReturn(mouldSize);
         when(mockValidation.getMedium(eqCi(medium.getName()))).thenReturn(medium);
+        when(mockValidation.getFixative(eqCi(fixative.getName()))).thenReturn(fixative);
         Arrays.stream(lts).forEach(lt -> when(mockValidation.getLabwareType(eqCi(lt.getName()))).thenReturn(lt));
         Arrays.stream(hmdmcs).forEach(h -> when(mockValidation.getHmdmc(eqCi(h.getHmdmc()))).thenReturn(h));
         RegisterRequest request = new RegisterRequest(List.of(block0, block1));
@@ -182,9 +190,9 @@ public class TestRegisterService {
 
         Tissue[] tissues = new Tissue[]{
                 new Tissue(5000, block0.getExternalIdentifier(), block0.getReplicateNumber(),
-                        sls[0], donor, mouldSize, medium, hmdmcs[0]),
+                        sls[0], donor, mouldSize, medium, fixative, hmdmcs[0]),
                 new Tissue(5001, block1.getExternalIdentifier(), block1.getReplicateNumber(),
-                        sls[1], donor, null, null, hmdmcs[1]),
+                        sls[1], donor, mouldSize, medium, fixative, hmdmcs[1]),
         };
 
         Sample[] samples = new Sample[]{
@@ -212,8 +220,9 @@ public class TestRegisterService {
                             block.getReplicateNumber(),
                             sls[i],
                             donor,
-                            i == 0 ? mouldSize : null,
-                            i == 0 ? medium : null,
+                            mouldSize,
+                            medium,
+                            fixative,
                             hmdmcs[i]
                     ));
             verify(mockSampleRepo).save(new Sample(null, null, tissues[i]));

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidation.java
@@ -1,5 +1,6 @@
 package uk.ac.sanger.sccp.stan.service.register;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Streams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,6 @@ import uk.ac.sanger.sccp.stan.service.register.RegisterValidationImp.StringIntKe
 
 import java.util.*;
 import java.util.function.*;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -37,6 +37,7 @@ public class TestRegisterValidation {
     private LabwareTypeRepo mockLtRepo;
     private MouldSizeRepo mockMouldSizeRepo;
     private MediumRepo mockMediumRepo;
+    private FixativeRepo mockFixativeRepo;
     private TissueRepo mockTissueRepo;
     private Validator<String> mockDonorNameValidation;
     private Validator<String> mockExternalNameValidation;
@@ -50,6 +51,7 @@ public class TestRegisterValidation {
         mockMouldSizeRepo = mock(MouldSizeRepo.class);
         mockMediumRepo = mock(MediumRepo.class);
         mockTissueRepo = mock(TissueRepo.class);
+        mockFixativeRepo = mock(FixativeRepo.class);
         //noinspection unchecked
         mockDonorNameValidation = mock(Validator.class);
         //noinspection unchecked
@@ -58,7 +60,7 @@ public class TestRegisterValidation {
 
     private RegisterValidationImp create(RegisterRequest request) {
         return spy(new RegisterValidationImp(request, mockDonorRepo, mockHmdmcRepo, mockTtRepo, mockLtRepo,
-                mockMouldSizeRepo, mockMediumRepo, mockTissueRepo, mockDonorNameValidation, mockExternalNameValidation));
+                mockMouldSizeRepo, mockMediumRepo, mockFixativeRepo, mockTissueRepo, mockDonorNameValidation, mockExternalNameValidation));
     }
 
     private void stubValidationMethods(RegisterValidationImp validation) {
@@ -69,6 +71,7 @@ public class TestRegisterValidation {
         doNothing().when(validation).validateMouldSizes();
         doNothing().when(validation).validateMediums();
         doNothing().when(validation).validateTissues();
+        doNothing().when(validation).validateFixatives();
     }
 
     private void verifyValidateMethods(RegisterValidationImp validation, VerificationMode verificationMode) {
@@ -79,6 +82,7 @@ public class TestRegisterValidation {
         verify(validation, verificationMode).validateMouldSizes();
         verify(validation, verificationMode).validateMediums();
         verify(validation, verificationMode).validateTissues();
+        verify(validation, verificationMode).validateFixatives();
     }
 
     @Test
@@ -253,9 +257,21 @@ public class TestRegisterValidation {
     }
 
     @ParameterizedTest
+    @MethodSource("fixativeData")
+    public void testValidateFixatives(List<Fixative> knownItems, List<String> givenNames,
+                                      List<Fixative> expectedItems, List<String> expectedProblems) {
+        when(mockFixativeRepo.findByName(any())).then(invocation -> {
+            final String arg = invocation.getArgument(0);
+            return knownItems.stream().filter(item -> arg.equalsIgnoreCase(item.getName())).findAny();
+        });
+        testValidateSimpleField(givenNames, expectedItems, expectedProblems,
+                RegisterValidationImp::validateFixatives, Fixative::getName, BlockRegisterRequest::setFixative,
+                v -> v.fixativeMap, RegisterValidationImp::getFixative);
+    }
+
+    @ParameterizedTest
     @MethodSource("tissueData")
-    public void testValidateTissues(List<String> names, List<Integer> replicates, List<Integer> highestSections,
-                                    List<Tissue> knownTissues, List<String> expectedProblems) {
+    public void testValidateTissues(final List<ValidateTissueTestData> testData, List<String> expectedProblems) {
         when(mockExternalNameValidation.validate(any(), any())).then(invocation -> {
             String name = invocation.getArgument(0);
             Consumer<String> addProblem = invocation.getArgument(1);
@@ -267,22 +283,47 @@ public class TestRegisterValidation {
         });
         when(mockTissueRepo.findByExternalName(anyString())).then(invocation -> {
             final String name = invocation.getArgument(0);
-            return knownTissues.stream()
-                    .filter(tissue -> tissue.getExternalName().equalsIgnoreCase(name))
-                    .findAny();
+            return testData.stream()
+                    .filter(td -> td.anyWithSameIdentifier && td.externalName.equalsIgnoreCase(name))
+                    .findAny()
+                    .map(td -> EntityFactory.getTissue());
         });
+
         RegisterRequest request = new RegisterRequest(
-                IntStream.range(0, names.size())
-                        .mapToObj(i -> {
-                            BlockRegisterRequest br = new BlockRegisterRequest();
-                            br.setExternalIdentifier(names.get(i));
-                            br.setHighestSection(highestSections.get(i));
-                            br.setReplicateNumber(replicates.get(i));
-                            return br;
-                        }).collect(toList())
+                testData.stream()
+                .map(td -> {
+                    BlockRegisterRequest br = new BlockRegisterRequest();
+                    br.setExternalIdentifier(td.externalName);
+                    br.setReplicateNumber(td.replicate);
+                    br.setDonorIdentifier(td.donorName);
+                    br.setTissueType(td.tissueTypeName);
+                    br.setSpatialLocation(td.slCode);
+                    br.setMedium(td.mediumName);
+                    br.setHighestSection(td.highestSection);
+                    br.setFixative(td.fixativeName);
+                    return br;
+                })
+                .collect(toList())
         );
+
         RegisterValidationImp validation = create(request);
-        when(validation.anySimilarTissuesInDatabase(any(), any(), anyInt(), any(), anyInt())).thenReturn(false);
+
+        doAnswer(invocation -> {
+            final String donorName = invocation.getArgument(0);
+            final String tissueTypeName = invocation.getArgument(1);
+            final int slCode = invocation.getArgument(2);
+            final String mediumName = invocation.getArgument(3);
+            final String fixativeName = invocation.getArgument(4);
+            final int replicate = invocation.getArgument(5);
+
+            return testData.stream()
+                    .anyMatch(td -> td.anySimilarInDatabase && td.donorName.equalsIgnoreCase(donorName)
+                            && td.tissueTypeName.equalsIgnoreCase(tissueTypeName)
+                            && td.slCode==slCode && td.mediumName.equalsIgnoreCase(mediumName)
+                            && td.fixativeName.equalsIgnoreCase(fixativeName) && td.replicate==replicate);
+
+        }).when(validation).anySimilarTissuesInDatabase(any(), any(), anyInt(), any(), any(), anyInt());
+
         validation.validateTissues();
         assertThat(validation.getProblems()).hasSameElementsAs(expectedProblems);
     }
@@ -290,7 +331,8 @@ public class TestRegisterValidation {
     @Test
     public void testAnySimilarTissuesInDatabase() {
         Tissue tissue = EntityFactory.getTissue();
-        final Medium medium = EntityFactory.getMedium();
+        final Medium medium = tissue.getMedium();
+        final Fixative fixative = tissue.getFixative();
         Donor donor = tissue.getDonor();
         SpatialLocation sl = tissue.getSpatialLocation();
         RegisterValidationImp validation = create(new RegisterRequest());
@@ -299,57 +341,53 @@ public class TestRegisterValidation {
         validation.donorMap.put(donorName.toUpperCase(), donor);
         int slCode = sl.getCode();
         int replicate = tissue.getReplicate();
-        validation.spatialLocationMap.put(new StringIntKey(tissueTypeName, slCode), sl);
+        StringIntKey key = new StringIntKey(tissueTypeName, slCode);
+        assertEquals(key.toString(), "("+tissueTypeName.toUpperCase()+", "+slCode+")");
+        validation.spatialLocationMap.put(key, sl);
         final String mediumName = medium.getName();
+        final String fixativeName = fixative.getName();
         validation.mediumMap.put(mediumName.toUpperCase(), medium);
+        validation.fixativeMap.put(fixativeName.toUpperCase(), fixative);
 
-        when(mockTissueRepo.findByDonorIdAndSpatialLocationIdAndReplicate(anyInt(), anyInt(), anyInt()))
+        when(mockTissueRepo.findByDonorIdAndSpatialLocationIdAndMediumIdAndFixativeIdAndReplicate(anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
                 .then(invocation -> {
                     int donorId = invocation.getArgument(0);
                     int slId = invocation.getArgument(1);
-                    int repl = invocation.getArgument(2);
+                    int mediumId = invocation.getArgument(2);
+                    int fixativeId = invocation.getArgument(3);
+                    int repl = invocation.getArgument(4);
                     if (tissue.getDonor().getId()==donorId
                             && tissue.getSpatialLocation().getId()==slId
+                            && tissue.getMedium().getId()==mediumId
+                            && tissue.getFixative().getId()==fixativeId
                             && tissue.getReplicate()==repl) {
-                        return List.of(tissue);
+                        return Optional.of(tissue);
                     }
-                    return List.of();
+                    return Optional.empty();
                 });
 
-        assertTrue(validation.anySimilarTissuesInDatabase(donorName.toUpperCase(), tissueTypeName.toUpperCase(), slCode, null, replicate));
-        assertThat(validation.anySimilarTissuesInDatabase(donorName.toLowerCase(), tissueTypeName.toLowerCase(), slCode, "", replicate));
+        assertTrue(validation.anySimilarTissuesInDatabase(donorName.toUpperCase(), tissueTypeName.toUpperCase(), slCode,
+                mediumName.toUpperCase(), fixativeName.toUpperCase(), replicate));
+        assertTrue(validation.anySimilarTissuesInDatabase(donorName.toLowerCase(), tissueTypeName.toLowerCase(), slCode,
+                mediumName.toLowerCase(), fixativeName.toLowerCase(), replicate));
 
-        assertFalse(validation.anySimilarTissuesInDatabase("foop", tissueTypeName, slCode, null, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, "boop", slCode, null, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode+1, null, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode, mediumName, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode, null, replicate+1));
+        assertFalse(validation.anySimilarTissuesInDatabase(donorName, null, 0, null, null, 0));
 
-        Tissue tissue2 = new Tissue(99, "Tissue1", replicate, sl, donor, null, medium, tissue.getHmdmc());
-        when(mockTissueRepo.findByDonorIdAndSpatialLocationIdAndReplicate(anyInt(), anyInt(), anyInt()))
-                .then(invocation -> {
-                    int donorId = invocation.getArgument(0);
-                    int slId = invocation.getArgument(1);
-                    int repl = invocation.getArgument(2);
-                    if (tissue2.getDonor().getId()==donorId
-                            && tissue2.getSpatialLocation().getId()==slId
-                            && tissue2.getReplicate()==repl) {
-                        return List.of(tissue2);
-                    }
-                    return List.of();
-                });
-        assertTrue(validation.anySimilarTissuesInDatabase(donorName.toUpperCase(), tissueTypeName.toUpperCase(), slCode, mediumName, replicate));
-        assertThat(validation.anySimilarTissuesInDatabase(donorName.toLowerCase(), tissueTypeName.toLowerCase(), slCode, mediumName.toUpperCase(), replicate));
-
-        assertFalse(validation.anySimilarTissuesInDatabase("foop", tissueTypeName, slCode, mediumName, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, "boop", slCode, mediumName, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode+1, mediumName, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode, null, replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode, "", replicate));
-        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode, mediumName, replicate+1));
+        assertFalse(validation.anySimilarTissuesInDatabase("Bananas", tissueTypeName, slCode,
+                mediumName, fixativeName, replicate));
+        assertFalse(validation.anySimilarTissuesInDatabase(donorName, "Custard", slCode,
+                mediumName, fixativeName, replicate));
+        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode+1,
+                mediumName, fixativeName, replicate));
+        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode,
+                "Rhubarb", fixativeName, replicate));
+        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode,
+                mediumName, "Blancmange", replicate));
+        assertFalse(validation.anySimilarTissuesInDatabase(donorName, tissueTypeName, slCode,
+                mediumName, fixativeName, replicate+1));
     }
 
-    private  <E> void testValidateSimpleField(List<String> givenStrings,
+    private <E> void testValidateSimpleField(List<String> givenStrings,
                                    List<E> expectedItems, List<String> expectedProblems,
                                             Consumer<RegisterValidationImp> validationFunction,
                                             Function<E, String> stringFn,
@@ -435,7 +473,7 @@ public class TestRegisterValidation {
                         List.of(tt), List.of(), List.of("Missing tissue type.")),
                 Arguments.of(List.of(name, "", "Plumbus", name), List.of(0, 0, 0, 5),
                         List.of(tt), List.of(sl0),
-                        List.of("Missing tissue type.", "Unknown tissue types: [Plumbus]",
+                        List.of("Missing tissue type.", "Unknown tissue type: [Plumbus]",
                                 "Unknown spatial location 5 for tissue type Arm."))
         );
     }
@@ -447,7 +485,7 @@ public class TestRegisterValidation {
                 Arguments.of(List.of(h0, h1), List.of("20/001", "20/000", "20/000"), List.of(h0, h1), List.of()),
                 Arguments.of(List.of(h0, h1), List.of("20/001", "20/404", "20/405"), List.of(h1), List.of("Unknown HMDMCs: [20/404, 20/405]")),
                 Arguments.of(List.of(h0), Arrays.asList(null, "20/000", null), List.of(h0), List.of("Missing HMDMC.")),
-                Arguments.of(List.of(h0, h1), List.of("20/000", "20/001", "20/000", "", "", "20/404"), List.of(h0, h1), List.of("Missing HMDMC.", "Unknown HMDMCs: [20/404]"))
+                Arguments.of(List.of(h0, h1), List.of("20/000", "20/001", "20/000", "", "", "20/404"), List.of(h0, h1), List.of("Missing HMDMC.", "Unknown HMDMC: [20/404]"))
         );
     }
 
@@ -460,56 +498,150 @@ public class TestRegisterValidation {
                 Arguments.of(List.of(lt0, lt1), List.of(name1, name0, name0), List.of(lt0, lt1), List.of()),
                 Arguments.of(List.of(lt0, lt1), List.of(name1, "Custard", "Banana"), List.of(lt1), List.of("Unknown labware types: [Custard, Banana]")),
                 Arguments.of(List.of(lt0), Arrays.asList(null, name0, null), List.of(lt0), List.of("Missing labware type.")),
-                Arguments.of(List.of(lt0, lt1), List.of(name0, name1, name0, "", "", "Banana"), List.of(lt0, lt1), List.of("Missing labware type.", "Unknown labware types: [Banana]"))
+                Arguments.of(List.of(lt0, lt1), List.of(name0, name1, name0, "", "", "Banana"), List.of(lt0, lt1), List.of("Missing labware type.", "Unknown labware type: [Banana]"))
         );
     }
 
     private static Stream<Arguments> mouldSizeData() {
         MouldSize ms = EntityFactory.getMouldSize();
         return Stream.of(Arguments.of(List.of(ms), List.of(ms.getName()), List.of(ms), List.of()),
-                Arguments.of(List.of(), Arrays.asList(null, ""), List.of(), List.of()),
-                Arguments.of(List.of(ms), List.of("", "Sausage"), List.of(), List.of("Unknown mould sizes: [Sausage]")));
+                Arguments.of(List.of(), Arrays.asList(null, ""), List.of(), List.of("Missing mould size.")),
+                Arguments.of(List.of(ms), List.of(ms.getName(), "Sausage"), List.of(ms), List.of("Unknown mould size: [Sausage]")));
     }
 
 
     private static Stream<Arguments> mediumData() {
         Medium med = EntityFactory.getMedium();
         return Stream.of(Arguments.of(List.of(med), List.of(med.getName()), List.of(med), List.of()),
-                Arguments.of(List.of(), Arrays.asList(null, ""), List.of(), List.of()),
-                Arguments.of(List.of(med), List.of("", "Sausage", "Sausage"), List.of(), List.of("Unknown mediums: [Sausage]")));
+                Arguments.of(List.of(), Arrays.asList(null, ""), List.of(), List.of("Missing medium.")),
+                Arguments.of(List.of(med), List.of(med.getName(), "Sausage", "Sausage"), List.of(med), List.of("Unknown medium: [Sausage]")));
     }
 
+
+    private static Stream<Arguments> fixativeData() {
+        Fixative fix = EntityFactory.getFixative();
+        return Stream.of(Arguments.of(List.of(fix), List.of(fix.getName()), List.of(fix), List.of()),
+                Arguments.of(List.of(), Arrays.asList(null, ""), List.of(), List.of("Missing fixative.")),
+                Arguments.of(List.of(fix), List.of(fix.getName(), "Sausage", "Sausage"), List.of(fix), List.of("Unknown fixative: [Sausage]")));
+    }
+
+
     private static Stream<Arguments> tissueData() {
-        // TODO: rewrite
-        /*
-        testValidateTissues(List<String> names, List<Integer> replicates, List<Integer> highestSections,
-                                    List<Tissue> knownTissues, List<String> expectedProblems) {
-         */
-        final Tissue tissue = EntityFactory.getTissue();
-        final String name = tissue.getExternalName();
-        final int repl = tissue.getReplicate();
         return Stream.of(
-                Arguments.of(List.of("NewTissue", "NewTissue", name, name),
-                        List.of(1, 2, repl + 1, repl + 2), List.of(0,0,1,7), List.of(tissue), List.of()),
+                // No problems
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1").replicate(1),
+                        ValidateTissueTestData.externalName("X2").replicate(2)),
+                        List.of()),
 
-                Arguments.of(List.of(name, name), List.of(repl, repl+1), List.of(1,2), List.of(tissue),
-                        List.of("Tissue with external identifier "+name+", replicate number "+repl+" already exists.")),
-
-                Arguments.of(List.of(name, name), List.of(7, 7), List.of(1,2), List.of(tissue),
-                        List.of("Repeated external identifier and replicate number: "+name+", 7")),
-
-                Arguments.of(List.of("Banana*", "Custard*", name, "Banana*"), List.of(10, 11, 12, 13), List.of(1, 2, 3, 4),
-                        List.of(tissue),
-                        List.of("Invalid name: Banana*", "Invalid name: Custard*")),
-
-                Arguments.of(Arrays.asList(null, "Bananas", null), List.of(1,2,3), List.of(1,2,3), List.of(tissue),
+                // Some problems
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1").replicate(1),
+                        ValidateTissueTestData.externalName("X2").replicate(-4)),
+                        List.of("Replicate number cannot be negative.")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1").replicate(1),
+                        ValidateTissueTestData.externalName("X2").replicate(2).highestSection(-2)),
+                        List.of("Highest section number cannot be negative.")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName(null)),
                         List.of("Missing external identifier.")),
-
-                Arguments.of(List.of("", "Bananas", ""), List.of(1,2,3), List.of(1,2,3), List.of(tissue),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("")),
                         List.of("Missing external identifier.")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("Banana*")),
+                        List.of("Invalid name: Banana*")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("xyz").replicate(1),
+                        ValidateTissueTestData.externalName("Xyz").replicate(2)),
+                        List.of("Repeated external identifier: Xyz")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1").replicate(1),
+                        ValidateTissueTestData.externalName("X2").replicate(2).anyWithSameIdentifier(true)),
+                        List.of("There is already tissue in the database with external identifier X2.")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1").replicate(1).anyWithSameIdentifier(true),
+                        ValidateTissueTestData.externalName("X1").replicate(2).anyWithSameIdentifier(true),
+                        ValidateTissueTestData.externalName("X2").replicate(3).anyWithSameIdentifier(true)),
+                        List.of("There is already tissue in the database with external identifier X1.",
+                                "There is already tissue in the database with external identifier X2.",
+                                "Repeated external identifier: X1")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1"),
+                        ValidateTissueTestData.externalName("X2")),
+                        List.of("Repeated combination of fields: {donor=D, medium=M, fixative=F, tissue type=TT, " +
+                                "spatial location=2, replicate=1}")),
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1").replicate(1),
+                        ValidateTissueTestData.externalName("X2").replicate(2).anySimilarInDatabase(true)),
+                        List.of("There is already similar tissue in the database: {donor=D, medium=M, fixative=F, " +
+                                "tissue type=TT, spatial location=2, replicate=2}")),
 
-                Arguments.of(List.of(name), List.of(-1), List.of(-1), List.of(tissue),
-                        List.of("Replicate number cannot be negative.", "Highest section number cannot be negative."))
+                // Many problems
+                Arguments.of(List.of(ValidateTissueTestData.externalName("X1*").replicate(-1).highestSection(-1),
+                        ValidateTissueTestData.externalName(null).replicate(2),
+                        ValidateTissueTestData.externalName("X1").replicate(3).anySimilarInDatabase(true),
+                        ValidateTissueTestData.externalName("X2").replicate(4).anyWithSameIdentifier(true),
+                        ValidateTissueTestData.externalName("X3").replicate(5),
+                        ValidateTissueTestData.externalName("X4").replicate(5),
+                        ValidateTissueTestData.externalName("X4").replicate(6)),
+                        List.of("Replicate number cannot be negative.",
+                                "Highest section number cannot be negative.",
+                                "Missing external identifier.",
+                                "Invalid name: X1*",
+                                "Repeated external identifier: X4",
+                                "There is already tissue in the database with external identifier X2.",
+                                "Repeated combination of fields: {donor=D, medium=M, fixative=F, tissue type=TT, " +
+                                        "spatial location=2, replicate=5}",
+                                "There is already similar tissue in the database: {donor=D, medium=M, fixative=F, " +
+                                        "tissue type=TT, spatial location=2, replicate=3}"))
         );
+    }
+
+    static class ValidateTissueTestData {
+        String externalName;
+        int replicate = 1;
+        String donorName = "D";
+        String tissueTypeName = "TT";
+        int slCode = 2;
+        String mediumName = "M";
+        String fixativeName = "F";
+        int highestSection = 0;
+        boolean anySimilarInDatabase;
+        boolean anyWithSameIdentifier;
+
+        public ValidateTissueTestData(String externalName) {
+            this.externalName = externalName;
+        }
+
+        public static ValidateTissueTestData externalName(String externalName) {
+            return new ValidateTissueTestData(externalName);
+        }
+
+        public ValidateTissueTestData replicate(int replicate) {
+            this.replicate = replicate;
+            return this;
+        }
+
+        public ValidateTissueTestData highestSection(int highestSection) {
+            this.highestSection = highestSection;
+            return this;
+        }
+
+        public ValidateTissueTestData anySimilarInDatabase(boolean anySimilarInDatabase) {
+            this.anySimilarInDatabase = anySimilarInDatabase;
+            return this;
+        }
+
+        public ValidateTissueTestData anyWithSameIdentifier(boolean anyWithSameIdentifier) {
+            this.anyWithSameIdentifier = anyWithSameIdentifier;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                    .add("externalName", externalName)
+                    .add("replicate", replicate)
+                    .add("donorName", donorName)
+                    .add("tissueTypeName", tissueTypeName)
+                    .add("slCode", slCode)
+                    .add("mediumName", mediumName)
+                    .add("highestSection", highestSection)
+                    .add("fixativeName", fixativeName)
+                    .add("anySimilarInDatabase", anySimilarInDatabase)
+                    .add("anyWithSameIdentifier", anyWithSameIdentifier)
+                    .toString();
+        }
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidationFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidationFactory.java
@@ -17,7 +17,7 @@ public class TestRegisterValidationFactory {
         RegisterValidationFactory rgf = new RegisterValidationFactory(
                 mock(DonorRepo.class), mock(HmdmcRepo.class), mock(TissueTypeRepo.class),
                 mock(LabwareTypeRepo.class), mock(MouldSizeRepo.class), mock(MediumRepo.class),
-                mock(TissueRepo.class));
+                mock(FixativeRepo.class), mock(TissueRepo.class));
         assertNotNull(rgf.createRegisterValidation(new RegisterRequest()));
     }
 }


### PR DESCRIPTION
x551 Changes to registration

1. Add fixative as a thing.
2. Tissues now also have a fixative.
3. Mould size and medium are now compulsory fields.
3. Tissues are unique by external identifier (as opposed to
    {external identifier, replicate} in combination)
4. Tissues are also unique by their combination of {donor,
    spaceloc, replicate, medium, fixative}.
5. Rewrote registration validation and unit tests.
6. Update csvs for mould sizes, mediums and fixatives.
7. Renumber changesets.
8. Add graphql query for fixatives.