### PR TITLE
x637 Allow similar plan-actions when you're sectioning a block

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/request/confirm/CancelPlanAction.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/confirm/CancelPlanAction.java
@@ -1,0 +1,87 @@
+package uk.ac.sanger.sccp.stan.request.confirm;
+
+import uk.ac.sanger.sccp.stan.model.Address;
+import uk.ac.sanger.sccp.stan.model.PlanAction;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.util.Objects;
+
+/**
+ * Part of a confirm request indicating that a particular plan action is cancelled.
+ * @author dr6
+ */
+public class CancelPlanAction {
+    private Address destinationAddress;
+    private Integer sampleId;
+    private Integer newSection;
+
+    public CancelPlanAction() {}
+
+    public CancelPlanAction(Address destinationAddress, Integer sampleId, Integer newSection) {
+        this.destinationAddress = destinationAddress;
+        this.sampleId = sampleId;
+        this.newSection = newSection;
+    }
+
+    public CancelPlanAction(PlanAction planAction) {
+        this(planAction.getDestination().getAddress(), planAction.getSample().getId(), planAction.getNewSection());
+    }
+
+    public Address getDestinationAddress() {
+        return this.destinationAddress;
+    }
+
+    public void setDestinationAddress(Address destinationAddress) {
+        this.destinationAddress = destinationAddress;
+    }
+
+    public Integer getSampleId() {
+        return this.sampleId;
+    }
+
+    public void setSampleId(Integer sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    public Integer getNewSection() {
+        return this.newSection;
+    }
+
+    public void setNewSection(Integer newSection) {
+        this.newSection = newSection;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CancelPlanAction that = (CancelPlanAction) o;
+        return (Objects.equals(this.destinationAddress, that.destinationAddress)
+                && Objects.equals(this.sampleId, that.sampleId)
+                && Objects.equals(this.newSection, that.newSection));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(destinationAddress, sampleId, newSection);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe("CancelPlanAction")
+                .add("destinationAddress", destinationAddress)
+                .add("sampleId", sampleId)
+                .add("newSection", newSection)
+                .toString();
+    }
+
+    public String describeWithBarcode(String barcode) {
+        return String.format("(barcode=%s, address=%s, sampleId=%s, newSection=%s)",
+                barcode, destinationAddress, sampleId, newSection);
+    }
+
+    public static CancelPlanAction forPlanAction(PlanAction planAction) {
+        return new CancelPlanAction(planAction.getDestination().getAddress(), planAction.getSample().getId(),
+                planAction.getNewSection());
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/confirm/ConfirmOperationLabware.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/confirm/ConfirmOperationLabware.java
@@ -5,6 +5,8 @@ import uk.ac.sanger.sccp.stan.model.Address;
 
 import java.util.*;
 
+import static uk.ac.sanger.sccp.utils.BasicUtils.newArrayList;
+
 /**
  * The part of a {@link ConfirmOperationRequest confirmation request} applying to a single piece of labware
  * @author dr6
@@ -12,7 +14,7 @@ import java.util.*;
 public class ConfirmOperationLabware {
     private String barcode;
     private boolean cancelled;
-    private Set<Address> cancelledAddresses;
+    private Set<CancelPlanAction> cancelledActions;
     private List<AddressCommentId> addressComments;
 
     public ConfirmOperationLabware() {
@@ -23,11 +25,11 @@ public class ConfirmOperationLabware {
         this(barcode, false, null, null);
     }
 
-    public ConfirmOperationLabware(String barcode, boolean cancelled, Collection<Address> cancelledAddresses,
+    public ConfirmOperationLabware(String barcode, boolean cancelled, Collection<CancelPlanAction> cancelledActions,
                                    Collection<AddressCommentId> addressComments) {
         setBarcode(barcode);
         setCancelled(cancelled);
-        setCancelledAddresses(cancelledAddresses);
+        setCancelledActions(cancelledActions);
         setAddressComments(addressComments);
     }
 
@@ -47,12 +49,12 @@ public class ConfirmOperationLabware {
         this.cancelled = cancelled;
     }
 
-    public Set<Address> getCancelledAddresses() {
-        return this.cancelledAddresses;
+    public Set<CancelPlanAction> getCancelledActions() {
+        return this.cancelledActions;
     }
 
-    public void setCancelledAddresses(Collection<Address> cancelledAddresses) {
-        this.cancelledAddresses = (cancelledAddresses==null ? new HashSet<>() : new HashSet<>(cancelledAddresses));
+    public void setCancelledActions(Collection<CancelPlanAction> cancelledActions) {
+        this.cancelledActions = (cancelledActions==null ? new HashSet<>() : new HashSet<>(cancelledActions));
     }
 
     public List<AddressCommentId> getAddressComments() {
@@ -60,7 +62,7 @@ public class ConfirmOperationLabware {
     }
 
     public void setAddressComments(Collection<AddressCommentId> addressComments) {
-        this.addressComments = (addressComments==null ? new ArrayList<>() : new ArrayList<>(addressComments));
+        this.addressComments = newArrayList(addressComments);
     }
 
     @Override
@@ -68,7 +70,7 @@ public class ConfirmOperationLabware {
         return MoreObjects.toStringHelper(this)
                 .add("barcode", barcode)
                 .add("cancelled", cancelled)
-                .add("cancelledAddresses", cancelledAddresses)
+                .add("cancelledActions", cancelledActions)
                 .add("addressComments", addressComments)
                 .toString();
     }
@@ -80,7 +82,7 @@ public class ConfirmOperationLabware {
         ConfirmOperationLabware that = (ConfirmOperationLabware) o;
         return (this.cancelled == that.cancelled
                 && Objects.equals(this.barcode, that.barcode)
-                && Objects.equals(this.cancelledAddresses, that.cancelledAddresses)
+                && Objects.equals(this.cancelledActions, that.cancelledActions)
                 && Objects.equals(this.addressComments, that.addressComments));
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationImp.java
@@ -32,20 +32,26 @@ public class PlanValidationImp implements PlanValidation {
     @Override
     public Collection<String> validate() {
         OperationType opType = validateOperation();
-        validateSources(opType);
-        validateDestinations();
+        Map<ActionKey, Slot> actionSources = validateSources(opType);
+        validateDestinations(actionSources);
         return problems;
     }
 
-    public void validateSources(OperationType opType) {
+    /**
+     * Checks the sources. Returns a map of {@link ActionKey} to source slot for each action.
+     * @param opType the type of operation
+     * @return a map of {@code ActionKey} to source slot
+     */
+    public Map<ActionKey, Slot> validateSources(OperationType opType) {
         if (request.getLabware().isEmpty()) {
-            return;
+            return Map.of();
         }
         Map<String, Labware> labwareMap = new HashMap<>();
         Set<String> unfoundBarcodes = new LinkedHashSet<>();
         Set<String> destroyedBarcodes = new LinkedHashSet<>();
         Set<String> releasedBarcodes = new LinkedHashSet<>();
         Set<String> discardedBarcodes = new LinkedHashSet<>();
+        Map<ActionKey, Slot> actionSources = new HashMap<>();
         for (PlanRequestAction action : (Iterable<PlanRequestAction>) (actions()::iterator)) {
             PlanRequestSource source = action.getSource();
             if (source==null || source.getBarcode()==null || source.getBarcode().isEmpty()) {
@@ -79,6 +85,8 @@ public class PlanValidationImp implements PlanValidation {
                 continue;
             }
             Slot slot = lw.getSlot(address);
+            ActionKey actionKey = new ActionKey(action);
+            actionSources.put(actionKey, slot);
             Sample sample = slot.getSamples().stream().filter(sam -> sam.getId()==action.getSampleId())
                     .findAny().orElse(null);
             if (sample==null) {
@@ -104,9 +112,10 @@ public class PlanValidationImp implements PlanValidation {
         if (!discardedBarcodes.isEmpty()) {
             addProblem("Labware already discarded: "+discardedBarcodes);
         }
+        return actionSources;
     }
 
-    public void validateDestinations() {
+    public void validateDestinations(Map<ActionKey, Slot> actionSources) {
         if (request.getLabware().isEmpty()) {
             addProblem("No labware are specified in the plan request.");
             return;
@@ -148,7 +157,7 @@ public class PlanValidationImp implements PlanValidation {
                 addProblem("%s barcode supplied for new labware of type %s.",
                         gotBarcode ? "Unexpected":"No", lt.getName());
             }
-            checkActions(lw, lt);
+            checkActions(lw, lt, actionSources);
             if (gotBarcode && !alreadySeen && labwareRepo.existsByBarcode(lw.getBarcode())) {
                 addProblem("Labware with the barcode "+lw.getBarcode()+" already exists in the database.");
             } else if (gotBarcode && !alreadySeen && labwareRepo.existsByExternalBarcode(lw.getBarcode())) {
@@ -177,7 +186,7 @@ public class PlanValidationImp implements PlanValidation {
         return opType;
     }
 
-    public void checkActions(PlanRequestLabware lw, LabwareType lt) {
+    public void checkActions(PlanRequestLabware lw, LabwareType lt, Map<ActionKey, Slot> actionSources) {
         if (lw.getActions().isEmpty()) {
             addProblem("No actions specified for labware %s.", lwErrorDesc(lw));
             return;
@@ -193,7 +202,11 @@ public class PlanValidationImp implements PlanValidation {
             }
             ActionKey key = new ActionKey(ac);
             if (key.isComplete() && !keys.add(key)) {
-                addProblem("Actions for labware %s contain duplicate action: %s", lwErrorDesc(lw), key);
+                Slot slot = actionSources.get(key);
+                if (slot!=null && !slot.isBlock()) {
+                    // We allow duplicate actions from a block, because we can create multiple sections
+                    addProblem("Actions for labware %s contain duplicate action: %s", lwErrorDesc(lw), key);
+                }
             }
         }
     }
@@ -220,7 +233,7 @@ public class PlanValidationImp implements PlanValidation {
         addProblem(String.format(format, args));
     }
 
-    private static class ActionKey {
+    static class ActionKey {
         String sourceBarcode;
         Address sourceAddress;
         int sampleId;

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -651,11 +651,12 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <createIndex tableName="plan_action" indexName="uk_plan_action_plan_sample_slots" unique="true">
+        <createIndex tableName="plan_action" indexName="uk_plan_action_plan_sample_slots_section" unique="true">
             <column name="plan_operation_id"/>
             <column name="sample_id"/>
             <column name="source_slot_id"/>
             <column name="dest_slot_id"/>
+            <column name="new_section"/>
         </createIndex>
         <rollback>
             <dropAllForeignKeyConstraints baseTableName="plan_action"/>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -205,11 +205,17 @@ input AddressCommentInput {
     commentId: Int!,
 }
 
+input CancelPlanAction {
+    destinationAddress: Address!
+    sampleId: Int!
+    newSection: Int
+}
+
 input ConfirmOperationLabware {
-    barcode: String!,
-    cancelled: Boolean,
-    cancelledAddresses: [Address!],
-    addressComments: [AddressCommentInput!],
+    barcode: String!
+    cancelled: Boolean
+    cancelledActions: [CancelPlanAction!]
+    addressComments: [AddressCommentInput!]
 }
 
 input ConfirmOperationRequest {

--- a/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
@@ -109,7 +109,7 @@ public class IntegrationTests {
         Sample sample = entityCreator.createSample(entityCreator.createTissue(entityCreator.createDonor("DONOR1"), "TISSUE1"), null);
         Labware sourceBlock = entityCreator.createBlock("STAN-B70C", sample);
         String mutation = tester.readResource("graphql/plan.graphql");
-        mutation = mutation.replace("$sampleId", String.valueOf(sample.getId()));
+        mutation = mutation.replace("55555", String.valueOf(sample.getId()));
         Map<String, ?> result = tester.post(mutation);
         assertNull(result.get("errors"));
         Object resultPlan = chainGet(result, "data", "plan");
@@ -122,7 +122,7 @@ public class IntegrationTests {
         assertEquals(resultOps.size(), 1);
         assertEquals("Section", chainGet(resultOps, 0, "operationType", "name"));
         List<?> resultActions = chainGet(resultOps, 0, "planActions");
-        assertEquals(1, resultActions.size());
+        assertEquals(2, resultActions.size());
         Map<String, ?> resultAction = chainGet(resultActions, 0);
         assertEquals("A1", chainGet(resultAction, "source", "address"));
         assertEquals(sourceBlock.getId(), chainGet(resultAction, "source", "labwareId"));
@@ -143,7 +143,10 @@ public class IntegrationTests {
         List<?> slots = chainGet(resultLabware, 0, "slots");
         assertEquals(1, slots.size());
         assertEquals((Integer) 1, chainGet(slots, 0, "samples", 0, "section"));
+        assertThat(chainGetList(slots, 0, "samples")).hasSize(2);
         assertNotNull(chainGet(slots, 0, "samples", 0, "id"));
+        assertEquals((Integer) 1, chainGet(slots, 0, "samples", 0, "section"));
+        assertEquals((Integer) 2, chainGet(slots, 0, "samples", 1, "section"));
 
         resultOps = chainGet(resultConfirm, "operations");
         assertEquals(resultOps.size(), 1);
@@ -151,9 +154,12 @@ public class IntegrationTests {
         assertNotNull(chainGet(resultOp, "performed"));
         assertEquals("Section", chainGet(resultOp, "operationType", "name"));
         List<?> actions = chainGet(resultOp, "actions");
-        assertEquals(1, actions.size());
+        assertEquals(2, actions.size());
         Object action = actions.get(0);
         assertEquals((Integer) 1, chainGet(action, "sample", "section"));
+        assertEquals("A1", chainGet(action, "destination", "address").toString());
+        action = actions.get(1);
+        assertEquals((Integer) 2, chainGet(action, "sample", "section"));
         assertEquals("A1", chainGet(action, "destination", "address").toString());
     }
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmOperationService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmOperationService.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
-import org.mockito.ArgumentCaptor;
 import uk.ac.sanger.sccp.stan.EntityFactory;
 import uk.ac.sanger.sccp.stan.Matchers;
 import uk.ac.sanger.sccp.stan.model.*;
@@ -165,110 +164,143 @@ public class TestConfirmOperationService {
         assertThat(service.loadPlans(labware)).isEqualTo(Map.of(labware.get(0).getId(), plans.get(0), labware.get(1).getId(), plans.get(1)));
     }
 
+    /** @see ConfirmOperationServiceImp#performConfirmation */
     @ParameterizedTest
-    @MethodSource("performConfirmationArguments")
-    public void testPerformConfirmation(ConfirmOperationLabware col, OperationType opType, LabwareType lt,
-                                        List<Address> planDestAddresses, Integer[] planThicknesses,
-                                        boolean expectDiscard, Set<Address> expectedActionAddresses,
-                                        Map<Address, Integer> expectedThicknesses) {
-        User user = EntityFactory.getUser();
-        Labware lw = EntityFactory.makeEmptyLabware(lt);
-        lw.setBarcode(col.getBarcode());
-        Labware source = EntityFactory.makeLabware(EntityFactory.getTubeType(), EntityFactory.getSample());
-        List<Slot> sourceSlots = List.of(source.getFirstSlot());
-        List<Slot> destSlots = planDestAddresses.stream()
-                .map(lw::getSlot)
-                .collect(toList());
-        PlanOperation plan = EntityFactory.makePlanForSlots(opType, sourceSlots, destSlots, user);
-        if (planThicknesses!=null) {
-            for (int i = 0; i < planThicknesses.length; ++i) {
-                plan.getPlanActions().get(i).setSampleThickness(planThicknesses[i]);
-            }
-        }
-        Operation op = (expectDiscard ? null : EntityFactory.makeOpForSlots(opType, sourceSlots, destSlots, user));
-        when(mockSlotRepo.save(any())).then(Matchers.returnArgument());
+    @MethodSource("performConfirmationArgs")
+    public void testPerformConfirmation(ConfirmOperationLabware col, OperationType opType, Labware labware,
+                                        List<PlanAction> planActions, List<Action> expectedActions,
+                                        List<Measurement> expectedMeasurements,
+                                        Map<Slot, List<Sample>> expectedContents,
+                                        List<Sample> sections) {
         when(mockLabwareRepo.save(any())).then(Matchers.returnArgument());
-        when(mockOperationService.createOperation(any(), any(), anyList(), any())).thenReturn(op);
+        final boolean expectDiscard = (expectedActions==null || expectedActions.isEmpty());
+        final User user = EntityFactory.getUser();
+        final int planId = planActions.get(0).getPlanOperationId();
+        final PlanOperation plan = new PlanOperation(planId, opType, null, planActions, user);
 
-        ConfirmLabwareResult result = service.performConfirmation(col, lw, plan, user);
-        assertEquals(result.labware, lw);
-        assertEquals(expectDiscard, lw.isDiscarded());
-        if (expectedActionAddresses==null || expectedActionAddresses.isEmpty()) {
-            assertNull(result.operation);
-            verifyNoInteractions(mockOperationService);
-            verify(mockLabwareRepo).save(lw);
-            verifyNoInteractions(mockMeasurementRepo);
+        Operation op;
+        if (!expectDiscard) {
+            when(mockSlotRepo.save(any())).then(Matchers.returnArgument());
+            op = new Operation(99, opType, null, null, user);
+            when(mockOperationService.createOperation(any(), any(), any(), any())).thenReturn(op);
+            doAnswer(invocation -> {
+                PlanAction pa = invocation.getArgument(0);
+                int section = pa.getNewSection();
+                return sections.stream().filter(sec -> sec.getSection()==section)
+                        .findAny()
+                        .orElseThrow();
+            }).when(service).getOrCreateSample(any(), any());
         } else {
-            ConfirmLabwareResult expectedResult = new ConfirmLabwareResult(op, lw);
-            assertEquals(expectedResult.hashCode(), result.hashCode());
-            assertEquals(expectedResult, result);
-            assert op != null;
-            assertSame(op, result.operation);
-            @SuppressWarnings("unchecked")
-            ArgumentCaptor<List<Action>> actionsCaptor = ArgumentCaptor.forClass(List.class);
-            verify(mockOperationService).createOperation(eq(plan.getOperationType()), eq(user), actionsCaptor.capture(), eq(plan.getId()));
-            List<Action> actions = actionsCaptor.getValue();
-            List<Slot> expectedDestinations = expectedActionAddresses.stream()
-                    .map(lw::getSlot)
-                    .collect(toList());
-            assertThat(actions.stream().map(Action::getDestination)).hasSameElementsAs(expectedDestinations);
-            verify(mockEntityManager).refresh(lw);
-            expectedDestinations.forEach(destSlot -> verify(mockSlotRepo).save(destSlot));
-            if (expectedThicknesses!=null && !expectedThicknesses.isEmpty()) {
-                List<Measurement> expectedMeasurements = expectedThicknesses.entrySet().stream()
-                        .filter(e -> e.getValue()!=null)
-                        .map(e -> {
-                            Action action = actions.stream().filter(a -> a.getDestination().getAddress().equals(e.getKey()))
-                                    .findAny()
-                                    .orElseThrow();
-                            return new Measurement(null, "Thickness", e.getValue().toString(),
-                                    action.getSample().getId(), op.getId(), action.getDestination().getId());
-                        })
-                        .collect(toList());
-                verify(mockMeasurementRepo).saveAll(Matchers.sameElements(expectedMeasurements));
-            } else {
-                verifyNoInteractions(mockMeasurementRepo);
-            }
+            op = null;
         }
+
+        ConfirmLabwareResult result = service.performConfirmation(col, labware, plan, user);
+
+        if (expectDiscard) {
+            assertEquals(new ConfirmLabwareResult(null, labware), result);
+            assertTrue(labware.isDiscarded());
+            verify(mockLabwareRepo).save(labware);
+            verifyNoInteractions(mockSlotRepo);
+            verifyNoInteractions(mockOperationService);
+            verifyNoInteractions(mockMeasurementRepo);
+            return;
+        }
+        assertSame(op, result.operation);
+        assertEquals(labware, result.labware);
+        assertFalse(labware.isDiscarded());
+        verify(mockOperationService).createOperation(opType, user, expectedActions, planId);
+        if (expectedMeasurements!=null && !expectedMeasurements.isEmpty()) {
+            verify(mockMeasurementRepo).saveAll(Matchers.sameElements(expectedMeasurements));
+        } else {
+            verifyNoInteractions(mockMeasurementRepo);
+        }
+        verify(mockSlotRepo).saveAll(expectedContents.keySet());
+        for (var entry : expectedContents.entrySet()) {
+            assertThat(labware.getSlot(entry.getKey().getAddress()).getSamples()).containsExactlyInAnyOrderElementsOf(entry.getValue());
+        }
+        verify(mockEntityManager).refresh(labware);
     }
 
-    static Stream<Arguments> performConfirmationArguments() {
+    /** @see #testPerformConfirmation */
+    static Stream<Arguments> performConfirmationArgs() {
         OperationType opType = EntityFactory.makeOperationType("Section", null);
-        LabwareType lt = EntityFactory.makeLabwareType(2,2);
-        String bc = "STAN-DST";
-        List<Address> planDestAddresses = List.of(
-                new Address(1,1), new Address(1,2), new Address(2,1)
-        );
-
-        List<ConfirmOperationLabware> cols = List.of(
-                new ConfirmOperationLabware(bc),
-                new ConfirmOperationLabware(bc, true, null, null),
-                new ConfirmOperationLabware(bc, false, List.of(new Address(1,1), new Address(1,2), new Address(2,1)), null),
-                new ConfirmOperationLabware(bc, false, List.of(new Address(2,1)), null)
-        );
-        boolean[] expectLabwareDiscarded = {false, true, true, false};
-        Integer[][] planThicknesses = {
-                {100, null, 150},
-                {100, null, 150},
+        final LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Sample sample = new Sample(50, null, EntityFactory.getTissue(), EntityFactory.getBioState());
+        Sample[] sections = {
                 null,
-                {100, null, 150},
+                new Sample(51, 1, sample.getTissue(), sample.getBioState()),
+                new Sample(52, 2, sample.getTissue(), sample.getBioState()),
+                new Sample(53, 3, sample.getTissue(), sample.getBioState()),
         };
-        List<Set<Address>> expectedActionAddresses = Arrays.asList(
-                Set.of(new Address(1, 1), new Address(1, 2), new Address(2, 1)),
+        Labware source = EntityFactory.makeLabware(EntityFactory.getTubeType(), sample);
+        final Slot srcSlot = source.getFirstSlot();
+        Labware[] dests = IntStream.range(0, 4).mapToObj(i -> EntityFactory.makeEmptyLabware(lt)).toArray(Labware[]::new);
+
+        final Address A1 = new Address(1,1);
+        final Address A2 = new Address(1,2);
+
+        ConfirmOperationLabware[] cols = {
+                new ConfirmOperationLabware(dests[0].getBarcode()),
+                new ConfirmOperationLabware(dests[1].getBarcode(), true, null, null),
+                new ConfirmOperationLabware(dests[2].getBarcode(), false,
+                        List.of(new CancelPlanAction(A1, sample.getId(), 2), new CancelPlanAction(A2, sample.getId(), 3)),
+                        null
+                ),
+                new ConfirmOperationLabware(dests[3].getBarcode(), false,
+                        List.of(new CancelPlanAction(A1, sample.getId(), 1),
+                                new CancelPlanAction(A1, sample.getId(), 2),
+                                new CancelPlanAction(A2, sample.getId(), 3)),
+                        null
+                )
+        };
+        Slot otherSlot = EntityFactory.makeEmptyLabware(lt).getFirstSlot();
+
+        List<?>[] planActions = Arrays.stream(dests)
+                .map(dest -> List.of(
+                        new PlanAction(20, 10, srcSlot, dest.getSlot(A1), sample, 1, 4, null),
+                        new PlanAction(21, 10, srcSlot, dest.getSlot(A1), sample, 2, null, null),
+                        new PlanAction(22, 10, srcSlot, dest.getSlot(A2), sample, 3, 7, null),
+                        new PlanAction(23, 10, srcSlot, otherSlot, sample, 4, null, null)
+                ))
+                .toArray(List[]::new);
+
+        List<?>[] expectedActions = {
+                List.of(new Action(null, null, srcSlot, dests[0].getSlot(A1), sections[1], sample),
+                        new Action(null, null, srcSlot, dests[0].getSlot(A1), sections[2], sample),
+                        new Action(null, null, srcSlot, dests[0].getSlot(A2), sections[3], sample)),
                 null,
+                List.of(new Action(null, null, srcSlot, dests[2].getSlot(A1), sections[1], sample)),
                 null,
-                Set.of(new Address(1, 1), new Address(1, 2))
+        };
+
+        List<?>[] expectedMeasurements = {
+                List.of(
+                        new Measurement(null, "Thickness", "4", sections[1].getId(), 99, dests[0].getSlot(A1).getId()),
+                        new Measurement(null, "Thickness", "7", sections[3].getId(), 99, dests[0].getSlot(A2).getId())
+                ),
+                null,
+                List.of(
+                        new Measurement(null, "Thickness", "4", sections[1].getId(), 99, dests[2].getSlot(A1).getId())
+                ),
+                null,
+        };
+
+        Map<?,?>[] expectedContents = {
+                Map.of(dests[0].getSlot(A1), List.of(sections[1], sections[2]), dests[0].getSlot(A2), List.of(sections[3])),
+                null,
+                Map.of(dests[2].getSlot(A1), List.of(sections[1])),
+                null,
+        };
+        List<Sample> sectionList = Arrays.asList(sections).subList(1, 4);
+
+        return IntStream.range(0, cols.length).mapToObj(i ->
+            Arguments.of(cols[i], opType, dests[i], planActions[i], expectedActions[i],
+                    expectedMeasurements[i], expectedContents[i], sectionList)
         );
-        List<Map<Address, Integer>> expectedThicknesses = Arrays.asList(
-                Map.of(new Address(1,1), 100, new Address(2,1), 150),
-                null,
-                null,
-                Map.of(new Address(1,1), 100)
-        );
-        return IntStream.range(0, cols.size()).mapToObj(
-                i -> Arguments.of(cols.get(i), opType, lt, planDestAddresses, planThicknesses[i],
-                        expectLabwareDiscarded[i], expectedActionAddresses.get(i), expectedThicknesses.get(i))
-        );
+        // nothing cancelled
+        // lw cancelled
+        // some actions cancelled
+        // all actions cancelled
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmOperationValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmOperationValidation.java
@@ -8,9 +8,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.ac.sanger.sccp.stan.EntityFactory;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
-import uk.ac.sanger.sccp.stan.request.confirm.ConfirmOperationLabware;
+import uk.ac.sanger.sccp.stan.request.confirm.*;
 import uk.ac.sanger.sccp.stan.request.confirm.ConfirmOperationLabware.AddressCommentId;
-import uk.ac.sanger.sccp.stan.request.confirm.ConfirmOperationRequest;
 
 import java.util.*;
 import java.util.stream.IntStream;
@@ -185,15 +184,56 @@ public class TestConfirmOperationValidation {
 
         ConfirmOperationValidationImp validation = makeValidation(request);
 
-        doNothing().when(validation).validateAddresses(any(), any(), any());
+        doNothing().when(validation).validateCancelledActions(any(), any(), any());
+        doNothing().when(validation).validateCommentAddresses(any(), any(), any());
 
         validation.validateOperations(bcMap(labware), planMap);
 
-        verify(validation).validateAddresses(request.getLabware().get(0), labware.get(0), plan);
+        verify(validation).validateCancelledActions(request.getLabware().get(0).getCancelledActions(), labware.get(0), plan);
+        verify(validation).validateCommentAddresses(request.getLabware().get(0).getAddressComments(), labware.get(0), plan);
     }
 
     @Test
-    public void testValidateAddresses() {
+    public void testValidateCancelledActions() {
+        final Address A1 = new Address(1,1);
+        final Address A2 = new Address(1, 2);
+        final Address B1 = new Address(2, 1);
+        LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Labware lw = EntityFactory.makeEmptyLabware(lt);
+        String bc = lw.getBarcode();
+        Labware otherLabware = EntityFactory.makeEmptyLabware(lt);
+        final Sample sample = EntityFactory.getSample();
+        Labware source = EntityFactory.makeLabware(EntityFactory.getTubeType(), sample);
+        Slot srcSlot = source.getFirstSlot();
+        OperationType opType = EntityFactory.makeOperationType("Section", null);
+        int planId = 200;
+        List<PlanAction> planActions = List.of(
+                new PlanAction(201, planId, srcSlot, lw.getFirstSlot(), sample, 1, null, null),
+                new PlanAction(202, planId, srcSlot, lw.getFirstSlot(), sample, 2, null, null),
+                new PlanAction(203, planId, srcSlot, otherLabware.getSlot(A2), sample, 1, null, null)
+        );
+        PlanOperation plan = new PlanOperation(planId, opType, null, planActions, EntityFactory.getUser());
+        final Integer sampleId = sample.getId();
+        List<CancelPlanAction> cpas = List.of(
+                new CancelPlanAction(A1, sampleId, 1),
+                new CancelPlanAction(A2, sampleId, 1),
+                new CancelPlanAction(B1, sampleId, 1),
+                new CancelPlanAction(null, null, null)
+        );
+
+        ConfirmOperationValidationImp validation = makeValidation();
+        validation.validateCancelledActions(cpas, lw, plan);
+        assertThat(validation.getProblems()).containsExactlyInAnyOrder(
+                String.format("Cancelled plan action does not match any action in the plan: (barcode=%s, address=A2, sampleId=%s, newSection=1)",
+                        bc, sampleId),
+                String.format("Invalid address B1 in cancelled plan action for labware %s.", bc),
+                "No address specified in cancelled plan action.",
+                "No sample id specified in cancelled plan action."
+        );
+    }
+
+    @Test
+    public void testValidateCommentAddresses() {
         LabwareType lt = EntityFactory.makeLabwareType(1, 2);
         Labware lw = EntityFactory.makeEmptyLabware(lt);
         String bc = lw.getBarcode();
@@ -203,23 +243,17 @@ public class TestConfirmOperationValidation {
         PlanOperation plan = EntityFactory.makePlanForSlots(opType, List.of(source.getFirstSlot()),
                 List.of(lw.getFirstSlot(), otherLabware.getFirstSlot(), otherLabware.getSlots().get(1)),
                 null);
-        List<Address> cancelledAddresses = List.of(new Address(1,1), new Address(1,2),
-                new Address(2,1));
         List<AddressCommentId> addressCommentIds = List.of(
                 new AddressCommentId(new Address(1,1), 1),
                 new AddressCommentId(new Address(1,2), 2),
                 new AddressCommentId(new Address(2,3), 3),
                 new AddressCommentId(null, 4)
         );
-        ConfirmOperationLabware col = new ConfirmOperationLabware(lw.getBarcode(), false, cancelledAddresses,
-                addressCommentIds);
 
         ConfirmOperationValidationImp validation = makeValidation();
-        validation.validateAddresses(col, lw, plan);
+        validation.validateCommentAddresses(addressCommentIds, lw, plan);
 
         assertThat(validation.getProblems()).containsOnly(
-                "Invalid address B1 in cancelled addresses for labware "+bc+".",
-                "No planned action recorded for address A2 in labware "+bc+", specified as cancelled.",
                 "Comment specified with no address for labware "+bc+".",
                 "Invalid address B3 in comments for labware "+bc+".",
                 "No planned action recorded for address A2 in labware "+bc+", specified in comments."

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidation.java
@@ -10,13 +10,16 @@ import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.plan.*;
 import uk.ac.sanger.sccp.stan.service.Validator;
+import uk.ac.sanger.sccp.stan.service.operation.plan.PlanValidationImp.ActionKey;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -53,14 +56,15 @@ public class TestPlanValidation {
         PlanValidationImp validation = makeValidation(request);
         final OperationType opType = new OperationType(1, "Stir fry");
         doReturn(opType).when(validation).validateOperation();
-        doNothing().when(validation).validateSources(any());
-        doNothing().when(validation).validateDestinations();
+        Map<ActionKey, Slot> actionKeySlotMap = Map.of();
+        doReturn(actionKeySlotMap).when(validation).validateSources(any());
+        doNothing().when(validation).validateDestinations(any());
 
         assertSame(validation.validate(), validation.problems);
 
         verify(validation).validateOperation();
         verify(validation).validateSources(opType);
-        verify(validation).validateDestinations();
+        verify(validation).validateDestinations(actionKeySlotMap);
     }
 
     @Test
@@ -136,12 +140,12 @@ public class TestPlanValidation {
 
     @ParameterizedTest
     @MethodSource("actionsData")
-    public void testCheckActions(String barcode, Object planRequestActions, LabwareType labwareType, Object expectedProblems) {
-        PlanRequestLabware prlw = new PlanRequestLabware(labwareType==null ? null : labwareType.getName(), barcode,
-                objToList(planRequestActions));
+    public void testCheckActions(String barcode, boolean isBlock, Object planRequestActions, LabwareType labwareType, Object expectedProblems) {
+        final List<PlanRequestAction> placs = objToList(planRequestActions);
+        PlanRequestLabware prlw = new PlanRequestLabware(labwareType==null ? null : labwareType.getName(), barcode, placs);
 
         PlanValidationImp validation = makeValidation(new PlanRequest());
-        validation.checkActions(prlw, labwareType);
+        validation.checkActions(prlw, labwareType, makeActionSources(placs, isBlock));
 
         assertProblems(expectedProblems, validation.problems);
     }
@@ -153,7 +157,7 @@ public class TestPlanValidation {
         PlanRequest request = new PlanRequest("opType", objToList(planRequestLabware));
 
         PlanValidationImp validation = makeValidation(request);
-        doNothing().when(validation).checkActions(any(), any());
+        doNothing().when(validation).checkActions(any(), any(), any());
 
         when(mockLabwareTypeRepo.findByName(anyString())).thenReturn(Optional.empty());
         if (labwareTypes!=null && !labwareTypes.isEmpty()) {
@@ -176,12 +180,14 @@ public class TestPlanValidation {
             when(mockLabwareRepo.existsByBarcode(eqCi("extant"))).thenReturn(true);
         }
 
-        validation.validateDestinations();
+        Map<ActionKey, Slot> actionSources = Map.of();
+
+        validation.validateDestinations(actionSources);
 
         assertProblems(expectedProblems, validation.problems);
 
         if (expectedProblems==null) {
-            verify(validation, times(request.getLabware().size())).checkActions(any(), any());
+            verify(validation, times(request.getLabware().size())).checkActions(any(), any(), any());
             for (PlanRequestLabware prlw : request.getLabware()) {
                 if (prlw.getBarcode()!=null) {
                     verify(mockPrebarcodeValidator).validate(eqCi(prlw.getBarcode()), any());
@@ -249,6 +255,7 @@ public class TestPlanValidation {
         );
     }
 
+    /** @see #testCheckActions */
     static Stream<Arguments> actionsData() {
         LabwareType lt = EntityFactory.makeLabwareType(1,2);
         final Address FIRST = new Address(1,1);
@@ -257,38 +264,46 @@ public class TestPlanValidation {
         PlanRequestSource srcAlt = new PlanRequestSource("stan-100", FIRST);
         PlanRequestSource src2 = new PlanRequestSource("STAN-001", FIRST);
         PlanRequestSource src3 = new PlanRequestSource("STAN-000", SECOND);
+
         return Stream.of(
-                Arguments.of("STAN-100", List.of(new PlanRequestAction(FIRST, 4, src, null),
+                Arguments.of("STAN-100", true, List.of(new PlanRequestAction(FIRST, 4, src, null),
                         new PlanRequestAction(FIRST, 5, src, null),
                         new PlanRequestAction(SECOND, 4, src, null),
                         new PlanRequestAction(FIRST, 4, src2, null),
                         new PlanRequestAction(FIRST, 4, src3, null)),
                         lt, null),
-                Arguments.of(null, List.of(new PlanRequestAction(FIRST, 4, src, null),
+                Arguments.of(null, true, List.of(new PlanRequestAction(FIRST, 4, src, null),
                         new PlanRequestAction(FIRST, 5, src, null),
                         new PlanRequestAction(SECOND, 4, src, null),
                         new PlanRequestAction(FIRST, 4, src2, null),
                         new PlanRequestAction(FIRST, 4, src3, null)),
                         lt, null),
 
-                Arguments.of("STAN-100", List.of(), lt, "No actions specified for labware STAN-100."),
-                Arguments.of(null, List.of(), lt, "No actions specified for labware of type "+lt.getName()+"."),
-                Arguments.of(null, List.of(), null, "No actions specified for labware of unspecified type."),
-                Arguments.of("STAN-100", List.of(new PlanRequestAction(FIRST, 4, src, null),
+                Arguments.of("STAN-100", true, List.of(), lt, "No actions specified for labware STAN-100."),
+                Arguments.of(null, true, List.of(), lt, "No actions specified for labware of type "+lt.getName()+"."),
+                Arguments.of(null, true, List.of(), null, "No actions specified for labware of unspecified type."),
+                // Duplicate actions from a block source
+                Arguments.of("STAN-100", true, List.of(new PlanRequestAction(FIRST, 4, src, null),
+                        new PlanRequestAction(FIRST, 4, src, null),
+                        new PlanRequestAction(SECOND, 4, srcAlt, null)),
+                        lt, null), // no problem
+                //Duplicate actions from a non-block source
+                Arguments.of("STAN-100", false, List.of(new PlanRequestAction(FIRST, 4, src, null),
                         new PlanRequestAction(FIRST, 4, src, null),
                         new PlanRequestAction(SECOND, 4, srcAlt, null)),
                         lt, "Actions for labware STAN-100 contain duplicate action: (address=A1, sampleId=4, source={STAN-000, A1})"),
-                Arguments.of(null, List.of(new PlanRequestAction(FIRST, 4, src, null),
+                //Duplicate actions from a non-block source without a barcode
+                Arguments.of(null, false, List.of(new PlanRequestAction(FIRST, 4, src, null),
                         new PlanRequestAction(FIRST, 4, src, null),
                         new PlanRequestAction(SECOND, 4, src, null)),
                         lt, "Actions for labware of type "+lt.getName()+" contain duplicate action: (address=A1, sampleId=4, source={STAN-000, A1})"),
-                Arguments.of("STAN-100", new PlanRequestAction(null, 4, src, null), lt,
+                Arguments.of("STAN-100", true, new PlanRequestAction(null, 4, src, null), lt,
                         "Missing destination address."),
-                Arguments.of(null, new PlanRequestAction(null, 4, src, null), lt,
+                Arguments.of(null, true, new PlanRequestAction(null, 4, src, null), lt,
                         "Missing destination address."),
-                Arguments.of("STAN-100", new PlanRequestAction(new Address(2,4), 4, src, null), lt,
+                Arguments.of("STAN-100", true, new PlanRequestAction(new Address(2,4), 4, src, null), lt,
                         "Invalid address B4 given for labware type "+lt.getName()+"."),
-                Arguments.of(null, new PlanRequestAction(new Address(4,7), 4, src, null), lt,
+                Arguments.of(null, true, new PlanRequestAction(new Address(4,7), 4, src, null), lt,
                         "Invalid address D7 given for labware type "+lt.getName()+".")
         );
     }
@@ -341,6 +356,15 @@ public class TestPlanValidation {
             //noinspection unchecked
             assertThat(problems).hasSameElementsAs((Iterable<String>) expectedProblems);
         }
+    }
+
+    private Map<ActionKey, Slot> makeActionSources(Collection<PlanRequestAction> planRequestActions, boolean isBlock) {
+        final Slot mockSlot = mock(Slot.class);
+        when(mockSlot.isBlock()).thenReturn(isBlock);
+        return planRequestActions.stream()
+                .map(ActionKey::new)
+                .distinct()
+                .collect(toMap(Function.identity(), k -> mockSlot));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/resources/graphql/plan.graphql
+++ b/src/test/resources/graphql/plan.graphql
@@ -3,13 +3,18 @@ mutation {
         operationType: "Section",
         labware:[{
             labwareType:"Tube",
-            actions:[{
-                source:{
-                    barcode:"STAN-B70C",
-                },
-                address:"A1",
-                sampleId:$sampleId,
-            }],
+            actions:[
+                {
+                    source:{ barcode:"STAN-B70C" }
+                    address: "A1"
+                    sampleId: 55555
+                }
+                {
+                    source: { barcode: "STAN-B70C" }
+                    address: "A1"
+                    sampleId: 55555
+                }
+            ]
         }]
     }) {
         labware {


### PR DESCRIPTION
Refine plan validation to allow identical plan-actions in some circumstances.
If you're sectioning a block then each plan-action will create a new section of that block,
and creating two sections into the same destination is a valid request.
The db schema has been slightly changed to allow for more similar plan-actions.
