### PR TITLE
Use Storelight location "name" field

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/store/LinkedLocation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/store/LinkedLocation.java
@@ -1,8 +1,6 @@
 package uk.ac.sanger.sccp.stan.model.store;
 
 import com.google.common.base.MoreObjects;
-import org.json.JSONException;
-import org.json.JSONObject;
 import uk.ac.sanger.sccp.stan.model.Address;
 
 import java.util.Objects;
@@ -14,79 +12,78 @@ import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
  * @author dr6
  */
 public class LinkedLocation {
-    private static final String NAME_FIELD = "name";
-    private static final String CUSTOM_NAME_FIELD = "customName";
+    private static final String NAME_SEP = ": ";
     private String barcode;
-    private String description;
+    private String name;
     private Address address;
 
     public String getBarcode() {
         return this.barcode;
     }
 
-    public String getDescription() {
-        return this.description;
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public Address getAddress() {
         return this.address;
     }
 
-    public void setBarcode(String barcode) {
-        this.barcode = barcode;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public void setAddress(Address address) {
         this.address = address;
     }
 
-    public String getName() {
-        if (description==null || description.isEmpty()) {
+    public String getFixedName() {
+        if (name ==null || name.isEmpty()) {
             return null;
         }
-        try {
-            JSONObject jo = new JSONObject(description);
-            return jo.getString(NAME_FIELD);
-        } catch (JSONException je) {
+        int n = name.indexOf(NAME_SEP);
+        if (n < 0) {
+            return name;
+        }
+        if (n==0) {
             return null;
         }
+        return name.substring(0, n);
     }
 
     public String getCustomName() {
-        if (description==null || description.isEmpty()) {
+        if (name ==null || name.isEmpty()) {
             return null;
         }
-        try {
-            JSONObject jo = new JSONObject(description);
-            return jo.getString(CUSTOM_NAME_FIELD);
-        } catch (JSONException je) {
+        int n = name.indexOf(NAME_SEP);
+        if (n < 0) {
             return null;
         }
+        return name.substring(n + NAME_SEP.length());
     }
 
-    public void setName(String name) {
+    public void setFixedName(String name) {
         setNameAndCustomName(name, getCustomName());
     }
 
     public void setCustomName(String customName) {
-        setNameAndCustomName(getName(), customName);
+        setNameAndCustomName(getFixedName(), customName);
     }
 
-    public void setNameAndCustomName(String name, String customName) {
-        name = sanitise(name);
+    public void setNameAndCustomName(String fixedName, String customName) {
+        fixedName = sanitise(fixedName);
         customName = sanitise(customName);
-        if (name==null && customName==null) {
-            setDescription(null);
-            return;
+        if (customName==null) {
+            this.name = fixedName;
+        } else if (fixedName==null) {
+            this.name = NAME_SEP + customName;
+        } else {
+            this.name = fixedName + NAME_SEP + customName;
         }
-        JSONObject jo = new JSONObject();
-        jo.put(NAME_FIELD, name);
-        jo.put(CUSTOM_NAME_FIELD, customName);
-        setDescription(jo.toString());
     }
 
     private static String sanitise(String string) {
@@ -108,7 +105,7 @@ public class LinkedLocation {
 
     protected boolean equalsLinkedLocation(LinkedLocation that) {
         return (Objects.equals(this.barcode, that.barcode)
-                && Objects.equals(this.description, that.description)
+                && Objects.equals(this.name, that.name)
                 && Objects.equals(this.address, that.address));
     }
 
@@ -121,10 +118,9 @@ public class LinkedLocation {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("barcode", repr(barcode))
-                .add("description", repr(description))
+                .add("name", repr(name))
                 .add("address", address)
                 .omitNullValues()
-                .toString()
-                ;
+                .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/store/StoreService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/store/StoreService.java
@@ -109,8 +109,8 @@ public class StoreService {
         Location location = getLocation(locationBarcode);
         location.setCustomName(customName);
         return send(user, "editLocation",
-                new String[] {"\"LOCATIONBARCODE\"", "\"DESCRIPTION\""},
-                new Object[] { location.getBarcode(), location.getDescription() },
+                new String[] {"\"LOCATIONBARCODE\"", "\"NAME\""},
+                new Object[] { location.getBarcode(), location.getName() },
                 Location.class).fixInternalLinks();
     }
 

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -298,7 +298,7 @@ enum GridDirection {
 type Location {
     id: Int!
     barcode: String!
-    name: String
+    fixedName: String
     customName: String
     address: Address
     size: Size
@@ -310,7 +310,7 @@ type Location {
 
 type LinkedLocation {
     barcode: String!
-    name: String
+    fixedName: String
     customName: String
     address: Address
 }

--- a/src/main/resources/storelight/editLocation.graphql
+++ b/src/main/resources/storelight/editLocation.graphql
@@ -1,13 +1,13 @@
 mutation {
-    editLocation(location: {barcode:"LOCATIONBARCODE"}, change: {description:"DESCRIPTION"}) {
+    editLocation(location: {barcode:"LOCATIONBARCODE"}, change: {name:"NAME"}) {
         id
         barcode
-        description
+        name
         address
         size { numRows numColumns }
-        children { barcode description address }
+        children { barcode name address }
         stored { barcode address }
-        parent { barcode description address }
+        parent { barcode name address }
         direction
     }
 }

--- a/src/main/resources/storelight/location.graphql
+++ b/src/main/resources/storelight/location.graphql
@@ -2,12 +2,12 @@
     location(location: {barcode:"LOCATIONBARCODE"}) {
         id
         barcode
-        description
+        name
         address
         size { numRows numColumns}
-        children { barcode description address }
+        children { barcode name address }
         stored { barcode address }
-        parent { barcode description address }
+        parent { barcode name address }
         direction
     }
 }

--- a/src/main/resources/storelight/storeBarcode.graphql
+++ b/src/main/resources/storelight/storeBarcode.graphql
@@ -5,12 +5,12 @@ mutation {
         location {
             id
             barcode
-            description
+            name
             address
             size { numRows numColumns }
-            children { barcode description address }
+            children { barcode name address }
             stored { barcode address }
-            parent { barcode description address }
+            parent { barcode name address }
             direction
         }
     }

--- a/src/main/resources/storelight/stored.graphql
+++ b/src/main/resources/storelight/stored.graphql
@@ -5,11 +5,11 @@
         location {
             id
             barcode
-            description
+            name
             address
             size { numRows numColumns}
-            children { barcode description address }
-            parent { barcode description address }
+            children { barcode name address }
+            parent { barcode name address }
             stored { barcode address }
             direction
         }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/store/TestStoreService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/store/TestStoreService.java
@@ -101,10 +101,10 @@ public class TestStoreService {
 
         verifyQueryMatches("mutation { storeBarcode(barcode: \""+itemBarcode+"\", location: {barcode: \""
                 + locationBarcode+"\"}, address: " + quote(address) + ") { barcode address location " +
-                "{ id barcode description address size { numRows numColumns } " +
-                "children { barcode description address } " +
+                "{ id barcode name address size { numRows numColumns } " +
+                "children { barcode name address } " +
                 "stored { barcode address }" +
-                "parent { barcode description address }" +
+                "parent { barcode name address }" +
                 "direction}}}");
         verify(service).checkErrors(response);
         assertEquals(item, result);
@@ -232,21 +232,21 @@ public class TestStoreService {
         Location alteredLocation = new Location();
         alteredLocation.setNameAndCustomName(name, newCustomName);
         ObjectNode returnedNode = objectMapper.valueToTree(alteredLocation);
-        returnedNode.remove("name");
+        returnedNode.remove("fixedName");
         returnedNode.remove("customName");
         GraphQLResponse response = setupResponse("editLocation", returnedNode);
         Location result = service.setLocationCustomName(user, barcode, newCustomName);
         verifyQueryMatches("mutation { editLocation(location:{barcode:"+json(barcode)
-                +"}, change: {description:"+json(alteredLocation.getDescription())+"}) {" +
-                "id barcode description address size {numRows numColumns } " +
-                "children { barcode description address }" +
+                +"}, change: {name:"+json(alteredLocation.getName())+"}) {" +
+                "id barcode name address size {numRows numColumns } " +
+                "children { barcode name address }" +
                 "stored { barcode address } " +
-                "parent { barcode description address }" +
+                "parent { barcode name address }" +
                 "direction }}");
         verify(service).checkErrors(response);
         assertEquals(alteredLocation, result);
         assertEquals(newCustomName, alteredLocation.getCustomName());
-        assertEquals(name, alteredLocation.getName());
+        assertEquals(name, alteredLocation.getFixedName());
     }
 
     @Test
@@ -270,7 +270,7 @@ public class TestStoreService {
         location.getChildren().add(child);
 
         ObjectNode returnedNode = objectMapper.valueToTree(location);
-        returnedNode.remove("name");
+        returnedNode.remove("fixedName");
         returnedNode.remove("customName");
         GraphQLResponse response = setupResponse("location", returnedNode);
         Location result = service.getLocation(barcode);
@@ -278,12 +278,12 @@ public class TestStoreService {
                         "    location(location: {barcode:\""+barcode+"\"}) {" +
                         "        id" +
                         "        barcode" +
-                        "        description" +
+                        "        name" +
                         "        address" +
                         "        size { numRows numColumns}" +
-                        "        children { barcode description address }" +
+                        "        children { barcode name address }" +
                         "        stored { barcode address }" +
-                        "        parent { barcode description address }" +
+                        "        parent { barcode name address }" +
                         "        direction" +
                         "    }}",
 
@@ -342,11 +342,11 @@ public class TestStoreService {
                 "        location {" +
                 "            id" +
                 "            barcode" +
-                "            description" +
+                "            name" +
                 "            address" +
                 "            size { numRows numColumns}" +
-                "            children { barcode description address }" +
-                "            parent { barcode description address }" +
+                "            children { barcode name address }" +
+                "            parent { barcode name address }" +
                 "            stored { barcode address }" +
                 "            direction" +
                 "        }}}",


### PR DESCRIPTION
Follows on from Storelight Location adding a name column.
Instead of putting a block of JSON into the description, put
"fixedName: customName" into the "name" field.
The Stan graphql location entities now have fields called "fixedName"
and "customName" instead of "name" and "customName".