### PR TITLE
Allow space in donor names but check how it is used

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
@@ -1,0 +1,52 @@
+package uk.ac.sanger.sccp.stan.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.ac.sanger.sccp.stan.service.StringValidator;
+import uk.ac.sanger.sccp.stan.service.StringValidator.CharacterType;
+import uk.ac.sanger.sccp.stan.service.Validator;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Holder for the validators for certain fields
+ * @author dr6
+ */
+@Configuration
+public class FieldValidation {
+    @Bean
+    public Validator<String> donorNameValidator() {
+        Set<CharacterType> charTypes = EnumSet.of(
+                CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT,
+                CharacterType.HYPHEN, CharacterType.UNDERSCORE, CharacterType.SPACE
+        );
+        return new StringValidator("Donor identifier", 3, 64, charTypes);
+    }
+
+    @Bean
+    public Validator<String> visiumLPBarcodeValidator() {
+        Set<CharacterType> charTypes = EnumSet.of(CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT, CharacterType.HYPHEN);
+        Pattern pattern = Pattern.compile("[0-9]{7}[0-9A-Z]+-[0-9]+-[0-9]+-[0-9]+", Pattern.CASE_INSENSITIVE);
+        return new StringValidator("Visium LP barcode", 14, 32, charTypes, false, pattern);
+    }
+
+    @Bean
+    public Validator<String> externalNameValidator() {
+        Set<CharacterType> charTypes = EnumSet.of(
+                CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT, CharacterType.HYPHEN,
+                CharacterType.UNDERSCORE
+        ) ;
+        return new StringValidator("External identifier", 3, 64, charTypes);
+    }
+
+    @Bean
+    public Validator<String> externalBarcodeValidator() {
+        Set<CharacterType> charTypes = EnumSet.of(
+                CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT, CharacterType.HYPHEN,
+                CharacterType.UNDERSCORE
+        ) ;
+        return new StringValidator("External barcode", 3, 32, charTypes);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationFactory.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationFactory.java
@@ -1,16 +1,11 @@
 package uk.ac.sanger.sccp.stan.service.operation.plan;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.plan.PlanRequest;
-import uk.ac.sanger.sccp.stan.service.StringValidator;
-import uk.ac.sanger.sccp.stan.service.StringValidator.CharacterType;
 import uk.ac.sanger.sccp.stan.service.Validator;
-
-import java.util.EnumSet;
-import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * @author dr6
@@ -23,13 +18,12 @@ public class PlanValidationFactory {
     private final Validator<String> prebarcodeValidator;
 
     @Autowired
-    public PlanValidationFactory(LabwareRepo lwRepo, LabwareTypeRepo ltRepo, OperationTypeRepo opTypeRepo) {
+    public PlanValidationFactory(LabwareRepo lwRepo, LabwareTypeRepo ltRepo, OperationTypeRepo opTypeRepo,
+                                 @Qualifier("visiumLPBarcodeValidator") Validator<String> prebarcodeValidator) {
         this.lwRepo = lwRepo;
         this.ltRepo = ltRepo;
         this.opTypeRepo = opTypeRepo;
-        Set<CharacterType> charTypes = EnumSet.of(CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT, CharacterType.HYPHEN);
-        Pattern pattern = Pattern.compile("[0-9]{7}[0-9A-Z]+-[0-9]+-[0-9]+-[0-9]+", Pattern.CASE_INSENSITIVE);
-        this.prebarcodeValidator = new StringValidator("Barcode", 14, 32, charTypes, pattern);
+        this.prebarcodeValidator = prebarcodeValidator;
     }
 
     public PlanValidation createPlanValidation(PlanRequest request) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationFactory.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationFactory.java
@@ -1,17 +1,12 @@
 package uk.ac.sanger.sccp.stan.service.register;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.register.RegisterRequest;
 import uk.ac.sanger.sccp.stan.request.register.SectionRegisterRequest;
-import uk.ac.sanger.sccp.stan.service.StringValidator;
-import uk.ac.sanger.sccp.stan.service.StringValidator.CharacterType;
 import uk.ac.sanger.sccp.stan.service.Validator;
-
-import java.util.EnumSet;
-import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * Factory for {@link RegisterValidation}
@@ -40,7 +35,12 @@ public class RegisterValidationFactory {
     public RegisterValidationFactory(DonorRepo donorRepo, HmdmcRepo hmdmcRepo, TissueTypeRepo ttRepo,
                                      LabwareTypeRepo ltRepo, MouldSizeRepo mouldSizeRepo, MediumRepo mediumRepo,
                                      FixativeRepo fixativeRepo, TissueRepo tissueRepo, SpeciesRepo speciesRepo,
-                                     LabwareRepo labwareRepo, BioStateRepo bioStateRepo, TissueFieldChecker tissueFieldChecker) {
+                                     LabwareRepo labwareRepo, BioStateRepo bioStateRepo,
+                                     @Qualifier("donorNameValidator") Validator<String> donorNameValidation,
+                                     @Qualifier("externalNameValidator") Validator<String> externalNameValidation,
+                                     @Qualifier("externalBarcodeValidator") Validator<String> externalBarcodeValidation,
+                                     @Qualifier("visiumLPBarcodeValidator") Validator<String> visiumLpSlideBarcodeValidation,
+                                     TissueFieldChecker tissueFieldChecker) {
         this.donorRepo = donorRepo;
         this.hmdmcRepo = hmdmcRepo;
         this.ttRepo = ttRepo;
@@ -52,15 +52,11 @@ public class RegisterValidationFactory {
         this.speciesRepo = speciesRepo;
         this.labwareRepo = labwareRepo;
         this.bioStateRepo = bioStateRepo;
+        this.donorNameValidation = donorNameValidation;
+        this.externalNameValidation = externalNameValidation;
+        this.externalBarcodeValidation = externalBarcodeValidation;
+        this.visiumLpSlideBarcodeValidation = visiumLpSlideBarcodeValidation;
         this.tissueFieldChecker = tissueFieldChecker;
-        Set<CharacterType> charTypes = EnumSet.of(
-                CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT, CharacterType.HYPHEN, CharacterType.UNDERSCORE
-        ) ;
-        this.donorNameValidation = new StringValidator("Donor identifier", 3, 64, charTypes);
-        this.externalNameValidation = new StringValidator("External identifier", 3, 64, charTypes);
-        this.externalBarcodeValidation = new StringValidator("External barcode", 3, 32, charTypes);
-        Pattern pattern = Pattern.compile("[0-9]{7}[0-9A-Z]+-[0-9]+-[0-9]+-[0-9]+", Pattern.CASE_INSENSITIVE);
-        this.visiumLpSlideBarcodeValidation = new StringValidator("Visium LP barcode", 14, 32, charTypes, pattern);
     }
 
     public RegisterValidation createRegisterValidation(RegisterRequest request) {

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/StringValidatorTest.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/StringValidatorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.ac.sanger.sccp.stan.service.StringValidator.CharacterType;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,43 +21,70 @@ public class StringValidatorTest {
     @ParameterizedTest
     @MethodSource("validatorStrings")
     public void testStringValidator(String string, List<String> expectedProblems) {
-        List<String> problems = new ArrayList<>();
         StringValidator validator = new StringValidator("X", 3, 8,
                 CharacterType.UPPER, CharacterType.DIGIT);
-        final boolean ok = validator.validate(string, problems::add);
-        assertThat(problems).containsExactlyInAnyOrderElementsOf(expectedProblems);
-        assertEquals(expectedProblems.isEmpty(), ok);
+        testValidate(validator, string, expectedProblems);
     }
 
     static Stream<Arguments> validatorStrings() {
-        return Arrays.stream(new String[][]{
+        return argStream(new String[][]{
                 {"A", "X \"A\" is shorter than the minimum length 3."},
                 {"AAAAAAAAA", "X \"AAAAAAAAA\" is longer than the maximum length 8."},
                 {"abcabc", "X \"abcabc\" contains invalid characters \"abc\"."},
                 {"*", "X \"*\" is shorter than the minimum length 3.", "X \"*\" contains invalid characters \"*\"."},
-        }).map(arr -> Arguments.of(arr[0], Arrays.asList(arr).subList(1, arr.length)));
+        });
     }
 
     @ParameterizedTest
     @MethodSource("checkWhitespaceArgs")
     public void testCheckWhitespace(String string, List<String> expectedProblems) {
-        List<String> problems = new ArrayList<>();
         StringValidator validator = new StringValidator("X", 3, 16,
                 CharacterType.UPPER, CharacterType.LOWER, CharacterType.SPACE);
+        testValidate(validator, string, expectedProblems);
+    }
+
+    static Stream<Arguments> checkWhitespaceArgs() {
+        return argStream(new String[][] {
+                {"", "X \"\" is shorter than the minimum length 3."},
+                {"ABCD"},
+                {"AB C D"},
+                {"     ", "X \"     \" is all space."},
+                {" AB C", "X \" AB C\" has leading space."},
+                {"AB C  ", "X \"AB C  \" has trailing spaces."},
+                {"AB  C", "X \"AB  C\" contains consecutive spaces."},
+                {" A  B C  ", "X \" A  B C  \" has leading and trailing spaces.", "X \" A  B C  \" contains consecutive spaces."},
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("patternArgs")
+    public void testPattern(String string, List<String> expectedProblems) {
+        StringValidator validator = new StringValidator("X", 3, 8,
+                EnumSet.of(CharacterType.UPPER, CharacterType.LOWER, CharacterType.DIGIT, CharacterType.HYPHEN), false,
+                Pattern.compile("[A-Z]+-\\d+", Pattern.CASE_INSENSITIVE));
+        testValidate(validator, string, expectedProblems);
+    }
+
+    static Stream<Arguments> patternArgs() {
+        return argStream(new String[][] {
+                {"ABC-123"},
+                {"abc-123"},
+                {"ABC-@123", "X \"ABC-@123\" contains invalid characters \"@\"."},
+                {"Bananas", "X \"Bananas\" does not match the expected format."},
+                {"ABC-123A", "X \"ABC-123A\" does not match the expected format."},
+        });
+    }
+
+    private void testValidate(StringValidator validator, String string, List<String> expectedProblems) {
+        List<String> problems = new ArrayList<>();
         final boolean ok = validator.validate(string, problems::add);
         assertThat(problems).containsExactlyInAnyOrderElementsOf(expectedProblems);
         assertEquals(expectedProblems.isEmpty(), ok);
     }
 
-    static Stream<Arguments> checkWhitespaceArgs() {
-        return Arrays.stream(new String[][] {
-                {"ABCD"},
-                {"AB C D"},
-                {" AB C", "X \" AB C\" has leading space."},
-                {"AB C  ", "X \"AB C  \" has trailing spaces."},
-                {"AB  C", "X \"AB  C\" contains consecutive spaces."},
-                {" A  B C  ", "X \" A  B C  \" has leading and trailing spaces.", "X \" A  B C  \" contains consecutive spaces."},
-        }).map(arr -> Arguments.of(arr[0], Arrays.asList(arr).subList(1, arr.length)));
+    static Stream<Arguments> argStream(String[][] strings) {
+        return Arrays.stream(strings)
+                .map(arr -> Arguments.of(arr[0], Arrays.asList(arr).subList(1, arr.length)));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidationFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidationFactory.java
@@ -3,6 +3,7 @@ package uk.ac.sanger.sccp.stan.service.operation.plan;
 import org.junit.jupiter.api.Test;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.plan.PlanRequest;
+import uk.ac.sanger.sccp.stan.service.Validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,7 +20,9 @@ public class TestPlanValidationFactory {
         LabwareRepo lwRepo = mock(LabwareRepo.class);
         LabwareTypeRepo ltRepo = mock(LabwareTypeRepo.class);
         OperationTypeRepo opTypeRepo = mock(OperationTypeRepo.class);
-        PlanValidationFactory factory = new PlanValidationFactory(lwRepo, ltRepo, opTypeRepo);
+        //noinspection unchecked
+        Validator<String> mockStringValidator = mock(Validator.class);
+        PlanValidationFactory factory = new PlanValidationFactory(lwRepo, ltRepo, opTypeRepo, mockStringValidator);
         PlanRequest request = new PlanRequest();
         PlanValidation validation = factory.createPlanValidation(request);
         assertThat(validation).isInstanceOf(PlanValidationImp.class);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidationFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidationFactory.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.register.RegisterRequest;
 import uk.ac.sanger.sccp.stan.request.register.SectionRegisterRequest;
+import uk.ac.sanger.sccp.stan.service.Validator;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -17,11 +18,14 @@ public class TestRegisterValidationFactory {
     RegisterValidationFactory registerValidationFactory;
     @BeforeEach
     void setup() {
+        //noinspection unchecked
+        Validator<String> mockStringValidator = mock(Validator.class);
         registerValidationFactory = new RegisterValidationFactory(
                 mock(DonorRepo.class), mock(HmdmcRepo.class), mock(TissueTypeRepo.class),
                 mock(LabwareTypeRepo.class), mock(MouldSizeRepo.class), mock(MediumRepo.class),
                 mock(FixativeRepo.class), mock(TissueRepo.class), mock(SpeciesRepo.class), mock(LabwareRepo.class),
-                mock(BioStateRepo.class), mock(TissueFieldChecker.class));
+                mock(BioStateRepo.class), mockStringValidator, mockStringValidator, mockStringValidator, mockStringValidator,
+                mock(TissueFieldChecker.class));
     }
 
     @Test


### PR DESCRIPTION
StringValidator has new logic checking that the string
doesn't contain leading or trailing whitespace or consecutive
runs of whitespace.
The various string field validators are now beans. They are
supplied in a new config class called FieldValidation,
and are autowired in by name.
