### PR TITLE
x628: printing labels for labware through SPrint

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLCustomTypes.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLCustomTypes.java
@@ -1,0 +1,48 @@
+package uk.ac.sanger.sccp.stan;
+
+import graphql.language.StringValue;
+import graphql.schema.*;
+import uk.ac.sanger.sccp.stan.model.Address;
+
+/**
+ * @author dr6
+ */
+public class GraphQLCustomTypes {
+    public static final GraphQLScalarType ADDRESS = GraphQLScalarType.newScalar()
+            .name("Address")
+            .description("A 1-indexed row and column, in the form \"B12\" (row 2, column 12) or \"32,15\" (row 32, column 15).")
+            .coercing(new Coercing<Address, String>() {
+                @Override
+                public String serialize(Object dataFetcherResult) throws CoercingSerializeException {
+                    if (dataFetcherResult instanceof Address) {
+                        return dataFetcherResult.toString();
+                    }
+                    throw new CoercingSerializeException("Unable to serialize "+dataFetcherResult+" as Address.");
+                }
+
+                @Override
+                public Address parseValue(Object input) throws CoercingParseValueException {
+                    if (input instanceof String) {
+                        try {
+                            return Address.valueOf((String) input);
+                        } catch (RuntimeException rte) {
+                            throw new CoercingParseValueException("Unable to parse value "+input+" as Address.", rte);
+                        }
+                    }
+                    throw new CoercingParseValueException("Unable to parse value "+input+" as Address.");
+                }
+
+                @Override
+                public Address parseLiteral(Object input) throws CoercingParseLiteralException {
+                    if (input instanceof StringValue) {
+                        try {
+                            return Address.valueOf(((StringValue) input).getValue());
+                        } catch (RuntimeException rte) {
+                            throw new CoercingParseValueException("Unable to parse literal "+input+" as Address.", rte);
+                        }
+                    }
+                    throw new CoercingParseValueException("Unable to parse literal "+input+" as Address.");
+                }
+            })
+            .build();
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import uk.ac.sanger.sccp.stan.config.SessionConfig;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.service.label.print.LabelPrintService;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -31,13 +32,14 @@ public class GraphQLDataFetchers {
     final MouldSizeRepo mouldSizeRepo;
     final HmdmcRepo hmdmcRepo;
     final LabwareRepo labwareRepo;
+    final LabelPrintService labelPrintService;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, SessionConfig sessionConfig,
                                UserRepo userRepo,
                                TissueTypeRepo tissueTypeRepo, LabwareTypeRepo labwareTypeRepo,
                                MediumRepo mediumRepo, FixativeRepo fixativeRepo, MouldSizeRepo mouldSizeRepo,
-                               HmdmcRepo hmdmcRepo, LabwareRepo labwareRepo) {
+                               HmdmcRepo hmdmcRepo, LabwareRepo labwareRepo, LabelPrintService labelPrintService) {
         this.objectMapper = objectMapper;
         this.authComp = authComp;
         this.sessionConfig = sessionConfig;
@@ -49,6 +51,7 @@ public class GraphQLDataFetchers {
         this.mouldSizeRepo = mouldSizeRepo;
         this.hmdmcRepo = hmdmcRepo;
         this.labwareRepo = labwareRepo;
+        this.labelPrintService = labelPrintService;
     }
 
     public DataFetcher<User> getUser() {
@@ -93,6 +96,13 @@ public class GraphQLDataFetchers {
             }
             return labwareRepo.findByBarcode(barcode)
                     .orElseThrow(() -> new EntityNotFoundException("No labware found with barcode: "+barcode));
+        };
+    }
+
+    public DataFetcher<Iterable<Printer>> findPrinters() {
+        return dfe -> {
+            String labelTypeName = dfe.getArgument("labelType");
+            return labelPrintService.findPrinters(labelTypeName);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -71,12 +71,14 @@ public class GraphQLProvider {
                         .dataFetcher("fixatives", graphQLDataFetchers.getFixatives())
                         .dataFetcher("mouldSizes", graphQLDataFetchers.getMouldSizes())
                         .dataFetcher("labware", graphQLDataFetchers.findLabwareByBarcode())
+                        .dataFetcher("printers", graphQLDataFetchers.findPrinters())
                 )
                 .type(newTypeWiring("Mutation")
                         .dataFetcher("login", graphQLMutation.logIn())
                         .dataFetcher("logout", graphQLMutation.logOut())
                         .dataFetcher("register", transact(graphQLMutation.register()))
                         .dataFetcher("plan", transact(graphQLMutation.recordPlan()))
+                        .dataFetcher("printLabware", graphQLMutation.printLabware()) // not transacted
                 )
                 .build();
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -80,6 +80,7 @@ public class GraphQLProvider {
                         .dataFetcher("plan", transact(graphQLMutation.recordPlan()))
                         .dataFetcher("printLabware", graphQLMutation.printLabware()) // not transacted
                 )
+                .scalar(GraphQLCustomTypes.ADDRESS)
                 .build();
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/config/SprintConfig.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/SprintConfig.java
@@ -1,0 +1,87 @@
+package uk.ac.sanger.sccp.stan.config;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import uk.ac.sanger.sccp.utils.StringTemplate;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author dr6
+ */
+@Configuration
+@PropertySource("classpath:sprint.properties")
+public class SprintConfig {
+    private static final String TEMPLATE_KEY_START = "#", TEMPLATE_KEY_END = "#";
+
+    @Value("${sprint.host}")
+    private String host;
+    @Value("${sprint.template_dir}")
+    private String templateDir;
+
+    private Map<String, SortedMap<Integer, StringTemplate>> templates;
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public StringTemplate getTemplate(String templateName, int size) {
+        templateName = templateName.toLowerCase();
+        Map<Integer, StringTemplate> sizeTemplates = templates.get(templateName);
+        if (sizeTemplates==null) {
+            throw new IllegalArgumentException("No template listed for "+templateName);
+        }
+        if (sizeTemplates.size()==1) {
+            return sizeTemplates.values().iterator().next();
+        }
+        StringTemplate template = null;
+        for (Map.Entry<Integer, StringTemplate> entry : sizeTemplates.entrySet()) {
+            template = entry.getValue();
+            if (entry.getKey() >= size) {
+                return template;
+            }
+        }
+        return template;
+    }
+
+    @Autowired
+    public void setTemplateFilenames(@Value("#{${sprint.templates}}") Map<String, String> configMap) throws IOException {
+        templates = new HashMap<>(configMap.size());
+        final Pattern pattern = Pattern.compile("(\\w+)@(\\d+)");
+        for (Map.Entry<String, String> entry : configMap.entrySet()) {
+            String key = entry.getKey().toLowerCase();
+            Matcher matcher = pattern.matcher(key);
+            String labelTypeName;
+            int size;
+            if (matcher.matches()) {
+                labelTypeName = matcher.group(1);
+                size = Integer.parseInt(matcher.group(2));
+            } else {
+                labelTypeName = key;
+                size = Integer.MAX_VALUE;
+            }
+            String filename = entry.getValue();
+            if (templateDir!=null) {
+                filename = Paths.get(templateDir, filename).toString();
+            }
+            StringTemplate template = readTemplate(filename);
+            templates.computeIfAbsent(labelTypeName, k -> new TreeMap<>()).put(size, template);
+        }
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private StringTemplate readTemplate(String filename) throws IOException {
+        URL url = Resources.getResource(filename);
+        String templateString = Resources.toString(url, Charsets.UTF_8);
+        return new StringTemplate(templateString, TEMPLATE_KEY_START, TEMPLATE_KEY_END);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Address.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Address.java
@@ -5,10 +5,12 @@ import org.jetbrains.annotations.NotNull;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
+ * An address representing a row and a column (both positive ints).
  * @author dr6
  */
 @SuppressWarnings("JpaDataSourceORMInspection")
@@ -24,14 +26,8 @@ public class Address implements Comparable<Address> {
     public Address() {}
 
     public Address(int row, int column) {
-        if (row < 1) {
-            throw new IllegalArgumentException("Row cannot be less than 1.");
-        }
-        if (column < 1) {
-            throw new IllegalArgumentException("Column cannot be less than 1.");
-        }
-        this.row = row;
-        this.column = column;
+        setRow(row);
+        setColumn(column);
     }
 
     public int getRow() {
@@ -43,19 +39,78 @@ public class Address implements Comparable<Address> {
     }
 
     public void setRow(int row) {
+        if (row < 1) {
+            throw new IllegalArgumentException("Address row cannot be less than 1.");
+        }
         this.row = row;
     }
 
     public void setColumn(int column) {
+        if (column < 1) {
+            throw new IllegalArgumentException("Address column cannot be less than 1.");
+        }
         this.column = column;
     }
 
+    /**
+     * Returns a string representation of this address.
+     * <p>Formats:
+     * <ul>
+     *     <li><tt>"B13"</tt> for row 2, column 13 (if {@code row <= 26})</li>
+     *     <li><tt>"32,15"</tt> for row 32, column 15 (if {@code row > 26}</li>
+     * </ul>
+     * @return a string representation of this address
+     */
     @Override
     public String toString() {
         if (row <= 26) {
             return String.format("%c%d", 'A'+row-1, column);
         }
         return String.format("%d,%d", row, column);
+    }
+
+    /**
+     * Parses a string as an address.
+     * Row and column must be positive ints.
+     * <p>Supported formats:
+     * <ul>
+     *     <li><tt>"B13"</tt>: row 2, column 13</li>
+     *     <li><tt>"32,15"</tt>: row 32, column 15</li>
+     * </ul>
+     * @param string the string to parse
+     * @return the address parsed from the string
+     * @exception NullPointerException if the string is null
+     * @exception IllegalArgumentException if the string is not parsable as an address
+     */
+    public static Address valueOf(String string) {
+        // Adapted from CGAP LIMS
+        Objects.requireNonNull(string, "Cannot convert null to an address.");
+        int row = -1, column = -1;
+        if (string.length() >= 2) {
+            char ch = string.charAt(0);
+            if (ch >= 'A' && ch <= 'Z') {
+                row = ch - 'A' + 1;
+                try {
+                    column = Integer.parseInt(string.substring(1));
+                } catch (NumberFormatException e) {
+                    column = -1;
+                }
+            } else if (ch >= '0' && ch <= '9') {
+                int n = string.indexOf(',');
+                if (n > 0) {
+                    try {
+                        row = Integer.parseInt(string.substring(0, n));
+                        column = Integer.parseInt(string.substring(n + 1));
+                    } catch (NumberFormatException e) {
+                        row = column = -1;
+                    }
+                }
+            }
+        }
+        if (row < 0 || column < 0) {
+            throw new IllegalArgumentException("Invalid address string: "+string);
+        }
+        return new Address(row, column);
     }
 
     @Override

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/LabwarePrint.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/LabwarePrint.java
@@ -1,0 +1,110 @@
+package uk.ac.sanger.sccp.stan.model;
+
+import com.google.common.base.MoreObjects;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.util.Objects;
+
+/**
+ * A record of printing a label for a particular piece of labware
+ * @author dr6
+ */
+@Entity
+public class LabwarePrint {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    @ManyToOne
+    private Printer printer;
+    @ManyToOne
+    private Labware labware;
+    @ManyToOne
+    private User user;
+    @Generated(GenerationTime.INSERT)
+    private Timestamp printed;
+
+    public LabwarePrint() {}
+
+    public LabwarePrint(Integer id, Printer printer, Labware labware, User user, Timestamp printed) {
+        this.id = id;
+        this.printer = printer;
+        this.labware = labware;
+        this.user = user;
+        this.printed = printed;
+    }
+
+    public LabwarePrint(Printer printer, Labware labware, User user) {
+        this(null, printer, labware, user, null);
+    }
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Printer getPrinter() {
+        return this.printer;
+    }
+
+    public void setPrinter(Printer printer) {
+        this.printer = printer;
+    }
+
+    public Labware getLabware() {
+        return this.labware;
+    }
+
+    public void setLabware(Labware labware) {
+        this.labware = labware;
+    }
+
+    public User getUser() {
+        return this.user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Timestamp getPrinted() {
+        return this.printed;
+    }
+
+    public void setPrinted(Timestamp printed) {
+        this.printed = printed;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LabwarePrint that = (LabwarePrint) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.printer, that.printer)
+                && Objects.equals(this.labware, that.labware)
+                && Objects.equals(this.user, that.user)
+                && Objects.equals(this.printed, that.printed));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, printer, labware, user, printed);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("id", id)
+                .add("printer", printer)
+                .add("labware", labware)
+                .add("user", user)
+                .add("printed", printed)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Operation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Operation.java
@@ -1,8 +1,9 @@
 package uk.ac.sanger.sccp.stan.model;
 
 import com.google.common.base.MoreObjects;
-import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.*;
 
+import javax.persistence.Entity;
 import javax.persistence.*;
 import java.sql.Timestamp;
 import java.util.List;
@@ -21,6 +22,7 @@ public class Operation {
     @ManyToOne
     private OperationType operationType;
 
+    @Generated(GenerationTime.INSERT)
     private Timestamp performed;
 
     @OneToMany

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/PlanOperation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/PlanOperation.java
@@ -1,8 +1,9 @@
 package uk.ac.sanger.sccp.stan.model;
 
 import com.google.common.base.MoreObjects;
-import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.*;
 
+import javax.persistence.Entity;
 import javax.persistence.*;
 import java.sql.Timestamp;
 import java.util.List;
@@ -24,6 +25,7 @@ public class PlanOperation {
 
     private Integer operationId;
 
+    @Generated(GenerationTime.INSERT)
     private Timestamp planned;
 
     @OneToMany
@@ -34,6 +36,12 @@ public class PlanOperation {
     private User user;
 
     public PlanOperation() {}
+
+    public PlanOperation(Integer id, OperationType opType, User user) {
+        this.id = id;
+        this.operationType = opType;
+        this.user = user;
+    }
 
     public Integer getId() {
         return this.id;

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Printer.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Printer.java
@@ -1,0 +1,86 @@
+package uk.ac.sanger.sccp.stan.model;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+/**
+ * @author dr6
+ */
+@Entity
+public class Printer {
+    public enum Service { sprint }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+    @ManyToOne
+    private LabelType labelType;
+
+    @Column(columnDefinition = "enum('sprint')")
+    @Enumerated(EnumType.STRING)
+    private Service service;
+
+    public Printer() {}
+
+    public Printer(Integer id, String name, LabelType labelType, Service service) {
+        this.id = id;
+        this.name = name;
+        this.labelType = labelType;
+        this.service = service;
+    }
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public LabelType getLabelType() {
+        return this.labelType;
+    }
+
+    public void setLabelType(LabelType labelType) {
+        this.labelType = labelType;
+    }
+
+    public Service getService() {
+        return this.service;
+    }
+
+    public void setService(Service service) {
+        this.service = service;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Printer that = (Printer) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.name, that.name)
+                && Objects.equals(this.labelType, that.labelType)
+                && this.service == that.service);
+    }
+
+    @Override
+    public int hashCode() {
+        return (id!=null ? id.hashCode() : name!=null ? name.hashCode() : 0);
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/LabelTypeRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/LabelTypeRepo.java
@@ -3,5 +3,14 @@ package uk.ac.sanger.sccp.stan.repo;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.LabelType;
 
+import javax.persistence.EntityNotFoundException;
+import java.util.Optional;
+
 public interface LabelTypeRepo extends CrudRepository<LabelType, Integer> {
+    Optional<LabelType> findByName(String name);
+
+    default LabelType getByName(String name) throws EntityNotFoundException {
+        return findByName(name)
+                .orElseThrow(() -> new EntityNotFoundException("Unknown label type: "+name));
+    }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwarePrintRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwarePrintRepo.java
@@ -1,0 +1,10 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.LabwarePrint;
+
+/**
+ * @author dr6
+ */
+public interface LabwarePrintRepo extends CrudRepository<LabwarePrint, Integer> {
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareRepo.java
@@ -4,7 +4,9 @@ import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.Labware;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.Optional;
+import java.util.*;
+
+import static java.util.stream.Collectors.toMap;
 
 public interface LabwareRepo extends CrudRepository<Labware, Integer> {
     Optional<Labware> findByBarcode(String barcode);
@@ -12,4 +14,36 @@ public interface LabwareRepo extends CrudRepository<Labware, Integer> {
         return findByBarcode(barcode).orElseThrow(() -> new EntityNotFoundException("No labware found with barcode "+barcode));
     }
     boolean existsByBarcode(String barcode);
+
+    List<Labware> findByBarcodeIn(Collection<String> barcodes);
+
+    /**
+     * Gets an exact sequence of labware identified by barcodes.
+     * @param barcodes the barcodes to find
+     * @return the matching labware, in the same order as the barcodes, including repetitions
+     * @exception EntityNotFoundException some barcodes could not be found
+     */
+    default List<Labware> getByBarcodeIn(Collection<String> barcodes) {
+        if (barcodes.isEmpty()) {
+            return List.of();
+        }
+        List<Labware> foundLabware = findByBarcodeIn(barcodes);
+        Map<String, Labware> bcToLabware = foundLabware.stream()
+                .collect(toMap(lw -> lw.getBarcode().toUpperCase(), lw -> lw));
+        List<String> missing = new ArrayList<>();
+        List<Labware> correctLabware = new ArrayList<>(barcodes.size());
+        for (String barcode : barcodes) {
+            Labware lw = bcToLabware.get(barcode.toUpperCase());
+            if (lw==null) {
+                missing.add(barcode);
+            } else {
+                correctLabware.add(lw);
+            }
+        }
+        if (!missing.isEmpty()) {
+            throw new EntityNotFoundException("No labware found with barcodes "+missing);
+        }
+        return correctLabware;
+    }
+
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/PlanActionRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/PlanActionRepo.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.PlanAction;
 
+import java.util.List;
 import java.util.OptionalInt;
 
 public interface PlanActionRepo extends CrudRepository<PlanAction, Integer> {
@@ -19,4 +20,6 @@ public interface PlanActionRepo extends CrudRepository<PlanAction, Integer> {
         Integer maxInteger = _findMaxPlannedSectionForTissueId(tissueId);
         return (maxInteger==null ? OptionalInt.empty() : OptionalInt.of(maxInteger));
     }
+
+    List<PlanAction> findAllByDestinationLabwareId(int labwareId);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/PrinterRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/PrinterRepo.java
@@ -1,0 +1,19 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.LabelType;
+import uk.ac.sanger.sccp.stan.model.Printer;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Optional;
+
+public interface PrinterRepo extends CrudRepository<Printer, Integer> {
+    Optional<Printer> findByName(String name);
+
+    default Printer getByName(String name) throws EntityNotFoundException {
+        return findByName(name).orElseThrow(() -> new EntityNotFoundException("Printer not found: "+name));
+    }
+
+    List<Printer> findAllByLabelType(LabelType labelType);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabelPrintRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabelPrintRequest.java
@@ -1,0 +1,50 @@
+package uk.ac.sanger.sccp.stan.service.label;
+
+import com.google.common.base.MoreObjects;
+import uk.ac.sanger.sccp.stan.model.LabelType;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author dr6
+ */
+public class LabelPrintRequest {
+    private final LabelType labelType;
+    private final List<LabwareLabelData> labwareLabelData;
+
+    public LabelPrintRequest(LabelType labelType, List<LabwareLabelData> labwareLabelData) {
+        this.labelType = labelType;
+        this.labwareLabelData = List.copyOf(labwareLabelData);
+    }
+
+    public List<LabwareLabelData> getLabwareLabelData() {
+        return this.labwareLabelData;
+    }
+
+    public LabelType getLabelType() {
+        return this.labelType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LabelPrintRequest that = (LabelPrintRequest) o;
+        return (Objects.equals(this.labwareLabelData, that.labwareLabelData)
+                && Objects.equals(this.labelType, that.labelType));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labwareLabelData);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("labelType", labelType)
+                .add("labwareLabelData", labwareLabelData)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelData.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelData.java
@@ -1,0 +1,138 @@
+package uk.ac.sanger.sccp.stan.service.label;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.*;
+
+/**
+ * A collection of information that may be printed onto a labware label.
+ * @author dr6
+ */
+public class LabwareLabelData {
+    private final String barcode;
+    private final String medium;
+    private final List<LabelContent> contents;
+
+    public LabwareLabelData(String barcode, String medium, List<LabelContent> contents) {
+        this.barcode = barcode;
+        this.medium = medium;
+        this.contents = List.copyOf(contents);
+    }
+
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public String getMedium() {
+        return this.medium;
+    }
+
+    public List<LabelContent> getContents() {
+        return this.contents;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LabwareLabelData that = (LabwareLabelData) o;
+        return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.medium, that.medium)
+                && Objects.equals(this.contents, that.contents));
+    }
+
+    @Override
+    public int hashCode() {
+        return barcode!=null ? barcode.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("barcode", barcode)
+                .add("medium", medium)
+                .add("contents", contents)
+                .toString();
+    }
+
+    public Map<String, String> getFields() {
+        HashMap<String, String> fields = new HashMap<>(2 + 4 * contents.size());
+        fields.put("barcode", getBarcode());
+        fields.put("medium", getMedium());
+        int index = 0;
+        for (LabelContent content : contents) {
+            addField(fields, "donor", index, content.getDonorName());
+            addField(fields, "tissue", index, content.getTissueDesc());
+            if (content.getReplicate()!=null) {
+                addField(fields, "replicate", index, "R:"+content.getReplicate());
+            }
+            if (content.getSection()!=null) {
+                addField(fields, "section", index, String.format("S%03d", content.getSection()));
+            }
+            ++index;
+        }
+        return fields;
+    }
+
+    private void addField(Map<String, String> map, String fieldName, int index, String value) {
+        if (value!=null && !value.isEmpty()) {
+            map.put(fieldName+"["+index+"]", value);
+        }
+    }
+
+    public static class LabelContent {
+        private final String donorName;
+        private final String tissueDesc;
+        private final Integer replicate;
+        private final Integer section;
+
+        public LabelContent(String donorName, String tissueDesc, Integer replicate, Integer section) {
+            this.donorName = donorName;
+            this.tissueDesc = tissueDesc;
+            this.replicate = replicate;
+            this.section = section;
+        }
+
+        public String getDonorName() {
+            return this.donorName;
+        }
+
+        public String getTissueDesc() {
+            return this.tissueDesc;
+        }
+
+        public Integer getReplicate() {
+            return this.replicate;
+        }
+
+        public Integer getSection() {
+            return this.section;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LabelContent that = (LabelContent) o;
+            return (Objects.equals(this.donorName, that.donorName)
+                    && Objects.equals(this.tissueDesc, that.tissueDesc)
+                    && Objects.equals(this.replicate, that.replicate)
+                    && Objects.equals(this.section, that.section));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(donorName, tissueDesc, replicate, section);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                    .add("donorName", donorName)
+                    .add("tissueDesc", tissueDesc)
+                    .add("replicate", replicate)
+                    .add("section", section)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelDataService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelDataService.java
@@ -1,0 +1,87 @@
+package uk.ac.sanger.sccp.stan.service.label;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.PlanActionRepo;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData.LabelContent;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * @author dr6
+ */
+@Service
+public class LabwareLabelDataService {
+    private final PlanActionRepo planActionRepo;
+
+    @Autowired
+    public LabwareLabelDataService(PlanActionRepo planActionRepo) {
+        this.planActionRepo = planActionRepo;
+    }
+
+    public LabwareLabelData getLabelData(Labware labware) {
+        List<LabelContent> content = labware.getSlots().stream()
+                .flatMap(slot -> slot.getSamples().stream())
+                .map(this::getContent)
+                .collect(toList());
+        Set<String> mediums = labware.getSlots().stream()
+                .flatMap(slot -> slot.getSamples().stream())
+                .map(sample -> sample.getTissue().getMedium().getName())
+                .collect(toSet());
+        if (content.isEmpty()) {
+            List<PlanAction> planActions = planActionRepo.findAllByDestinationLabwareId(labware.getId());
+            if (!planActions.isEmpty()) {
+                mediums = planActions.stream()
+                        .map(pa -> pa.getSample().getTissue().getMedium().getName())
+                        .collect(toSet());
+                content = getPlannedContent(planActions);
+            }
+        }
+        String medium = (mediums.size()==1 ? mediums.iterator().next() : null);
+        return new LabwareLabelData(labware.getBarcode(), medium, content);
+    }
+
+    public LabelContent getContent(Sample sample) {
+        Tissue tissue = sample.getTissue();
+        return new LabelContent(tissue.getDonor().getDonorName(),
+                getTissueDesc(tissue), tissue.getReplicate(), sample.getSection());
+    }
+
+    public String getTissueDesc(Tissue tissue) {
+        SpatialLocation sl = tissue.getSpatialLocation();
+        return prefix(tissue.getDonor().getLifeStage()) + sl.getTissueType().getCode() + "-" + sl.getCode();
+    }
+
+    public String prefix(LifeStage lifeStage) {
+        switch (lifeStage) {
+            case fetal: return "F";
+            case paediatric: return "P";
+            default: return "";
+        }
+    }
+
+    public List<LabelContent> getPlannedContent(List<PlanAction> planActions) {
+        return planActions.stream()
+                .sorted(Comparator.comparing((PlanAction ac) -> ac.getDestination().getAddress())
+                        .thenComparing(PlanAction::getId))
+                .map(this::getContent)
+                .collect(toList());
+    }
+
+    public LabelContent getContent(PlanAction planAction) {
+        Integer section = planAction.getNewSection();
+        if (section==null) {
+            section = planAction.getSample().getSection();
+        }
+        return new LabelContent(
+                planAction.getSample().getTissue().getDonor().getDonorName(),
+                getTissueDesc(planAction.getSample().getTissue()),
+                planAction.getSample().getTissue().getReplicate(),
+                section
+        );
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/LabelPrintService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/LabelPrintService.java
@@ -1,0 +1,101 @@
+package uk.ac.sanger.sccp.stan.service.label.print;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.service.label.*;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Service to perform and record labware label printing
+ * @author dr6
+ */
+@Service
+public class LabelPrintService {
+    private final LabwareLabelDataService labwareLabelDataService;
+    private final PrintClientFactory printClientFactory;
+    private final LabwareRepo labwareRepo;
+    private final PrinterRepo printerRepo;
+    private final LabwarePrintRepo labwarePrintRepo;
+    private final LabelTypeRepo labelTypeRepo;
+
+    @Autowired
+    public LabelPrintService(LabwareLabelDataService labwareLabelDataService, PrintClientFactory printClientFactory,
+                             LabwareRepo labwareRepo, PrinterRepo printerRepo, LabwarePrintRepo labwarePrintRepo,
+                             LabelTypeRepo labelTypeRepo) {
+        this.labwareLabelDataService = labwareLabelDataService;
+        this.printClientFactory = printClientFactory;
+        this.labwareRepo = labwareRepo;
+        this.printerRepo = printerRepo;
+        this.labwarePrintRepo = labwarePrintRepo;
+        this.labelTypeRepo = labelTypeRepo;
+    }
+
+    public void printLabwareBarcodes(User user, String printerName, List<String> barcodes) throws IOException {
+        if (barcodes.isEmpty()) {
+            throw new IllegalArgumentException("No labware barcodes supplied to print.");
+        }
+        List<Labware> labware = labwareRepo.getByBarcodeIn(barcodes);
+        printLabware(user, printerName, labware);
+    }
+
+    public void printLabware(User user, String printerName, List<Labware> labware) throws IOException {
+        if (labware.isEmpty()) {
+            throw new IllegalArgumentException("No labware supplied to print.");
+        }
+        Printer printer = printerRepo.getByName(printerName);
+        Set<LabelType> labelTypes = labware.stream()
+                .map(lw -> lw.getLabwareType().getLabelType())
+                .collect(toSet());
+        if (labelTypes.contains(null)) {
+            throw new IllegalArgumentException("Cannot print label for labware without a label type.");
+        }
+        if (labelTypes.size() > 1) {
+            throw new IllegalArgumentException("Cannot perform a print request incorporating multiple different label types.");
+        }
+        LabelType labelType = labelTypes.iterator().next();
+        List<LabwareLabelData> labelData = labware.stream()
+                .map(labwareLabelDataService::getLabelData)
+                .collect(toList());
+        LabelPrintRequest request = new LabelPrintRequest(labelType, labelData);
+        print(printer, request);
+        recordPrint(printer, user, labware);
+    }
+
+    public void print(Printer printer, LabelPrintRequest request) throws IOException {
+        PrintClient<? super LabelPrintRequest> printClient = printClientFactory.getClient(printer.getService());
+        printClient.print(printer.getName(), request);
+    }
+
+    @Transactional
+    public Iterable<LabwarePrint> recordPrint(final Printer printer, final User user, final List<Labware> labware) {
+        List<LabwarePrint> labwarePrints = labware.stream()
+                .map(lw -> new LabwarePrint(printer, lw, user))
+                .collect(toList());
+        return labwarePrintRepo.saveAll(labwarePrints);
+    }
+
+    /**
+     * Finds all matching printers. Either all printers with the indicated label type (if one is specified),
+     * or all printers.
+     * @param labelTypeName the name of a label type (or null to get all printers)
+     * @return matching printers
+     * @exception EntityNotFoundException an invalid label type name is given
+     */
+    public Iterable<Printer> findPrinters(String labelTypeName) {
+        if (labelTypeName==null) {
+            return printerRepo.findAll();
+        }
+        LabelType labelType = labelTypeRepo.getByName(labelTypeName);
+        return printerRepo.findAllByLabelType(labelType);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/PrintClient.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/PrintClient.java
@@ -1,0 +1,18 @@
+package uk.ac.sanger.sccp.stan.service.label.print;
+
+import java.io.IOException;
+
+/**
+ * @author dr6
+ */
+public interface PrintClient<T> {
+    /**
+     * Sends the given request to this client's service to print on the specified printer.
+     * @param request the specification of what to print
+     * @param printerName the identifier for the printer
+//     * @exception JSONException there was a problem formulating the JSON for the request or parsing the response
+     * @exception IOException there was a problem transmitting the request to the print service
+     */
+    void print(String printerName, T request) throws IOException;
+}
+

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/PrintClientFactory.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/PrintClientFactory.java
@@ -1,0 +1,24 @@
+package uk.ac.sanger.sccp.stan.service.label.print;
+
+import org.springframework.stereotype.Component;
+import uk.ac.sanger.sccp.stan.model.Printer;
+import uk.ac.sanger.sccp.stan.service.label.LabelPrintRequest;
+
+/**
+ * @author dr6
+ */
+@Component
+public class PrintClientFactory {
+    private final SprintClient sprintClient;
+
+    public PrintClientFactory(SprintClient sprintClient) {
+        this.sprintClient = sprintClient;
+    }
+
+    public PrintClient<LabelPrintRequest> getClient(Printer.Service service) {
+        if (service == Printer.Service.sprint) {
+            return sprintClient;
+        }
+        throw new IllegalArgumentException("Unsupported printer service: "+service);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/SprintClient.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/print/SprintClient.java
@@ -1,0 +1,89 @@
+package uk.ac.sanger.sccp.stan.service.label.print;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.sanger.sccp.stan.config.SprintConfig;
+import uk.ac.sanger.sccp.stan.service.label.LabelPrintRequest;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData;
+import uk.ac.sanger.sccp.utils.BaseHttpClient;
+import uk.ac.sanger.sccp.utils.StringTemplate;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Client for sending print requests to SPrint
+ * @author dr6
+ */
+@Component
+public class SprintClient extends BaseHttpClient implements PrintClient<LabelPrintRequest> {
+    Logger log = LoggerFactory.getLogger(SprintClient.class);
+
+    private final SprintConfig config;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public SprintClient(SprintConfig config) {
+        this.config = config;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public void print(String printerName, LabelPrintRequest request) throws IOException {
+        JsonNode jsonData = toJson(printerName, request);
+        ObjectNode result = postJson(new URL(config.getHost()), jsonData, ObjectNode.class);
+        checkResult(result);
+    }
+
+    public JsonNode toJson(String printerName, LabelPrintRequest request) throws IOException {
+        String labelTypeName = request.getLabelType().getName();
+        ObjectNode variables = objectMapper.createObjectNode();
+        variables.put("printer", printerName);
+        ArrayNode layouts = objectMapper.createArrayNode();
+        for (LabwareLabelData lwData : request.getLabwareLabelData()) {
+            StringTemplate template = config.getTemplate(labelTypeName, lwData.getContents().size());
+            ObjectNode labwareObjectNode = objectMapper.readValue(template.substitute(lwData.getFields()), ObjectNode.class);
+            layouts.add(labwareObjectNode);
+        }
+        ObjectNode printRequest = objectMapper.createObjectNode();
+        printRequest.set("layouts", layouts);
+        variables.set("printRequest", printRequest);
+
+        ObjectNode printMutation = objectMapper.createObjectNode();
+        printMutation.put("query", getQueryText());
+        printMutation.set("variables", variables);
+        return printMutation;
+    }
+
+    // expose for mockery
+    protected <T> T postJson(URL url, Object data, Class<T> jsonReturnType) throws IOException {
+        return super.postJson(url, data, jsonReturnType);
+    }
+
+    private String getQueryText() {
+        return "mutation ($printer:String!, $printRequest:PrintRequest!) {" +
+                "  print(printer: $printer, printRequest: $printRequest) {" +
+                "    jobId" +
+                "  }" +
+                "}";
+    }
+
+    private void checkResult(ObjectNode result) throws IOException {
+        if (result.has("errors")) {
+            log.error("Error from SPrint");
+            log.error(result.toPrettyString());
+            throw new IOException(getSprintErrorMessage(result));
+        }
+    }
+
+    private String getSprintErrorMessage(ObjectNode result) {
+        return result.get("errors").get(0).get("message").asText();
+    }
+
+}

--- a/src/main/java/uk/ac/sanger/sccp/utils/BaseHttpClient.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BaseHttpClient.java
@@ -1,0 +1,192 @@
+package uk.ac.sanger.sccp.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.*;
+import java.net.*;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+
+/**
+ * Base class for a client that needs to post and get json.
+ * @author dr6
+ */
+public abstract class BaseHttpClient {
+    private int timeout = 2000; // 2 s
+    private Proxy proxy;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Gets the connect and read timeout (milliseconds). Zero is no timeout.
+     * @return the timeout in milliseconds.
+     */
+    public int getTimeout() {
+        return this.timeout;
+    }
+
+    /**
+     * Sets the connect and read timeout (milliseconds). Zero is no timeout.
+     * @param timeout the timeout in milliseconds
+     * @exception IllegalArgumentException if {@code timeout} is negative
+     */
+    public void setTimeout(int timeout) {
+        if (timeout < 0) {
+            throw new IllegalArgumentException("timeout cannot be negative");
+        }
+        this.timeout = timeout;
+    }
+
+    public Proxy getProxy() {
+        return this.proxy;
+    }
+
+    public void setProxy(Proxy proxy) {
+        this.proxy = proxy;
+    }
+
+    protected boolean responseIsGood(int responseCode) {
+        return (responseCode >= 200 && responseCode < 300);
+    }
+
+    /**
+     * Reads the response from a connection's inputstream and converts it to the given type.
+     * @param connection the connection to read
+     * @param returnType the class of the expected return type
+     * @param <T> the expected return type
+     * @return a response of the given type read from the given connection
+     * @exception IOException communication problem
+     */
+    private <T> T readReturnValue(URLConnection connection, Class<T> returnType) throws IOException {
+        if (returnType==null || returnType==Void.class) {
+            return null;
+        }
+        String string = getResponseString(connection.getInputStream());
+        if (returnType==String.class) {
+            //noinspection unchecked
+            return (T) string;
+        }
+        return objectMapper.readValue(string, returnType);
+    }
+
+    /**
+     * Posts some JSON and returns a response whose type is as indicated by the supplied class.
+     * @param url the address to post to
+     * @param data the data to post
+     * @param jsonReturnType the class of the expected return type
+     * @param <T> the expected return type
+     * @return a response whose type is indicated by the {@code jsonReturnType} argument
+     * @exception IOException there was a communication problem
+     */
+    protected <T> T postJson(URL url, Object data, Class<T> jsonReturnType) throws IOException {
+        HttpURLConnection connection = openConnection(url);
+        try {
+            attemptPost(data, connection);
+            return readReturnValue(connection, jsonReturnType);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private HttpURLConnection openConnection(URL url) throws IOException {
+        Proxy proxy = getProxy();
+        URLConnection con;
+        if (proxy==null) {
+            con = url.openConnection();
+        } else {
+            con = url.openConnection(proxy);
+        }
+        int timeout = getTimeout();
+        con.setReadTimeout(timeout);
+        con.setConnectTimeout(timeout);
+        return (HttpURLConnection) con;
+    }
+
+    private void attemptPost(Object data, HttpURLConnection connection) throws IOException {
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        setHeaders(connection);
+        connection.connect();
+        try (OutputStreamWriter out = new OutputStreamWriter(connection.getOutputStream())) {
+            out.write(data.toString());
+            out.flush();
+            int responseCode = connection.getResponseCode();
+            if (!responseIsGood(responseCode)) {
+                if (responseCode == HTTP_NOT_FOUND) {
+                    throw new Http404Exception();
+                }
+                throw new IOException(responseCode + " - " + getResponseString(connection.getErrorStream()));
+            }
+        }
+    }
+
+    /**
+     * Performs a GET and returns a response indicated by the supplied class.
+     * @param url location to get from
+     * @param jsonReturnType a class indicating what type to return
+     * @param <T> the type of response that will be returned
+     * @return a json object
+     * @exception IOException there was a communication problem
+     */
+    protected <T> T getJson(URL url, Class<T> jsonReturnType) throws IOException {
+        HttpURLConnection connection = openConnection(url);
+        try {
+            connection.setRequestMethod("GET");
+            setHeaders(connection);
+            connection.connect();
+            int responseCode = connection.getResponseCode();
+            if (responseCode==HTTP_NOT_FOUND) {
+                throw new IOException(HTTP_NOT_FOUND+" - NOT FOUND");
+            }
+            if (!responseIsGood(responseCode)) {
+                throw new IOException(getResponseString(connection.getErrorStream()));
+            }
+            return readReturnValue(connection, jsonReturnType);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    protected void setHeaders(HttpURLConnection connection) {
+        setUsualHeaders(connection);
+    }
+
+    /**
+     * Reads from an {@code InputStream} line by line, concatenates the lines and returns the result.
+     * @param is stream to read
+     * @return the text read from the input stream
+     * @exception IOException there was a communication problem
+     */
+    public static String getResponseString(InputStream is) throws IOException {
+        if (is==null) {
+            return null;
+        }
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(is))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = in.readLine()) != null) {
+                sb.append(line);
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Sets up the headers on a connection.
+     * The headers specify JSON in and JSON out
+     * @param connection the connection to set the headers on
+     */
+    public static void setUsualHeaders(HttpURLConnection connection) {
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setRequestProperty("Accept", "application/json");
+    }
+
+    /**
+     * Custom exception indicating an HTTP 404
+     * @author dr6
+     */
+    public static class Http404Exception extends IOException {
+        public Http404Exception() {
+            super(HTTP_NOT_FOUND + " - NOT FOUND");
+        }
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/utils/StringTemplate.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/StringTemplate.java
@@ -1,0 +1,90 @@
+package uk.ac.sanger.sccp.utils;
+
+import java.util.*;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A templating class.
+ * Missing keys are removed from the produced string.
+ * @author dr6
+ */
+public class StringTemplate {
+    /**
+     * Part of the template: a literal string, and then a key for replacement.
+     * Null values are omitted from the final string.
+     */
+    private static class Part {
+        String text;
+        String key;
+    }
+
+    private final List<Part> parts;
+    private final int guessedLength;
+
+    /**
+     * Creates a template from the given string using the other strings as start- and end-indicators for keys.
+     * @param template the template
+     * @param startKey the string that indicates the start of a substitution key
+     * @param endKey the string that indicates the end of a substitution key
+     * @exception NullPointerException any of the arguments is null
+     */
+    public StringTemplate(String template, String startKey, String endKey) {
+        final int templateLength = template.length();
+        final int startKeyLength = startKey.length();
+        final int endKeyLength = endKey.length();
+
+        guessedLength = templateLength + 16;
+
+        parts = new ArrayList<>();
+        int reached = 0;
+        while (true) {
+            int i = template.indexOf(startKey, reached);
+            if (i < 0) {
+                break;
+            }
+            int j = template.indexOf(endKey, i + startKeyLength);
+            if (j < 0) {
+                break;
+            }
+            Part part = new Part();
+            if (i > reached) {
+                part.text = template.substring(reached, i);
+            }
+            part.key = template.substring(i+startKeyLength, j);
+            parts.add(part);
+            reached = j + endKeyLength;
+        }
+        if (reached < templateLength) {
+            Part part = new Part();
+            part.text = template.substring(reached);
+            parts.add(part);
+        }
+    }
+
+    /**
+     * Performs a substitution using the given keys/values in this template.
+     * Any substitution key in the template will be replaced by the associated value in the map.
+     * Any substitution key in the template that is not present in the map (or whose value is null)
+     * will be replaced by the empty string.
+     * @param subs the map of keys to values to substitute into the template
+     * @return a templated string.
+     * @exception NullPointerException the {@code subs} map is null
+     */
+    public String substitute(Map<String, String> subs) {
+        requireNonNull(subs);
+        StringBuilder sb = new StringBuilder(guessedLength);
+        for (Part part : parts) {
+            if (part.text != null) {
+                sb.append(part.text);
+            }
+            if (part.key != null) {
+                String value = subs.get(part.key);
+                if (value != null) {
+                    sb.append(value);
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -596,4 +596,61 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="202" author="dr6">
+        <createTable tableName="printer">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(64)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="label_type_id" type="INT">
+                <constraints nullable="false" foreignKeyName="printer_fk_label_type" referencedTableName="label_type" referencedColumnNames="id"/>
+            </column>
+            <column name="service" type="ENUM('sprint')">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="203" author="dr6">
+        <createTable tableName="labware_print">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="user_id" type="INT">
+                <constraints nullable="false" foreignKeyName="labware_print_fk_user" referencedTableName="user" referencedColumnNames="id"/>
+            </column>
+            <column name="labware_id" type="INT">
+                <constraints nullable="false" foreignKeyName="labware_print_fk_labware" referencedTableName="labware" referencedColumnNames="id"/>
+            </column>
+            <column name="printer_id" type="INT">
+                <constraints nullable="false" foreignKeyName="labware_print_fk_printer" referencedTableName="printer" referencedColumnNames="id"/>
+            </column>
+            <column name="printed" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="204" author="dr6">
+        <loadData tableName="printer" file="db/printers.csv">
+            <column name="name" header="name" type="string"/>
+            <column name="label_type_id" header="label_type_id" type="numeric"/>
+            <column name="service" header="service" type="string"/>
+        </loadData>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/labeltypes.tsv
+++ b/src/main/resources/db/labeltypes.tsv
@@ -1,2 +1,3 @@
 id	name
 1	tiny
+2	slide

--- a/src/main/resources/db/labwaretypes.tsv
+++ b/src/main/resources/db/labwaretypes.tsv
@@ -1,6 +1,6 @@
 name	label_type_id	num_rows	num_columns	prebarcoded
 Proviasette	1	1	1	false
-Slide	1	3	2	false
-Visium TO	1	4	2	false
-Visium LP	null	2	2	true
+Slide	2	3	2	false
+Visium TO	2	4	2	false
+Visium LP	null	4	1	true
 Tube	1	1	1	false

--- a/src/main/resources/db/printers.csv
+++ b/src/main/resources/db/printers.csv
@@ -1,0 +1,3 @@
+name,label_type_id,service
+cgaptestbc,1,sprint
+slidelabel,2,sprint

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -167,6 +167,11 @@ type PlanResult {
     operations: [PlanOperation!]!,
 }
 
+type Printer {
+    name: String!,
+    labelType: LabelType!,
+}
+
 type Query {
     user: User,
     tissueTypes: [TissueType!]!,
@@ -176,6 +181,7 @@ type Query {
     fixatives: [Fixative!]!,
     mouldSizes: [MouldSize!]!,
     labware(barcode: String!): Labware!,
+    printers(labelType: String): [Printer!]!
 }
 
 type Mutation {
@@ -183,4 +189,5 @@ type Mutation {
     logout: String,
     register(request: RegisterRequest!): RegisterResult!,
     plan(request: PlanRequest!): PlanResult!,
+    printLabware(printer: String!, barcodes: [String!]!): String,
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1,3 +1,4 @@
+scalar Address
 
 type User {
     username: String!,
@@ -62,16 +63,6 @@ type Tissue {
     fixative: Fixative!,
 }
 
-type Address {
-    row: Int!,
-    column: Int!,
-}
-
-input AddressInput {
-    row: Int!,
-    column: Int!,
-}
-
 type Sample {
     id: Int!,
     section: Int,
@@ -125,7 +116,7 @@ type RegisterResult {
 
 input PlanRequestSource {
     barcode: String!,
-    address: AddressInput,
+    address: Address,
 }
 
 type OperationType {
@@ -145,7 +136,7 @@ type PlanOperation {
 }
 
 input PlanRequestAction {
-    address: AddressInput!,
+    address: Address!,
     sampleId: Int!,
     sampleThickness: Int,
     source: PlanRequestSource!,
@@ -181,7 +172,7 @@ type Query {
     fixatives: [Fixative!]!,
     mouldSizes: [MouldSize!]!,
     labware(barcode: String!): Labware!,
-    printers(labelType: String): [Printer!]!
+    printers(labelType: String): [Printer!]!,
 }
 
 type Mutation {

--- a/src/main/resources/sprint.properties
+++ b/src/main/resources/sprint.properties
@@ -1,0 +1,9 @@
+sprint.host = http://sprint.psd.sanger.ac.uk/graphql
+
+sprint.template_dir = sprint
+
+sprint.templates = {\
+  'slide@3' : 'slide3.json',\
+  'slide@6' : 'slide6.json',\
+  'tiny' : 'tiny.json'\
+}

--- a/src/main/resources/sprint/slide3.json
+++ b/src/main/resources/sprint/slide3.json
@@ -1,0 +1,102 @@
+{
+  "labelSize": {
+    "width": 23,
+    "height": 19,
+    "displacement": 22
+  },
+  "barcodeFields": [
+    {
+      "value": "#barcode#",
+      "barcodeType": "datamatrix",
+      "cellWidth": 0.25,
+      "x": 17,
+      "y": 2
+    }
+  ],
+  "textFields": [
+    {
+      "value": "#barcode#",
+      "fontSize": 2.2,
+      "x": 1,
+      "y": 4
+    },
+    {
+      "value": "#medium#",
+      "fontSize": 1.8,
+      "x": 8,
+      "y": 6
+    },
+    {
+      "value": "#donor[0]#",
+      "fontSize": 1.8,
+      "x": 1,
+      "y": 8
+    },
+    {
+      "value": "#tissue[0]#",
+      "fontSize": 1.8,
+      "x": 4,
+      "y": 10
+    },
+    {
+      "value": "#replicate[1]#",
+      "fontSize": 1.8,
+      "x": 12,
+      "y": 10
+    },
+    {
+      "value": "#section[0]#",
+      "fontSize": 1.8,
+      "x": 17,
+      "y": 10
+    },
+    {
+      "value": "#donor[1]#",
+      "fontSize": 1.8,
+      "x": 1,
+      "y": 12
+    },
+    {
+      "value": "#tissue[1]#",
+      "fontSize": 1.8,
+      "x": 4,
+      "y": 14
+    },
+    {
+      "value": "#replicate[1]#",
+      "fontSize": 1.8,
+      "x": 12,
+      "y": 14
+    },
+    {
+      "value": "#section[1]#",
+      "fontSize": 1.8,
+      "x": 17,
+      "y": 14
+    },
+    {
+      "value": "#donor[2]#",
+      "fontSize": 1.8,
+      "x": 1,
+      "y": 16
+    },
+    {
+      "value": "#tissue[2]#",
+      "fontSize": 1.8,
+      "x": 4,
+      "y": 18
+    },
+    {
+      "value": "#replicate[2]#",
+      "fontSize": 1.8,
+      "x": 12,
+      "y": 18
+    },
+    {
+      "value": "#section[2]#",
+      "fontSize": 1.8,
+      "x": 17,
+      "y": 18
+    }
+  ]
+}

--- a/src/main/resources/sprint/slide6.json
+++ b/src/main/resources/sprint/slide6.json
@@ -1,0 +1,174 @@
+{
+  "labelSize": {
+    "width": 23,
+    "height": 19,
+    "displacement": 22
+  },
+  "barcodeFields":[
+    {
+      "value": "#barcode#",
+      "barcodeType": "datamatrix",
+      "cellWidth": 0.25,
+      "x": 17,
+      "y": 1
+    }
+  ],
+  "textFields":[
+    {
+      "value": "#barcode#",
+      "fontSize": 2.2,
+      "x": 1,
+      "y": 3
+    },
+    {
+      "value": "#medium#",
+      "fontSize": 1.3,
+      "x": 11,
+      "y": 5
+    },
+    {
+      "value": "#donor[0]#",
+      "fontSize": 1.3,
+      "x": 1,
+      "y": 7
+    },
+    {
+      "value": "#tissue[0]#",
+      "fontSize": 1.3,
+      "x": 9,
+      "y": 7
+    },
+    {
+      "value": "#replicate[0]#",
+      "fontSize": 1.3,
+      "x": 15,
+      "y": 7
+    },
+    {
+      "value": "#section[0]#",
+      "fontSize": 1.3,
+      "x": 18,
+      "y": 7
+    },
+    {
+      "value": "#donor[1]#",
+      "fontSize": 1.3,
+      "x": 1,
+      "y": 9
+    },
+    {
+      "value": "#tissue[1]#",
+      "fontSize": 1.3,
+      "x": 9,
+      "y": 9
+    },
+    {
+      "value": "#replicate[1]#",
+      "fontSize": 1.3,
+      "x": 15,
+      "y": 9
+    },
+    {
+      "value": "#section[1]#",
+      "fontSize": 1.3,
+      "x": 18,
+      "y": 9
+    },
+    {
+      "value": "#donor[2]#",
+      "fontSize": 1.3,
+      "x": 1,
+      "y": 11
+    },
+    {
+      "value": "#tissue[2]#",
+      "fontSize": 1.3,
+      "x": 9,
+      "y": 11
+    },
+    {
+      "value": "#replicate[2]#",
+      "fontSize": 1.3,
+      "x": 15,
+      "y": 11
+    },
+    {
+      "value": "#section[2]#",
+      "fontSize": 1.3,
+      "x": 18,
+      "y": 11
+    },
+    {
+      "value": "#donor[3]#",
+      "fontSize": 1.3,
+      "x": 1,
+      "y": 13
+    },
+    {
+      "value": "#tissue[3]#",
+      "fontSize": 1.3,
+      "x": 9,
+      "y": 13
+    },
+    {
+      "value": "#replicate[3]#",
+      "fontSize": 1.3,
+      "x": 15,
+      "y": 13
+    },
+    {
+      "value": "#section[3]#",
+      "fontSize": 1.3,
+      "x": 18,
+      "y": 13
+    },
+    {
+      "value": "#donor[4]#",
+      "fontSize": 1.3,
+      "x": 1,
+      "y": 15
+    },
+    {
+      "value": "#tissue[4]#",
+      "fontSize": 1.3,
+      "x": 9,
+      "y": 15
+    },
+    {
+      "value": "#replicate[4]#",
+      "fontSize": 1.3,
+      "x": 15,
+      "y": 15
+    },
+    {
+      "value": "#section[4]#",
+      "fontSize": 1.3,
+      "x": 18,
+      "y": 15
+    },
+    {
+      "value": "#donor[5]#",
+      "fontSize": 1.3,
+      "x": 1,
+      "y": 17
+    },
+    {
+      "value": "#tissue[5]#",
+      "fontSize": 1.3,
+      "x": 9,
+      "y": 17
+    },
+    {
+      "value": "#replicate[5]#",
+      "fontSize": 1.3,
+      "x": 15,
+      "y": 17
+    },
+    {
+      "value": "#section[5]#",
+      "fontSize": 1.3,
+      "x": 18,
+      "y": 17
+    }
+  ]
+}

--- a/src/main/resources/sprint/tiny.json
+++ b/src/main/resources/sprint/tiny.json
@@ -1,0 +1,48 @@
+{
+  "labelSize": {
+    "width": 28,
+    "height": 9,
+    "displacement": 12
+  },
+  "barcodeFields":[
+    {
+      "value": "#barcode#",
+      "barcodeType": "datamatrix",
+      "cellWidth": 0.25,
+      "x": 23,
+      "y": 1
+    }
+  ],
+  "textFields":[
+    {
+      "value": "#barcode#",
+      "fontSize": 2.2,
+      "x": 1,
+      "y": 3
+    },
+    {
+      "value": "#donor[0]#",
+      "fontSize": 1.9,
+      "x": 1,
+      "y": 6
+    },
+    {
+      "value": "#tissue[0]#",
+      "fontSize": 1.9,
+      "x": 1,
+      "y": 8
+    },
+    {
+      "value": "#replicate[0]#",
+      "fontSize": 1.9,
+      "x": 11,
+      "y": 8
+    },
+    {
+      "value": "#section[0]#",
+      "fontSize": 1.9,
+      "x": 18,
+      "y": 8
+    }
+  ]
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
@@ -25,6 +25,7 @@ public class EntityFactory {
     private static MouldSize mouldSize;
     private static Medium medium;
     private static Fixative fixative;
+    private static Printer printer;
     private static int idCounter = 10_000;
 
     public static User getUser() {
@@ -127,6 +128,14 @@ public class EntityFactory {
         return tube;
     }
 
+    public static Printer getPrinter() {
+        if (printer==null) {
+            int id = ++idCounter;
+            printer = new Printer(id, "printer"+id, getLabelType(), Printer.Service.sprint);
+        }
+        return printer;
+    }
+
     public static Labware makeEmptyLabware(LabwareType lt) {
         int lwId = ++idCounter;
         final int[] slotId = { 10*lwId };
@@ -142,5 +151,10 @@ public class EntityFactory {
             flagbits |= flag.bit();
         }
         return new OperationType(++idCounter, name, flagbits);
+    }
+
+    public static Tissue makeTissue(Donor donor, SpatialLocation sl) {
+        int id = ++idCounter;
+        return new Tissue(id, "TISSUE "+id, id%7, sl, donor, getMouldSize(), getMedium(), getFixative(), getHmdmc());
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/GraphQLTester.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/GraphQLTester.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.service.label.print.PrintClientFactory;
 
 import java.io.IOException;
 import java.net.URL;
@@ -28,6 +29,8 @@ public class GraphQLTester {
 
     @MockBean
     AuthenticationComponent mockAuthComp;
+    @MockBean
+    PrintClientFactory mockPrintClientFactory;
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
@@ -7,12 +7,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwarePrintRepo;
+import uk.ac.sanger.sccp.stan.service.label.LabelPrintRequest;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData.LabelContent;
+import uk.ac.sanger.sccp.stan.service.label.print.PrintClient;
 
 import javax.transaction.Transactional;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Non-exhaustive integration tests.
@@ -29,6 +36,8 @@ public class IntegrationTests {
 
     @Autowired
     private EntityCreator entityCreator;
+    @Autowired
+    private LabwarePrintRepo labwarePrintRepo;
 
     @Test
     @Transactional
@@ -68,6 +77,62 @@ public class IntegrationTests {
         assertNotNull(chainGet(resultAction, "destination", "labwareId"));
         assertEquals(sample.getId(), chainGet(resultAction, "sample", "id"));
         assertNotNull(chainGet(resultAction, "newSection"));
+    }
+
+    @Test
+    @Transactional
+    public void testPrintLabware() throws Exception {
+        //noinspection unchecked
+        PrintClient<LabelPrintRequest> mockPrintClient = mock(PrintClient.class);
+        when(tester.mockPrintClientFactory.getClient(any())).thenReturn(mockPrintClient);
+        tester.setUser(entityCreator.createUser("dr6"));
+        Tissue tissue = entityCreator.createTissue(entityCreator.createDonor("DONOR1", LifeStage.adult), "TISSUE1");
+        Labware lw = entityCreator.createLabware("STAN-SLIDE", entityCreator.createLabwareType("slide6", 3, 2),
+                entityCreator.createSample(tissue, 1), entityCreator.createSample(tissue, 2),
+                entityCreator.createSample(tissue, 3), entityCreator.createSample(tissue, 4));
+        Printer printer = entityCreator.createPrinter("stub");
+        String mutation = "mutation { printLabware(barcodes: [\"STAN-SLIDE\"], printer: \"stub\") }";
+        assertThat(tester.<Map<?,?>>post(mutation)).isEqualTo(Map.of("data", Map.of("printLabware", "OK")));
+        String donorName = tissue.getDonor().getDonorName();
+        String tissueDesc = getTissueDesc(tissue);
+        Integer replicate = tissue.getReplicate();
+        verify(mockPrintClient).print("stub", new LabelPrintRequest(
+                lw.getLabwareType().getLabelType(),
+                List.of(new LabwareLabelData(lw.getBarcode(), tissue.getMedium().getName(),
+                        List.of(
+                                new LabelContent(donorName, tissueDesc, replicate, 1),
+                                new LabelContent(donorName, tissueDesc, replicate, 2),
+                                new LabelContent(donorName, tissueDesc, replicate, 3),
+                                new LabelContent(donorName, tissueDesc, replicate, 4)
+                        ))
+                ))
+        );
+
+        Iterator<LabwarePrint> recordIter = labwarePrintRepo.findAll().iterator();
+        assertTrue(recordIter.hasNext());
+        LabwarePrint record = recordIter.next();
+        assertFalse(recordIter.hasNext());
+
+        assertNotNull(record.getPrinted());
+        assertNotNull(record.getId());
+        assertEquals(record.getLabware().getId(), lw.getId());
+        assertEquals(record.getPrinter().getId(), printer.getId());
+        assertEquals(record.getUser().getUsername(), "dr6");
+    }
+
+    private static String getTissueDesc(Tissue tissue) {
+        String prefix;
+        switch (tissue.getDonor().getLifeStage()) {
+            case paediatric:
+                prefix = "P";
+                break;
+            case fetal:
+                prefix = "F";
+                break;
+            default:
+                prefix = "";
+        }
+        return String.format("%s%s-%s", prefix, tissue.getTissueType().getCode(), tissue.getSpatialLocation().getCode());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
@@ -70,10 +70,9 @@ public class IntegrationTests {
         List<?> resultActions = chainGet(resultOps, 0, "planActions");
         assertEquals(1, resultActions.size());
         Map<String, ?> resultAction = chainGet(resultActions, 0);
-        Map<String, Integer> firstAddress = Map.of("row", 1, "column", 1);
-        assertEquals(firstAddress, chainGet(resultAction, "source", "address"));
+        assertEquals("A1", chainGet(resultAction, "source", "address"));
         assertEquals(sourceBlock.getId(), chainGet(resultAction, "source", "labwareId"));
-        assertEquals(firstAddress, chainGet(resultAction, "destination", "address"));
+        assertEquals("A1", chainGet(resultAction, "destination", "address"));
         assertNotNull(chainGet(resultAction, "destination", "labwareId"));
         assertEquals(sample.getId(), chainGet(resultAction, "sample", "id"));
         assertNotNull(chainGet(resultAction, "newSection"));

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/label/TestLabwareLabelData.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/label/TestLabwareLabelData.java
@@ -1,0 +1,40 @@
+package uk.ac.sanger.sccp.stan.service.label;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData.LabelContent;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link LabwareLabelData}
+ * @author dr6
+ */
+public class TestLabwareLabelData {
+    @Test
+    public void testFields() {
+        LabwareLabelData data = new LabwareLabelData(
+                "STAN-123", "Butter",
+                List.of(
+                        new LabelContent("DONOR1", "TISSUE1", 1, null),
+                        new LabelContent("DONOR2", "TISSUE2", 2, 3)
+                )
+        );
+        Map<String, String> fields = data.getFields();
+        assertThat(fields).isEqualTo(Map.of(
+                "barcode", "STAN-123",
+                "medium", "Butter",
+
+                "donor[0]", "DONOR1",
+                "tissue[0]", "TISSUE1",
+                "replicate[0]", "R:1",
+
+                "donor[1]", "DONOR2",
+                "tissue[1]", "TISSUE2",
+                "replicate[1]", "R:2",
+                "section[1]", "S003"
+        ));
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/label/TestLabwareLabelDataService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/label/TestLabwareLabelDataService.java
@@ -1,0 +1,119 @@
+package uk.ac.sanger.sccp.stan.service.label;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.PlanActionRepo;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData.LabelContent;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests {@link LabwareLabelDataService}
+ * @author dr6
+ */
+public class TestLabwareLabelDataService {
+    private PlanActionRepo mockPlanActionRepo;
+    private LabwareLabelDataService service;
+
+    @BeforeEach
+    void setup() {
+        mockPlanActionRepo = mock(PlanActionRepo.class);
+        service = new LabwareLabelDataService(mockPlanActionRepo);
+    }
+
+    @Test
+    public void testLabwareData() {
+        TissueType ttype = new TissueType(null, "Skellington", "SKE");
+        SpatialLocation sl = new SpatialLocation(null, "SL4", 4, ttype);
+        Tissue tissue = EntityFactory.makeTissue(EntityFactory.getDonor(), sl);
+        Sample sample1 = new Sample(null, null, tissue);
+        Sample sample2 = new Sample(null, 5, tissue);
+        Labware lw = EntityFactory.makeEmptyLabware(EntityFactory.makeLabwareType(1, 2));
+        lw.getSlots().get(1).getSamples().addAll(List.of(sample1, sample2));
+
+        LabwareLabelData actual = service.getLabelData(lw);
+
+        List<LabelContent> expectedContents = Stream.of(sample1, sample2)
+                .map(sam -> new LabelContent(sam.getTissue().getDonor().getDonorName(),
+                        tissueString(sam.getTissue()), sam.getTissue().getReplicate(), sam.getSection()))
+                .collect(toList());
+        LabwareLabelData expected = new LabwareLabelData(lw.getBarcode(), tissue.getMedium().getName(), expectedContents);
+        assertEquals(expected, actual);
+
+        Labware emptyLabware = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType());
+        when(mockPlanActionRepo.findAllByDestinationLabwareId(emptyLabware.getId())).thenReturn(List.of());
+        assertEquals(new LabwareLabelData(emptyLabware.getBarcode(), null, List.of()), service.getLabelData(emptyLabware));
+    }
+
+    @Test
+    public void testLabwareDataPlannedContents() {
+        Donor donor1 = new Donor(null, "DONOR1", LifeStage.adult);
+        Donor donor2 = new Donor(null, "DONOR2", LifeStage.fetal);
+        TissueType ttype1 = new TissueType(null, "Skellington", "SKE");
+        SpatialLocation sl1 = new SpatialLocation(null, "SL4", 4, ttype1);
+        TissueType ttype2 = new TissueType(null, "Bananas", "BNN");
+        SpatialLocation sl2 = new SpatialLocation(null, "SL7", 7, ttype2);
+        Tissue tissue1 = EntityFactory.makeTissue(donor1, sl1);
+        Tissue tissue2 = EntityFactory.makeTissue(donor2, sl2);
+        Sample sample1 = new Sample(null, null, tissue1);
+        Sample sample2 = new Sample(null, 5, tissue2);
+        Labware labware = EntityFactory.makeEmptyLabware(EntityFactory.makeLabwareType(1, 4));
+        List<Slot> slots = labware.getSlots();
+        PlanOperation plan = new PlanOperation();
+        final int planId = 400;
+        plan.setId(planId);
+        List<PlanAction> planActions = List.of(
+                new PlanAction(404, planId, slots.get(3), slots.get(3), sample2, 14, null),
+                new PlanAction(403, planId, slots.get(2), slots.get(2), sample2, null, null),
+                new PlanAction(401, planId, slots.get(0), slots.get(0), sample1, null, null),
+                new PlanAction(402, planId, slots.get(1), slots.get(1), sample1, 7, null)
+        );
+        when(mockPlanActionRepo.findAllByDestinationLabwareId(labware.getId())).thenReturn(planActions);
+
+        LabwareLabelData actual = service.getLabelData(labware);
+        List<LabelContent> expectedContents = List.of(
+                new LabelContent(donor1.getDonorName(), tissueString(tissue1), tissue1.getReplicate(), null),
+                new LabelContent(donor1.getDonorName(), tissueString(tissue1), tissue1.getReplicate(), 7),
+                new LabelContent(donor2.getDonorName(), tissueString(tissue2), tissue2.getReplicate(), 5),
+                new LabelContent(donor2.getDonorName(), tissueString(tissue2), tissue2.getReplicate(), 14)
+        );
+        assertEquals(new LabwareLabelData(labware.getBarcode(), tissue1.getMedium().getName(), expectedContents), actual);
+    }
+
+    @ParameterizedTest
+    @EnumSource(LifeStage.class)
+    public void testGetTissueDesc(LifeStage lifeStage) {
+        Donor donor = new Donor(null, "DONOR", lifeStage);
+        TissueType tt = new TissueType(null, "Xylophone", "XYL");
+        SpatialLocation sl = new SpatialLocation(null, "SL-6", 6, tt);
+        Tissue tissue = EntityFactory.makeTissue(donor, sl);
+        assertEquals(tissueString(tissue), service.getTissueDesc(tissue));
+    }
+
+    private String tissueString(Tissue tissue) {
+        String prefix;
+        switch (tissue.getDonor().getLifeStage()) {
+            case paediatric:
+                prefix = "P";
+                break;
+            case fetal:
+                prefix = "F";
+                break;
+            default:
+                prefix = "";
+                break;
+        }
+        return prefix + tissue.getTissueType().getCode() + "-" + tissue.getSpatialLocation().getCode();
+    }
+
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/label/print/TestLabelPrintService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/label/print/TestLabelPrintService.java
@@ -1,0 +1,151 @@
+package uk.ac.sanger.sccp.stan.service.label.print;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.service.label.*;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData.LabelContent;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link LabelPrintService}
+ * @author dr6
+ */
+public class TestLabelPrintService {
+    private LabwareLabelDataService mockLabwareLabelDataService;
+    private PrintClientFactory mockPrintClientFactory;
+    private LabwareRepo mockLabwareRepo;
+    private PrinterRepo mockPrinterRepo;
+    private LabwarePrintRepo mockLabwarePrintRepo;
+    private LabelTypeRepo mockLabelTypeRepo;
+
+    private LabelPrintService labelPrintService;
+    private User user;
+    private Printer printer;
+    private List<Labware> labware;
+
+    @BeforeEach
+    void setup() {
+        mockLabwareLabelDataService = mock(LabwareLabelDataService.class);
+        mockPrintClientFactory = mock(PrintClientFactory.class);
+        mockLabwareRepo = mock(LabwareRepo.class);
+        mockPrinterRepo = mock(PrinterRepo.class);
+        mockLabwarePrintRepo = mock(LabwarePrintRepo.class);
+        mockLabelTypeRepo = mock(LabelTypeRepo.class);
+
+        labelPrintService = spy(new LabelPrintService(mockLabwareLabelDataService, mockPrintClientFactory, mockLabwareRepo,
+                mockPrinterRepo, mockLabwarePrintRepo, mockLabelTypeRepo));
+        user = EntityFactory.getUser();
+        printer = EntityFactory.getPrinter();
+        LabwareType lt = EntityFactory.getTubeType();
+        labware = List.of(EntityFactory.makeEmptyLabware(lt), EntityFactory.makeEmptyLabware(lt));
+    }
+
+    @Test
+    public void testPrintLabwareBarcodes() throws IOException {
+        List<String> barcodes = labware.stream().map(Labware::getBarcode).collect(toList());
+        when(mockLabwareRepo.getByBarcodeIn(barcodes)).thenReturn(labware);
+        doNothing().when(labelPrintService).printLabware(any(), any(), any());
+
+        labelPrintService.printLabwareBarcodes(user, "printer1", barcodes);
+        verify(labelPrintService).printLabware(user, "printer1", labware);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> labelPrintService.printLabwareBarcodes(user, "printer1", List.of()),
+                "No labware barcodes supplied to print.");
+    }
+
+    @Test
+    public void testPrintLabwareSuccessful() throws IOException {
+        when(mockPrinterRepo.getByName(printer.getName())).thenReturn(printer);
+        List<LabwareLabelData> labelData = List.of(
+                new LabwareLabelData(labware.get(0).getBarcode(), "None", List.of(
+                        new LabelContent("DONOR1", "TISSUE1", 2, 3),
+                        new LabelContent("DONOR2", "TISSUE2", 3, 4)
+                )),
+                new LabwareLabelData(labware.get(1).getBarcode(), "None", List.of(
+                        new LabelContent("DONOR3", "TISSUE3", 4, null)
+                ))
+        );
+        LabelPrintRequest expectedRequest = new LabelPrintRequest(labware.get(0).getLabwareType().getLabelType(), labelData);
+
+        when(mockLabwareLabelDataService.getLabelData(labware.get(0))).thenReturn(labelData.get(0));
+        when(mockLabwareLabelDataService.getLabelData(labware.get(1))).thenReturn(labelData.get(1));
+        doNothing().when(labelPrintService).print(any(), any());
+        doReturn(List.of()).when(labelPrintService).recordPrint(any(), any(), any());
+
+        labelPrintService.printLabware(user, printer.getName(), labware);
+        verify(labelPrintService).print(printer, expectedRequest);
+        verify(labelPrintService).recordPrint(printer, user, labware);
+    }
+
+    @Test
+    public void testPrintLabwareErrors() throws IOException {
+        assertThrows(IllegalArgumentException.class, () -> labelPrintService.printLabware(user, printer.getName(), List.of()),
+                "No labware supplied to print.");
+
+        LabwareType unprintableType = new LabwareType(1, "dud", 1, 1, null, true);
+        Labware lw = EntityFactory.makeEmptyLabware(unprintableType);
+        assertThrows(IllegalArgumentException.class, () -> labelPrintService.printLabware(user, printer.getName(), List.of(lw)),
+                "Cannot print label for labware without a label type.");
+
+        List<Labware> labware = IntStream.range(0,2)
+                .mapToObj(i -> new LabelType(i, "label type "+i))
+                .map(labelType -> new LabwareType(10+labelType.getId(), "lw type "+labelType.getId(), 1, 1, labelType, false))
+                .map(EntityFactory::makeEmptyLabware)
+                .collect(toList());
+        assertThrows(IllegalArgumentException.class, () -> labelPrintService.printLabware(user, printer.getName(), labware),
+                "Cannot perform a print request incorporating multiple different label types.");
+    }
+
+    @Test
+    public void testPrint() throws IOException {
+        //noinspection unchecked
+        PrintClient<LabelPrintRequest> mockPrintClient = mock(PrintClient.class);
+        when(mockPrintClientFactory.getClient(printer.getService())).thenReturn(mockPrintClient);
+        LabelPrintRequest request = new LabelPrintRequest(EntityFactory.getLabelType(), List.of());
+        labelPrintService.print(printer, request);
+
+        verify(mockPrintClient).print(printer.getName(), request);
+    }
+
+    @Test
+    public void testRecordPrint() {
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        List<LabwarePrint> results = List.of(
+                new LabwarePrint(10, printer, labware.get(0), user, now),
+                new LabwarePrint(11, printer, labware.get(1), user, now)
+        );
+        when(mockLabwarePrintRepo.saveAll(any())).thenReturn(results);
+
+        assertSame(results, labelPrintService.recordPrint(printer, user, labware));
+        verify(mockLabwarePrintRepo).saveAll(List.of(new LabwarePrint(printer, labware.get(0), user),
+                new LabwarePrint(printer, labware.get(1), user)));
+    }
+
+    @Test
+    public void testFindPrinters() {
+        LabelType labelType = EntityFactory.getLabelType();
+        when(mockLabelTypeRepo.getByName(labelType.getName())).thenReturn(labelType);
+        Printer printer2 = new Printer(2, "printer 2", new LabelType(2, "label type 2"), Printer.Service.sprint);
+        List<Printer> allPrinters = List.of(this.printer, printer2);
+        when(mockPrinterRepo.findAll()).thenReturn(allPrinters);
+        List<Printer> somePrinters = List.of(this.printer);
+        when(mockPrinterRepo.findAllByLabelType(labelType)).thenReturn(somePrinters);
+
+        assertSame(allPrinters, labelPrintService.findPrinters(null));
+        assertSame(somePrinters, labelPrintService.findPrinters(labelType.getName()));
+    }
+
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/label/print/TestPrintClientFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/label/print/TestPrintClientFactory.java
@@ -1,0 +1,30 @@
+package uk.ac.sanger.sccp.stan.service.label.print;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.sanger.sccp.stan.model.Printer;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests {@link PrintClientFactory}
+ * @author dr6
+ */
+public class TestPrintClientFactory {
+    private PrintClientFactory printClientFactory;
+    private SprintClient mockSprintClient;
+
+    @BeforeEach
+    void setup() {
+        mockSprintClient = mock(SprintClient.class);
+        printClientFactory = new PrintClientFactory(mockSprintClient);
+    }
+
+    @Test
+    public void testGetClient() {
+        assertSame(mockSprintClient, printClientFactory.getClient(Printer.Service.sprint));
+        assertThrows(IllegalArgumentException.class, () -> printClientFactory.getClient(null));
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/label/print/TestSprintClient.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/label/print/TestSprintClient.java
@@ -1,0 +1,103 @@
+package uk.ac.sanger.sccp.stan.service.label.print;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.config.SprintConfig;
+import uk.ac.sanger.sccp.stan.model.LabelType;
+import uk.ac.sanger.sccp.stan.service.label.LabelPrintRequest;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData;
+import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData.LabelContent;
+import uk.ac.sanger.sccp.utils.StringTemplate;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author dr6
+ */
+public class TestSprintClient {
+    private SprintConfig mockSprintConfig;
+    private SprintClient sprintClient;
+
+    @BeforeEach
+    void setup() {
+        mockSprintConfig = mock(SprintConfig.class);
+        sprintClient = spy(new SprintClient(mockSprintConfig));
+    }
+
+    @Test
+    public void testToJson() throws IOException {
+        final LabelType labelType = EntityFactory.getLabelType();
+        LabelPrintRequest request = new LabelPrintRequest(labelType,
+                List.of(new LabwareLabelData("STAN-1", "None",
+                        List.of(new LabelContent("DONOR1", "TISSUE1", 1, 2),
+                                new LabelContent("DONOR2", "TISSUE2", 3, 4))),
+                        new LabwareLabelData("STAN-2", "None",
+                                List.of(new LabelContent("DONOR3", "TISSUE3", 5, null))))
+        );
+        StringTemplate template = new StringTemplate("{\"barcode\":\"#barcode#\", " +
+                "\"contents\":[\"#donor[0]#\", \"#tissue[0]#\", \"#replicate[0]#\", \"#section[0]#\"," +
+                "\"#donor[1]#\", \"#tissue[1]#\", \"#replicate[1]#\", \"#section[1]#\"]}", "#", "#");
+        when(mockSprintConfig.getTemplate(eq(labelType.getName()), anyInt())).thenReturn(template);
+
+        JsonNode result = sprintClient.toJson("printer1", request);
+        String expected = "{\"query\":\"mutation ($printer:String!, $printRequest:PrintRequest!) " +
+                "{  print(printer: $printer, printRequest: $printRequest) {    jobId  }}\"," +
+                "\"variables\":{\"printer\":\"printer1\"," +
+                "\"printRequest\":{\"layouts\":[{\"barcode\":\"STAN-1\"," +
+                "\"contents\":[\"DONOR1\",\"TISSUE1\",\"R:1\",\"S002\",\"DONOR2\",\"TISSUE2\",\"R:3\",\"S004\"]}," +
+                "{\"barcode\":\"STAN-2\"," +
+                "\"contents\":[\"DONOR3\",\"TISSUE3\",\"R:5\",\"\",\"\",\"\",\"\",\"\"]}]}}}";
+
+        assertEquals(expected, result.toString());
+    }
+
+    @Test
+    public void testPrintSuccess() throws IOException {
+        when(mockSprintConfig.getHost()).thenReturn("http://sprint.psd.sanger.ac.uk");
+        JsonNode requestJson = mock(JsonNode.class);
+        doReturn(requestJson).when(sprintClient).toJson(anyString(), any());
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode responseNode = objectMapper.createObjectNode();
+        responseNode.put("data", "OK");
+        doReturn(responseNode).when(sprintClient).postJson(any(), any(), any());
+        LabelPrintRequest request = new LabelPrintRequest(EntityFactory.getLabelType(), List.of());
+
+        sprintClient.print("printer1", request);
+
+        verify(sprintClient).toJson("printer1", request);
+        verify(sprintClient).postJson(new URL(mockSprintConfig.getHost()), requestJson, ObjectNode.class);
+    }
+
+    @Test
+    public void testPrintError() throws IOException {
+        when(mockSprintConfig.getHost()).thenReturn("http://sprint.psd.sanger.ac.uk");
+        JsonNode requestJson = mock(JsonNode.class);
+        doReturn(requestJson).when(sprintClient).toJson(anyString(), any());
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode responseNode = objectMapper.createObjectNode();
+        ArrayNode errors = objectMapper.createArrayNode();
+        ObjectNode error = objectMapper.createObjectNode();
+        final String errorMessage = "Spilled the Jam.";
+        error.put("message", errorMessage);
+        errors.add(error);
+        responseNode.set("errors", errors);
+        doReturn(responseNode).when(sprintClient).postJson(any(), any(), any());
+        LabelPrintRequest request = new LabelPrintRequest(EntityFactory.getLabelType(), List.of());
+
+        assertThrows(IOException.class, () -> sprintClient.print("printer1", request), errorMessage);
+
+        verify(sprintClient).toJson("printer1", request);
+        verify(sprintClient).postJson(new URL(mockSprintConfig.getHost()), requestJson, ObjectNode.class);
+    }
+}

--- a/src/test/resources/graphql/plan.graphql
+++ b/src/test/resources/graphql/plan.graphql
@@ -7,7 +7,7 @@ mutation {
                 source:{
                     barcode:"STAN-B70C",
                 },
-                address:{row:1, column:1},
+                address:"A1",
                 sampleId:$sampleId,
             }],
         }]
@@ -22,11 +22,11 @@ mutation {
             }
             planActions {
                 source {
-                    address { row, column }
+                    address
                     labwareId
                 }
                 destination {
-                    address { row, column }
+                    address
                     labwareId
                 }
                 sample { id }


### PR DESCRIPTION
Squashed commit of the following:

commit 8b78d96e1f0dad1cb35c3247c8419e921ca0d681
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Fri Dec 4 13:49:56 2020 +0000

    Fix tests and add integration test for printLabware

commit affb3c669b2f9694f68b17d1f562526877650a8c
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Fri Dec 4 12:31:41 2020 +0000

    Fix increment bug in labwarelabeldata

commit 46b55088f2ca5b132b1e974a04b4ebfe4a424d56
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Fri Dec 4 11:32:23 2020 +0000

    Add slide6.json to sprint.properties

commit ae8506667e46ca7e155ec49c84049eaab974d5a7
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Fri Dec 4 11:19:53 2020 +0000

    Add templates slide3, slide6 and tiny. Add printers. Fix logic.

    Include medium on label.
    Associate labware types with correct label types.

commit b83d7bf7ff39c710e2d09e3fd79b72db79a20e43
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Thu Dec 3 14:36:16 2020 +0000

    Unit tests for printing functionality

commit 189d79ca4575cacb251149f4db199cc701a500d8
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Thu Dec 3 11:57:28 2020 +0000

    Printers and print-records in db, and list printers through graphql

commit d1252528c2e1d5b5ec8f60308af2d56283351616
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Wed Dec 2 16:41:10 2020 +0000

    Basic labware printing code, mostly untried

commit e29aa40161400a340e39c03e9dd534684c82bcd3
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Tue Dec 1 10:12:35 2020 +0000

    LabwareLabelDataService - figures out the label info for labware

    The required info is essentially just the barcode of the labware
    and its contents. If it has no contents, then find its planned contents
    by searching for PlanActions with this labware as the destination.

Closes #

Changes proposed in this pull request:

*
*
* ...
