### PR TITLE
Various fixes mostly to storage and discarded labware

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -131,7 +131,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         return dfe -> {
             User user = checkUser();
             ExtractRequest request = arg(dfe, "request", ExtractRequest.class);
-            return extractService.extract(user, request);
+            return extractService.extractAndUnstore(user, request);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -89,13 +89,13 @@ public class GraphQLProvider {
                         .dataFetcher("printLabware", graphQLMutation.printLabware()) // not transacted
                         .dataFetcher("confirmOperation", transact(graphQLMutation.confirmOperation()))
                         .dataFetcher("release", graphQLMutation.release()) // transaction handled in service
-                        .dataFetcher("extract", transact(graphQLMutation.extract()))
+                        .dataFetcher("extract", graphQLMutation.extract()) // transaction handled in service
                         .dataFetcher("destroy", graphQLMutation.destroy()) // transaction handled in service
 
-                        .dataFetcher("storeBarcode", transact(graphQLStore.storeBarcode()))
-                        .dataFetcher("unstoreBarcode", transact(graphQLStore.unstoreBarcode()))
-                        .dataFetcher("empty", transact(graphQLStore.empty()))
-                        .dataFetcher("setLocationCustomName", transact(graphQLStore.setLocationCustomName()))
+                        .dataFetcher("storeBarcode", graphQLStore.storeBarcode())
+                        .dataFetcher("unstoreBarcode", graphQLStore.unstoreBarcode())
+                        .dataFetcher("empty", graphQLStore.empty())
+                        .dataFetcher("setLocationCustomName", graphQLStore.setLocationCustomName())
                 )
                 .scalar(GraphQLCustomTypes.ADDRESS)
                 .scalar(GraphQLCustomTypes.TIMESTAMP)

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Labware.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Labware.java
@@ -143,4 +143,9 @@ public class Labware {
     public boolean isUsable() {
         return !(isReleased() || isDestroyed() || isDiscarded());
     }
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return this.slots.stream().allMatch(slot -> slot.getSamples().isEmpty());
+    }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareValidator.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareValidator.java
@@ -209,7 +209,7 @@ public class LabwareValidator {
      * Adds an error for labware that is empty.
      */
     public void validateNonEmpty() {
-        validateState(lw -> lw.getSlots().stream().allMatch(slot -> slot.getSamples().isEmpty()), "empty");
+        validateState(Labware::isEmpty, "empty");
     }
 
     /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ReleaseServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ReleaseServiceImp.java
@@ -108,7 +108,7 @@ public class ReleaseServiceImp implements ReleaseService {
      */
     public void validateLabware(Collection<Labware> labware) {
         List<String> emptyLabwareBarcodes = labware.stream()
-                .filter(lw -> lw.getSlots().stream().allMatch(slot -> slot.getSamples().isEmpty()))
+                .filter(Labware::isEmpty)
                 .map(Labware::getBarcode)
                 .collect(toList());
         if (!emptyLabwareBarcodes.isEmpty()) {
@@ -127,6 +127,13 @@ public class ReleaseServiceImp implements ReleaseService {
                 .collect(toList());
         if (!destroyedLabwareBarcodes.isEmpty()) {
             throw new IllegalArgumentException("Labware cannot be released because it is destroyed: "+destroyedLabwareBarcodes);
+        }
+        List<String> discardedLabwareBarcodes = labware.stream()
+                .filter(Labware::isDiscarded)
+                .map(Labware::getBarcode)
+                .collect(toList());
+        if (!discardedLabwareBarcodes.isEmpty()) {
+            throw new IllegalArgumentException("Labware cannot be released because it is discarded: "+discardedLabwareBarcodes);
         }
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/extract/ExtractService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/extract/ExtractService.java
@@ -4,12 +4,17 @@ import uk.ac.sanger.sccp.stan.model.User;
 import uk.ac.sanger.sccp.stan.request.ExtractRequest;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
 
+/**
+ * Service for performing extractions.
+ * This creates new labware, populates it, creates operations, discards the sources, and unstores them.
+ */
 public interface ExtractService {
     /**
-     * Performs an extraction (creating labware, recording goals etc.)
+     * Performs an extraction (creating labware, recording goals etc.) in a transaction,
+     * then unstores the discarded source labware.
      * @param user the user responsible for the extraction
      * @param request the request of what to extract
      * @return the result of the extraction
      */
-    OperationResult extract(User user, ExtractRequest request);
+    OperationResult extractAndUnstore(User user, ExtractRequest request);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/confirm/ConfirmOperationValidationImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/confirm/ConfirmOperationValidationImp.java
@@ -76,7 +76,7 @@ public class ConfirmOperationValidationImp implements ConfirmOperationValidation
                 addProblem("Labware %s is already discarded.", col.getBarcode());
             }
 
-            if (lw.getSlots().stream().anyMatch(slot -> !slot.getSamples().isEmpty())) {
+            if (!lw.isEmpty()) {
                 addProblem("Labware %s already has contents.", col.getBarcode());
             }
             labware.put(bc, lw);

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationImp.java
@@ -45,6 +45,7 @@ public class PlanValidationImp implements PlanValidation {
         Set<String> unfoundBarcodes = new LinkedHashSet<>();
         Set<String> destroyedBarcodes = new LinkedHashSet<>();
         Set<String> releasedBarcodes = new LinkedHashSet<>();
+        Set<String> discardedBarcodes = new LinkedHashSet<>();
         for (PlanRequestAction action : (Iterable<PlanRequestAction>) (actions()::iterator)) {
             PlanRequestSource source = action.getSource();
             if (source==null || source.getBarcode()==null || source.getBarcode().isEmpty()) {
@@ -68,6 +69,8 @@ public class PlanValidationImp implements PlanValidation {
                     destroyedBarcodes.add(lw.getBarcode());
                 } else if (lw.isReleased()) {
                     releasedBarcodes.add(lw.getBarcode());
+                } else if (lw.isDiscarded()) {
+                    discardedBarcodes.add(lw.getBarcode());
                 }
             }
             Address address = (source.getAddress()==null ? new Address(1,1) : source.getAddress());
@@ -97,6 +100,9 @@ public class PlanValidationImp implements PlanValidation {
         }
         if (!destroyedBarcodes.isEmpty()) {
             addProblem("Labware already destroyed: "+destroyedBarcodes);
+        }
+        if (!discardedBarcodes.isEmpty()) {
+            addProblem("Labware already discarded: "+discardedBarcodes);
         }
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/store/StoreService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/store/StoreService.java
@@ -162,6 +162,7 @@ public class StoreService {
         if (lw.isDestroyed()) return "destroyed";
         if (lw.isReleased()) return "released";
         if (lw.isDiscarded()) return "discarded";
+        if (lw.isEmpty()) return "empty";
         return null;
         // In CGAP storing discarded labware automatically reactivates it.
         // The behaviour of stan wrt discarded labware is not yet established.

--- a/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
@@ -253,6 +253,8 @@ public class IntegrationTests {
                 .mapToObj(i -> entityCreator.createLabware(barcodes[i], lwType, samples[i]))
                 .toArray(Labware[]::new);
 
+        stubStorelightUnstore();
+
         String mutation = tester.readResource("graphql/extract.graphql")
                 .replace("[]", "[\"STAN-A1\", \"STAN-A2\"]")
                 .replace("LWTYPE", lwType.getName());
@@ -336,6 +338,8 @@ public class IntegrationTests {
             assertEquals(sample, action.getSample());
             assertNotNull(op.getPerformed());
         }
+
+        verifyUnstored(List.of(sources[0].getBarcode(), sources[1].getBarcode()), user.getUsername());
     }
 
     @Test

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestReleaseService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestReleaseService.java
@@ -217,17 +217,21 @@ public class TestReleaseService {
         destroyed.setDestroyed(true);
         Labware released = EntityFactory.makeLabware(lt, sample);
         released.setReleased(true);
+        Labware discarded = EntityFactory.makeLabware(lt, sample);
+        discarded.setDiscarded(true);
 
         String emptyError = "Cannot release empty labware: [" + empty.getBarcode()+"]";
         String releasedError = "Labware has already been released: ["+released.getBarcode()+"]";
         String destroyedError = "Labware cannot be released because it is destroyed: ["+destroyed.getBarcode()+"]";
+        String discardedError = "Labware cannot be released because it is discarded: ["+discarded.getBarcode()+"]";
         return Stream.of(
                 Arguments.of(List.of(good), null),
                 Arguments.of(List.of(good, empty), emptyError),
                 Arguments.of(List.of(empty, good), emptyError),
                 Arguments.of(List.of(destroyed), destroyedError),
                 Arguments.of(List.of(good, destroyed), destroyedError),
-                Arguments.of(List.of(released), releasedError)
+                Arguments.of(List.of(released), releasedError),
+                Arguments.of(List.of(discarded), discardedError)
         );
     }
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidation.java
@@ -212,6 +212,9 @@ public class TestPlanValidation {
         Labware releasedLw = EntityFactory.makeLabware(lt, sample);
         releasedLw.setReleased(true);
 
+        Labware discardedLw = EntityFactory.makeLabware(lt, sample);
+        discardedLw.setDiscarded(true);
+
         Address A1 = new Address(1,1);
 
         OperationType sectionOpType = EntityFactory.makeOperationType("Section", OperationTypeFlag.SOURCE_IS_BLOCK);
@@ -229,6 +232,7 @@ public class TestPlanValidation {
 
                 Arguments.of(destroyedLw.getBarcode(), A1, sectionSampleId, destroyedLw, otherOpType, "Labware already destroyed: ["+destroyedLw.getBarcode()+"]"),
                 Arguments.of(releasedLw.getBarcode(), A1, sectionSampleId, releasedLw, otherOpType, "Labware already released: ["+releasedLw.getBarcode()+"]"),
+                Arguments.of(discardedLw.getBarcode(), A1, sectionSampleId, discardedLw, otherOpType, "Labware already discarded: ["+discardedLw.getBarcode()+"]"),
                 Arguments.of(null, A1, blockSampleId, block, sectionOpType, "Missing source barcode."),
                 Arguments.of("", A1, blockSampleId, block, sectionOpType, "Missing source barcode."),
                 Arguments.of("404", A1, blockSampleId, block, sectionOpType, "Unknown labware barcode: [404]"),

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/store/TestStoreService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/store/TestStoreService.java
@@ -78,7 +78,7 @@ public class TestStoreService {
     @ValueSource(booleans={false, true})
     public void testStoreBarcode(boolean withAddress) throws IOException {
         Address address = withAddress ? new Address(2,3) : null;
-        Labware lw = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType());
+        Labware lw = EntityFactory.makeLabware(EntityFactory.getTubeType(), EntityFactory.getSample());
         String itemBarcode = lw.getBarcode();
         when(mockLabwareRepo.getByBarcode(itemBarcode)).thenReturn(lw);
         String locationBarcode = "STO-ABC";
@@ -171,7 +171,9 @@ public class TestStoreService {
 
     static Stream<Arguments> validateBarcodeForStorageArgs() {
         LabwareType lt = EntityFactory.getTubeType();
-        Labware okLabware = EntityFactory.makeEmptyLabware(lt);
+        Sample sample = EntityFactory.getSample();
+        Labware okLabware = EntityFactory.makeLabware(lt, sample);
+        Labware emptyLabware = EntityFactory.makeEmptyLabware(lt);
         Labware releasedLabware = EntityFactory.makeEmptyLabware(lt);
         releasedLabware.setReleased(true);
         Labware destroyedLabware = EntityFactory.makeEmptyLabware(lt);
@@ -185,7 +187,8 @@ public class TestStoreService {
                 Arguments.of(okLabware, null),
                 Arguments.of(releasedLabware, "Labware %bc cannot be stored because it is released."),
                 Arguments.of(destroyedLabware, "Labware %bc cannot be stored because it is destroyed."),
-                Arguments.of(discardedLabware, "Labware %bc cannot be stored because it is discarded.")
+                Arguments.of(discardedLabware, "Labware %bc cannot be stored because it is discarded."),
+                Arguments.of(emptyLabware, "Labware %bc cannot be stored because it is empty.")
         );
     }
 


### PR DESCRIPTION
* Add Labware::isEmpty method
* Handle transaction in ExtractService, then unstore discarded sources
* Check if sources are discarded in PlanValidation
* Block storing empty labware in StoreService
* Check if labware is discarded in ReleaseService
* Remove transaction from store mutations
