### PR TITLE
x709 new labware fields exposed via graphql

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Labware.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Labware.java
@@ -17,6 +17,11 @@ import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
  */
 @Entity
 public class Labware {
+
+    public enum State {
+        empty, active, discarded, released, destroyed
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -177,5 +182,14 @@ public class Labware {
     @JsonIgnore
     public boolean isEmpty() {
         return this.slots.stream().allMatch(slot -> slot.getSamples().isEmpty());
+    }
+
+    @JsonIgnore
+    public Labware.State getState() {
+        if (isDestroyed()) return State.destroyed;
+        if (isReleased()) return State.released;
+        if (isDiscarded()) return State.discarded;
+        if (isEmpty()) return State.empty;
+        return State.active;
     }
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -7,6 +7,14 @@ enum UserRole {
     admin
 }
 
+enum LabwareState {
+    empty
+    active
+    discarded
+    released
+    destroyed
+}
+
 type User {
     username: String!
     role: UserRole!
@@ -105,6 +113,8 @@ type Labware {
     released: Boolean!
     destroyed: Boolean!
     discarded: Boolean!
+    state: LabwareState!
+    created: Timestamp!
 }
 
 enum LifeStage {

--- a/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
@@ -28,6 +28,7 @@ import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -865,6 +866,27 @@ public class IntegrationTests {
         assertEquals(userMap, chainGet(result, "data", "setUserRole"));
         result = tester.post(userQuery);
         assertThat(chainGetList(result, "data", "users")).contains(userMap);
+    }
+
+    @Test
+    @Transactional
+    public void testLabwareQuery() throws Exception {
+        LabwareType lt = entityCreator.createLabwareType("pair", 2, 1);
+        Sample sample = entityCreator.createSample(entityCreator.createTissue(entityCreator.createDonor("DNR1"), "EXT1"),
+                25);
+        Labware lw = entityCreator.createLabware("STAN-100", lt, sample);
+
+        String query = tester.readResource("graphql/labware.graphql").replace("BARCODE", lw.getBarcode());
+        Object result = tester.post(query);
+        Map<String, ?> lwData = chainGet(result, "data", "labware");
+        assertEquals("active", lwData.get("state"));
+        assertEquals(lw.getCreated().format(DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss")), lwData.get("created"));
+        assertEquals(lt.getName(), chainGet(lwData, "labwareType", "name"));
+        List<Map<String, ?>> slotsData = chainGetList(lwData, "slots");
+        assertEquals(2, slotsData.size());
+        Map<String, ?> firstSlotData = slotsData.get(0);
+        assertEquals("A1", firstSlotData.get("address"));
+        assertEquals(1, chainGetList(firstSlotData, "samples").size());
     }
 
     private void stubStorelightUnstore() throws IOException {

--- a/src/test/java/uk/ac/sanger/sccp/stan/model/TestLabware.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/model/TestLabware.java
@@ -1,0 +1,29 @@
+package uk.ac.sanger.sccp.stan.model;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests {@link Labware}
+ * @author dr6
+ */
+public class TestLabware {
+    @Test
+    public void testLabwareState() {
+        Labware lw = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType());
+        assertEquals(Labware.State.empty, lw.getState());
+        lw.getFirstSlot().getSamples().add(EntityFactory.getSample());
+        assertEquals(Labware.State.active, lw.getState());
+        lw.setDiscarded(true);
+        assertEquals(Labware.State.discarded, lw.getState());
+        lw.setReleased(true);
+        assertEquals(Labware.State.released, lw.getState());
+        lw.setReleased(false);
+        lw.setDestroyed(true);
+        assertEquals(Labware.State.destroyed, lw.getState());
+        lw.getFirstSlot().getSamples().clear();
+        assertEquals(Labware.State.destroyed, lw.getState());
+    }
+}

--- a/src/test/resources/graphql/labware.graphql
+++ b/src/test/resources/graphql/labware.graphql
@@ -1,0 +1,11 @@
+query {
+    labware(barcode:"BARCODE") {
+        state
+        created
+        labwareType { name }
+        slots {
+            address
+            samples { id }
+        }
+    }
+}


### PR DESCRIPTION
Add labware created timestamp to schema.
Add derived field Labware.State (an enum).
