### PR TITLE
Decouple Snapshot from Release

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Release.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Release.java
@@ -6,9 +6,8 @@ import org.hibernate.annotations.GenerationTime;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.Objects;
 
-import static uk.ac.sanger.sccp.utils.BasicUtils.newArrayList;
 import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
 
 /**
@@ -37,26 +36,22 @@ public class Release {
     @Generated(GenerationTime.INSERT)
     private Timestamp released;
 
-    @OneToMany
-    @JoinColumn(name="release_id")
-    private List<ReleaseDetail> details;
+    private Integer snapshotId;
 
-    public Release() {
-        this(null, null, null, null, null, null);
+    public Release() {}
+
+    public Release(Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient, Integer snapshotId) {
+        this(null, labware, user, destination, recipient, snapshotId, null);
     }
 
-    public Release(Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient) {
-        this(null, labware, user, destination, recipient, null);
-    }
-
-    public Release(Integer id, Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient, Timestamp released) {
+    public Release(Integer id, Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient, Integer snapshotId, Timestamp released) {
         this.id = id;
         this.labware = labware;
         this.user = user;
         this.destination = destination;
         this.recipient = recipient;
         this.released = released;
-        this.details = new ArrayList<>();
+        this.snapshotId = snapshotId;
     }
 
     public Integer getId() {
@@ -107,12 +102,12 @@ public class Release {
         this.user = user;
     }
 
-    public List<ReleaseDetail> getDetails() {
-        return this.details;
+    public Integer getSnapshotId() {
+        return this.snapshotId;
     }
 
-    public void setDetails(Iterable<ReleaseDetail> details) {
-        this.details = newArrayList(details);
+    public void setSnapshotId(Integer snapshotId) {
+        this.snapshotId = snapshotId;
     }
 
     @Override
@@ -126,7 +121,7 @@ public class Release {
                 && Objects.equals(this.recipient, that.recipient)
                 && Objects.equals(this.released, that.released)
                 && Objects.equals(this.user, that.user)
-                && Objects.equals(this.details, that.details));
+                && Objects.equals(this.snapshotId, that.snapshotId));
     }
 
     @Override
@@ -143,7 +138,7 @@ public class Release {
                 .add("destination", destination)
                 .add("recipient", recipient)
                 .add("released", released)
-                .add("details", details)
+                .add("snapshotId", snapshotId)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Snapshot.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Snapshot.java
@@ -1,0 +1,88 @@
+package uk.ac.sanger.sccp.stan.model;
+
+import com.google.common.base.MoreObjects;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.Objects;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.newArrayList;
+
+/**
+ * A snapshot of the contents of an item of labware
+ * @author dr6
+ */
+@Entity
+public class Snapshot {
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Integer id;
+
+    private Integer labwareId;
+
+    @OneToMany
+    @JoinColumn(name="snapshot_id")
+    private List<SnapshotElement> elements;
+
+    public Snapshot() {
+        this(null, null, null);
+    }
+
+    public Snapshot(Integer labwareId) {
+        this.labwareId = labwareId;
+    }
+
+    public Snapshot(Integer id, Integer labwareId, List<SnapshotElement> elements) {
+        this.id = id;
+        this.labwareId = labwareId;
+        setElements(elements);
+    }
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getLabwareId() {
+        return this.labwareId;
+    }
+
+    public void setLabwareId(Integer labwareId) {
+        this.labwareId = labwareId;
+    }
+
+    public List<SnapshotElement> getElements() {
+        return this.elements;
+    }
+
+    public void setElements(Iterable<SnapshotElement> elements) {
+        this.elements = newArrayList(elements);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Snapshot that = (Snapshot) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.labwareId, that.labwareId)
+                && Objects.equals(this.elements, that.elements));
+    }
+
+    @Override
+    public int hashCode() {
+        return (id!=null ? id.hashCode() : labwareId!=null ? labwareId.hashCode() : 0);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("id", id)
+                .add("labwareId", labwareId)
+                .add("elements", elements)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/SnapshotElement.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/SnapshotElement.java
@@ -6,29 +6,26 @@ import javax.persistence.*;
 import java.util.Objects;
 
 /**
+ * A record of a particular slot and sample in a snapshot
  * @author dr6
  */
 @Entity
-@Table(name = "release_detail")
-public class ReleaseDetail {
+@Table(name="snapshot_element")
+public class SnapshotElement {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(name="release_id")
-    private Integer releaseId;
-
-    @Column(name="slot_id")
+    @Column(name="snapshot_id")
+    private Integer snapshotId;
     private Integer slotId;
-
-    @Column(name="sample_id")
     private Integer sampleId;
 
-    public ReleaseDetail() {}
+    public SnapshotElement() {}
 
-    public ReleaseDetail(Integer id, Integer releaseId, Integer slotId, Integer sampleId) {
+    public SnapshotElement(Integer id, Integer snapshotId, Integer slotId, Integer sampleId) {
         this.id = id;
-        this.releaseId = releaseId;
+        this.snapshotId = snapshotId;
         this.slotId = slotId;
         this.sampleId = sampleId;
     }
@@ -41,12 +38,12 @@ public class ReleaseDetail {
         this.id = id;
     }
 
-    public Integer getReleaseId() {
-        return this.releaseId;
+    public Integer getSnapshotId() {
+        return this.snapshotId;
     }
 
-    public void setReleaseId(Integer releaseId) {
-        this.releaseId = releaseId;
+    public void setSnapshotId(Integer snapshotId) {
+        this.snapshotId = snapshotId;
     }
 
     public Integer getSlotId() {
@@ -69,23 +66,23 @@ public class ReleaseDetail {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ReleaseDetail that = (ReleaseDetail) o;
+        SnapshotElement that = (SnapshotElement) o;
         return (Objects.equals(this.id, that.id)
-                && Objects.equals(this.releaseId, that.releaseId)
+                && Objects.equals(this.snapshotId, that.snapshotId)
                 && Objects.equals(this.slotId, that.slotId)
                 && Objects.equals(this.sampleId, that.sampleId));
     }
 
     @Override
     public int hashCode() {
-        return (id!=null ? id.hashCode() : Objects.hash(releaseId, slotId, sampleId));
+        return (id!=null ? id.hashCode() : Objects.hash(snapshotId, slotId, sampleId));
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("id", id)
-                .add("releaseId", releaseId)
+                .add("snapshotId", snapshotId)
                 .add("slotId", slotId)
                 .add("sampleId", sampleId)
                 .toString();

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/ReleaseDetailRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/ReleaseDetailRepo.java
@@ -1,7 +1,0 @@
-package uk.ac.sanger.sccp.stan.repo;
-
-import org.springframework.data.repository.CrudRepository;
-import uk.ac.sanger.sccp.stan.model.ReleaseDetail;
-
-public interface ReleaseDetailRepo extends CrudRepository<ReleaseDetail, Integer> {
-}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/SnapshotElementRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/SnapshotElementRepo.java
@@ -1,0 +1,7 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.SnapshotElement;
+
+public interface SnapshotElementRepo extends CrudRepository<SnapshotElement, Integer> {
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/SnapshotRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/SnapshotRepo.java
@@ -1,0 +1,11 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.Snapshot;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface SnapshotRepo extends CrudRepository<Snapshot, Integer> {
+    List<Snapshot> findAllByIdIn(Collection<Integer> ids);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SnapshotService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SnapshotService.java
@@ -1,0 +1,50 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.SnapshotElementRepo;
+import uk.ac.sanger.sccp.stan.repo.SnapshotRepo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service dealing with {@link Snapshot labware snapshots}.
+ * @author dr6
+ */
+@Service
+public class SnapshotService {
+    private final SnapshotRepo snapshotRepo;
+    private final SnapshotElementRepo snapshotElementRepo;
+
+    public SnapshotService(SnapshotRepo snapshotRepo, SnapshotElementRepo snapshotElementRepo) {
+        this.snapshotRepo = snapshotRepo;
+        this.snapshotElementRepo = snapshotElementRepo;
+    }
+
+    /**
+     * Creates a snapshot describing the current contents of a piece of labware.
+     * @param labware the labware to snapshot
+     * @return the new snapshot
+     */
+    public Snapshot createSnapshot(Labware labware) {
+        Snapshot snapshot = snapshotRepo.save(new Snapshot(labware.getId()));
+        var elements = createElements(labware, snapshot.getId());
+        snapshot.setElements(elements);
+        return snapshot;
+    }
+
+    /**
+     * Creates the elements listing each sample in each slot of the labware
+     */
+    private Iterable<SnapshotElement> createElements(Labware labware, Integer snapshotId) {
+        List<SnapshotElement> elements = new ArrayList<>();
+        for (Slot slot : labware.getSlots()) {
+            final Integer slotId = slot.getId();
+            for (Sample sample : slot.getSamples()) {
+                elements.add(new SnapshotElement(null, snapshotId, slotId, sample.getId()));
+            }
+        }
+        return snapshotElementRepo.saveAll(elements);
+    }
+}

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -816,6 +816,55 @@
     </changeSet>
 
     <changeSet id="402" author="dr6">
+        <createTable tableName="snapshot">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="labware_id" type="INT">
+                <constraints nullable="false" foreignKeyName="snapshot_fk_labware" referencedTableName="labware" referencedColumnNames="id"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="403" author="dr6">
+        <createTable tableName="snapshot_element">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="snapshot_id" type="INT">
+                <constraints nullable="false" foreignKeyName="snapshot_element_fk_snapshot" referencedTableName="snapshot" referencedColumnNames="id"/>
+            </column>
+            <column name="slot_id" type="INT">
+                <constraints nullable="false" foreignKeyName="snapshot_element_fk_slot" referencedTableName="slot" referencedColumnNames="id"/>
+            </column>
+            <column name="sample_id" type="INT">
+                <constraints nullable="false" foreignKeyName="snapshot_element_fk_sample" referencedTableName="sample" referencedColumnNames="id"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="snapshot_element" indexName="snapshot_element_key_snapshot_slot_sample" unique="true">
+            <column name="snapshot_id"/>
+            <column name="slot_id"/>
+            <column name="sample_id"/>
+        </createIndex>
+        <rollback>
+            <dropAllForeignKeyConstraints baseTableName="snapshot_element"/>
+            <dropTable tableName="snapshot_element"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="404" author="dr6">
         <createTable tableName="labware_release">
             <column name="id" type="INT" autoIncrement="true">
                 <constraints nullable="false" primaryKey="true"/>
@@ -835,6 +884,9 @@
             <column name="recipient_id" type="INT">
                 <constraints nullable="false" foreignKeyName="labware_release_fk_recipient" referencedTableName="release_recipient" referencedColumnNames="id"/>
             </column>
+            <column name="snapshot_id" type="INT">
+                <constraints nullable="false" foreignKeyName="labware_release_fk_snapshot" referencedTableName="snapshot" referencedColumnNames="id"/>
+            </column>
             <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
@@ -844,39 +896,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="403" author="dr6">
-        <createTable tableName="release_detail">
-            <column name="id" type="INT" autoIncrement="true">
-                <constraints nullable="false" primaryKey="true"/>
-            </column>
-            <column name="release_id" type="INT">
-                <constraints nullable="false" foreignKeyName="release_detail_fk_release" referencedTableName="labware_release" referencedColumnNames="id"/>
-            </column>
-            <column name="slot_id" type="INT">
-                <constraints nullable="false" foreignKeyName="release_detail_fk_slot" referencedTableName="slot" referencedColumnNames="id"/>
-            </column>
-            <column name="sample_id" type="INT">
-                <constraints nullable="false" foreignKeyName="release_detail_fk_sample" referencedTableName="sample" referencedColumnNames="id"/>
-            </column>
-            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
-                <constraints nullable="false"/>
-            </column>
-            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
-                <constraints nullable="false"/>
-            </column>
-        </createTable>
-        <createIndex tableName="release_detail" indexName="release_detail_key_release_slot_sample" unique="true">
-            <column name="release_id"/>
-            <column name="slot_id"/>
-            <column name="sample_id"/>
-        </createIndex>
-        <rollback>
-            <dropAllForeignKeyConstraints baseTableName="release_detail"/>
-            <dropTable tableName="release_detail"/>
-        </rollback>
-    </changeSet>
-
-    <changeSet id="404" author="dr6">
+    <changeSet id="405" author="dr6">
         <addColumn tableName="labware">
             <column name="released" type="BOOLEAN" defaultValue="FALSE">
                 <constraints nullable="false"/>
@@ -887,13 +907,13 @@
         </addColumn>
     </changeSet>
 
-    <changeSet id="405" author="dr6">
+    <changeSet id="406" author="dr6">
         <loadData tableName="release_destination" file="db/releasedestinations.tsv" separator="\t">
             <column name="name" header="name" type="string"/>
         </loadData>
     </changeSet>
 
-    <changeSet id="406" author="dr6">
+    <changeSet id="407" author="dr6">
         <loadData tableName="release_recipient" file="db/releaserecipients.tsv" separator="\t">
             <column name="username" header="username" type="string"/>
         </loadData>

--- a/src/test/java/uk/ac/sanger/sccp/stan/EntityCreator.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/EntityCreator.java
@@ -56,6 +56,10 @@ public class EntityCreator {
     private ReleaseRecipientRepo releaseRecipientRepo;
     @Autowired
     private BioStateRepo bioStateRepo;
+    @Autowired
+    private SnapshotRepo snapshotRepo;
+    @Autowired
+    private SnapshotElementRepo snapshotElementRepo;
 
     @Autowired
     private EntityManager entityManager;
@@ -123,6 +127,16 @@ public class EntityCreator {
 
     public LabwareType createLabwareType(String name, int rows, int columns) {
         return ltRepo.save(new LabwareType(null, name, rows, columns, getAny(labelTypeRepo), false));
+    }
+
+    public Snapshot createSnapshot(Labware lw) {
+        Snapshot snap = snapshotRepo.save(new Snapshot(lw.getId()));
+        Iterable<SnapshotElement> elements = snapshotElementRepo.saveAll(lw.getSlots().stream()
+                .flatMap(slot -> slot.getSamples().stream().map(sam ->
+                    new SnapshotElement(null, snap.getId(), slot.getId(), sam.getId())
+                )).collect(Collectors.toList()));
+        snap.setElements(elements);
+        return snap;
     }
 
     public OperationType createOpType(String opTypeName, OperationTypeFlag... opTypeFlags) {

--- a/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
@@ -239,6 +239,16 @@ public class EntityFactory {
         return new Timestamp(System.currentTimeMillis());
     }
 
+    public static Snapshot makeSnapshot(Labware lw) {
+        Integer snapId = ++idCounter;
+        final int[] elId = {100 * snapId};
+        List<SnapshotElement> elements = lw.getSlots().stream()
+                .flatMap(slot -> slot.getSamples().stream()
+                        .map(sam -> new SnapshotElement(++elId[0], snapId, slot.getId(), sam.getId())))
+                .collect(toList());
+        return new Snapshot(snapId, lw.getId(), elements);
+    }
+
     private static List<Slot> toFirstSlots(Collection<Labware> labware) {
         return labware.stream().map(Labware::getFirstSlot).collect(toList());
     }

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestSnapshotRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestSnapshotRepo.java
@@ -1,0 +1,75 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests {@link SnapshotRepo} and {@link SnapshotElementRepo}
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@Import(EntityCreator.class)
+public class TestSnapshotRepo {
+    @Autowired
+    private SnapshotRepo snapshotRepo;
+    @Autowired
+    private SnapshotElementRepo snapshotElementRepo;
+    @Autowired
+    private EntityCreator entityCreator;
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional
+    public void testSnapshot() {
+        Donor donor = entityCreator.createDonor("DONOR1");
+        Tissue tissue = entityCreator.createTissue(donor, "TISSUE1");
+        Sample sample1 = entityCreator.createSample(tissue, 1);
+        Sample sample2 = entityCreator.createSample(tissue, 2);
+        Labware lw = entityCreator.createLabware("STAN-A1", entityCreator.createLabwareType("lt", 1, 2));
+        Slot slot1 = lw.getFirstSlot();
+        Slot slot2 = lw.getSlots().get(1);
+        slot1.getSamples().addAll(List.of(sample1, sample2));
+        slot2.getSamples().add(sample1);
+
+        Snapshot snapshot = snapshotRepo.save(new Snapshot(lw.getId()));
+        final Integer snapshotId = snapshot.getId();
+        Iterable<SnapshotElement> elements = snapshotElementRepo.saveAll(
+                lw.getSlots().stream()
+                        .flatMap(slot -> slot.getSamples().stream()
+                                .map(sam -> new SnapshotElement(null, snapshotId, slot.getId(), sam.getId())))
+                        .collect(Collectors.toList())
+        );
+        entityManager.refresh(snapshot);
+        assertThat(snapshot.getElements()).hasSize(3);
+        Set<List<Integer>> slotSampleIds = new HashSet<>();
+        for (SnapshotElement el : elements) {
+            assertNotNull(el.getId());
+            assertEquals(snapshotId, el.getSnapshotId());
+            slotSampleIds.add(List.of(el.getSlotId(), el.getSampleId()));
+        }
+        Set<List<Integer>> expectedSlotSampleIds = Stream.of(
+                List.of(slot1, sample1),
+                List.of(slot1, sample2),
+                List.of(slot2, sample1)
+        ).map(lst -> List.of(((Slot) lst.get(0)).getId(), ((Sample) lst.get(1)).getId()))
+                .collect(toSet());
+        assertEquals(expectedSlotSampleIds, slotSampleIds);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestSnapshotService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestSnapshotService.java
@@ -1,0 +1,80 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.SnapshotElementRepo;
+import uk.ac.sanger.sccp.stan.repo.SnapshotRepo;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link SnapshotService}
+ * @author dr6
+ */
+public class TestSnapshotService {
+    private SnapshotRepo mockSnapshotRepo;
+    private SnapshotElementRepo mockSnapshotElementRepo;
+
+    private SnapshotService service;
+
+    @BeforeEach
+    void setup() {
+        mockSnapshotRepo = mock(SnapshotRepo.class);
+        mockSnapshotElementRepo = mock(SnapshotElementRepo.class);
+
+        service = new SnapshotService(mockSnapshotRepo, mockSnapshotElementRepo);
+    }
+
+    @Test
+    public void testCreateSnapshot() {
+        LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Labware labware = EntityFactory.makeEmptyLabware(lt);
+        Sample sample1 = EntityFactory.getSample();
+        Sample sample2 = new Sample(sample1.getId()+1, 8, sample1.getTissue(), sample1.getBioState());
+        final Slot slot1 = labware.getFirstSlot();
+        slot1.getSamples().addAll(List.of(sample1, sample2));
+        final Slot slot2 = labware.getSlots().get(1);
+        slot2.getSamples().add(sample1);
+        final int[] idCounter = {0};
+
+        when(mockSnapshotRepo.save(any())).then(invocation -> {
+            Snapshot snapshot = invocation.getArgument(0);
+            snapshot.setId(++idCounter[0]);
+            return snapshot;
+        });
+
+        when(mockSnapshotElementRepo.saveAll(any())).then(invocation -> {
+            Iterable<SnapshotElement> elements = invocation.getArgument(0);
+            for (var element : elements) {
+                element.setId(++idCounter[0]);
+            }
+            return elements;
+        });
+
+        Snapshot snapshot = service.createSnapshot(labware);
+        Integer snapshotId = snapshot.getId();
+        assertNotNull(snapshotId);
+        assertEquals(snapshot.getLabwareId(), labware.getId());
+        List<SnapshotElement> elements = snapshot.getElements();
+        assertThat(elements).hasSize(3);
+        Set<List<Integer>> slotSampleIds = new HashSet<>(3);
+        for (var el : elements) {
+            assertNotNull(el.getId());
+            assertEquals(snapshotId, el.getSnapshotId());
+            slotSampleIds.add(List.of(el.getSlotId(), el.getSampleId()));
+        }
+        assertEquals(Set.of(List.of(slot1.getId(), sample1.getId()), List.of(slot1.getId(), sample2.getId()),
+                List.of(slot2.getId(), sample1.getId())), slotSampleIds);
+
+        verify(mockSnapshotRepo).save(snapshot);
+        verify(mockSnapshotElementRepo).saveAll(elements);
+    }
+}


### PR DESCRIPTION
Previously Release was linked to ReleaseDetail which snapshotted the
labware.
Now Release is linked to a Snapshot that contains SnapshotElements, so
snapshots can be written, used and tested independently.

Also in ReleaseService, use new storeService.discardStorage method.

Requires clobbering the db again.