### PR TITLE
x558: support a query to get the history of samples

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 import uk.ac.sanger.sccp.stan.config.SessionConfig;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
-import uk.ac.sanger.sccp.stan.request.FindRequest;
-import uk.ac.sanger.sccp.stan.request.FindResult;
+import uk.ac.sanger.sccp.stan.request.*;
 import uk.ac.sanger.sccp.stan.service.CommentAdminService;
 import uk.ac.sanger.sccp.stan.service.FindService;
+import uk.ac.sanger.sccp.stan.service.history.HistoryService;
 import uk.ac.sanger.sccp.stan.service.label.print.LabelPrintService;
 
 import javax.persistence.EntityNotFoundException;
@@ -43,6 +43,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final LabelPrintService labelPrintService;
     final FindService findService;
     final CommentAdminService commentAdminService;
+    final HistoryService historyService;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, UserRepo userRepo,
@@ -52,7 +53,8 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                SpeciesRepo speciesRepo, HmdmcRepo hmdmcRepo, LabwareRepo labwareRepo, CommentRepo commentRepo,
                                ReleaseDestinationRepo releaseDestinationRepo, ReleaseRecipientRepo releaseRecipientRepo,
                                DestructionReasonRepo destructionReasonRepo,
-                               LabelPrintService labelPrintService, FindService findService, CommentAdminService commentAdminService) {
+                               LabelPrintService labelPrintService, FindService findService,
+                               CommentAdminService commentAdminService, HistoryService historyService) {
         super(objectMapper, authComp, userRepo);
         this.sessionConfig = sessionConfig;
         this.tissueTypeRepo = tissueTypeRepo;
@@ -70,6 +72,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.labelPrintService = labelPrintService;
         this.findService = findService;
         this.commentAdminService = commentAdminService;
+        this.historyService = historyService;
     }
 
     public DataFetcher<User> getUser() {
@@ -159,6 +162,34 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         return dfe -> {
             FindRequest request = arg(dfe, "request", FindRequest.class);
             return findService.find(request);
+        };
+    }
+
+    public DataFetcher<History> historyForSampleId() {
+        return dfe -> {
+            int sampleId = dfe.getArgument("sampleId");
+            return historyService.getHistoryForSampleId(sampleId);
+        };
+    }
+
+    public DataFetcher<History> historyForExternalName() {
+        return dfe -> {
+            String externalName = dfe.getArgument("externalName");
+            return historyService.getHistoryForExternalName(externalName);
+        };
+    }
+
+    public DataFetcher<History> historyForDonorName() {
+        return dfe -> {
+            String donorName = dfe.getArgument("donorName");
+            return historyService.getHistoryForDonorName(donorName);
+        };
+    }
+
+    public DataFetcher<History> historyForLabwareBarcode() {
+        return dfe -> {
+            String barcode = dfe.getArgument("barcode");
+            return historyService.getHistoryForLabwareBarcode(barcode);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -80,6 +80,11 @@ public class GraphQLProvider {
                         .dataFetcher("destructionReasons", graphQLDataFetchers.getDestructionReasons())
                         .dataFetcher("users", graphQLDataFetchers.getUsers())
 
+                        .dataFetcher("historyForSampleId", graphQLDataFetchers.historyForSampleId())
+                        .dataFetcher("historyForExternalName", graphQLDataFetchers.historyForExternalName())
+                        .dataFetcher("historyForDonorName", graphQLDataFetchers.historyForDonorName())
+                        .dataFetcher("historyForLabwareBarcode", graphQLDataFetchers.historyForLabwareBarcode())
+
                         .dataFetcher("location", graphQLStore.getLocation())
                         .dataFetcher("stored", graphQLStore.getStored())
                 )

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationCommentRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationCommentRepo.java
@@ -3,5 +3,9 @@ package uk.ac.sanger.sccp.stan.repo;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.OperationComment;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface OperationCommentRepo extends CrudRepository<OperationComment, Integer> {
+    List<OperationComment> findAllByOperationIdIn(Collection<Integer> operationIds);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationRepo.java
@@ -12,4 +12,7 @@ public interface OperationRepo extends CrudRepository<Operation, Integer> {
     @Query("select distinct op from Operation op join Action a on (a.operationId=op.id) " +
             "where op.operationType=?1 and a.sample.id in (?2)")
     List<Operation> findAllByOperationTypeAndSampleIdIn(OperationType opType, Collection<Integer> sampleIds);
+
+    @Query("select distinct op from Operation op join Action a ON (a.operationId=op.id) where a.sample.id IN (?1)")
+    List<Operation> findAllBySampleIdIn(Collection<Integer> sampleIds);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/ReleaseRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/ReleaseRepo.java
@@ -14,6 +14,7 @@ import static java.util.stream.Collectors.toMap;
 public interface ReleaseRepo extends CrudRepository<Release, Integer> {
     List<Release> findAllByIdIn(Collection<Integer> ids);
 
+    List<Release> findAllByLabwareIdIn(Collection<Integer> labwareIds);
 
     /**
      * Gets the releases matching the corresponding ids.

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/History.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/History.java
@@ -1,0 +1,73 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.stan.model.Labware;
+import uk.ac.sanger.sccp.stan.model.Sample;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author dr6
+ */
+public class History {
+    private List<HistoryEntry> entries;
+    private List<Sample> samples;
+    private List<Labware> labware;
+
+    public History(List<HistoryEntry> entries, List<Sample> samples, List<Labware> labware) {
+        setEntries(entries);
+        setSamples(samples);
+        setLabware(labware);
+    }
+
+    public History() {}
+
+    public List<HistoryEntry> getEntries() {
+        return this.entries;
+    }
+
+    public void setEntries(List<HistoryEntry> entries) {
+        this.entries = entries;
+    }
+
+    public List<Sample> getSamples() {
+        return this.samples;
+    }
+
+    public void setSamples(List<Sample> samples) {
+        this.samples = samples;
+    }
+
+    public List<Labware> getLabware() {
+        return this.labware;
+    }
+
+    public void setLabware(List<Labware> labware) {
+        this.labware = labware;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        History that = (History) o;
+        return (Objects.equals(this.entries, that.entries)
+                && Objects.equals(this.samples, that.samples)
+                && Objects.equals(this.labware, that.labware));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entries, samples, labware);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe("History")
+                .add("entries", entries)
+                .add("samples", samples)
+                .add("labware", labware)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/HistoryEntry.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/HistoryEntry.java
@@ -1,0 +1,136 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+/**
+ * Information for a row in the history table
+ * @author dr6
+ */
+public class HistoryEntry {
+    private int eventId;
+    private String type;
+    private LocalDateTime time;
+    private int sourceLabwareId;
+    private int destinationLabwareId;
+    private Integer sampleId;
+    private final List<String> details = new ArrayList<>();
+
+    public HistoryEntry(int eventId, String type, LocalDateTime time, int sourceLabwareId, int destinationLabwareId,
+                        Integer sampleId, Collection<String> details) {
+        this.eventId = eventId;
+        this.type = type;
+        this.time = time;
+        this.sourceLabwareId = sourceLabwareId;
+        this.destinationLabwareId = destinationLabwareId;
+        this.sampleId = sampleId;
+        setDetails(details);
+    }
+
+    public HistoryEntry(int eventId, String type, LocalDateTime time, int sourceLabwareId, int destinationLabwareId,
+                        Integer sampleId) {
+        this(eventId, type, time, sourceLabwareId, destinationLabwareId, sampleId, null);
+    }
+
+    public HistoryEntry() {}
+
+    public int getEventId() {
+        return this.eventId;
+    }
+
+    public void setEventId(int eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public LocalDateTime getTime() {
+        return this.time;
+    }
+
+    public void setTime(LocalDateTime time) {
+        this.time = time;
+    }
+
+    public int getSourceLabwareId() {
+        return this.sourceLabwareId;
+    }
+
+    public void setSourceLabwareId(int sourceLabwareId) {
+        this.sourceLabwareId = sourceLabwareId;
+    }
+
+    public int getDestinationLabwareId() {
+        return this.destinationLabwareId;
+    }
+
+    public void setDestinationLabwareId(int destinationLabwareId) {
+        this.destinationLabwareId = destinationLabwareId;
+    }
+
+    public Integer getSampleId() {
+        return this.sampleId;
+    }
+
+    public void setSampleId(Integer sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    public List<String> getDetails() {
+        return this.details;
+    }
+
+    public void setDetails(Collection<String> details) {
+        if (details != this.details) {
+            this.details.clear();
+            if (details != null) {
+                this.details.addAll(details);
+            }
+        }
+    }
+
+    public void addDetail(String detail) {
+        this.details.add(detail);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HistoryEntry that = (HistoryEntry) o;
+        return (this.eventId==that.eventId
+                && this.sourceLabwareId==that.sourceLabwareId
+                && this.destinationLabwareId==that.destinationLabwareId
+                && Objects.equals(this.sampleId, that.sampleId)
+                && Objects.equals(this.type, that.type)
+                && Objects.equals(this.time, that.time)
+                && Objects.equals(this.details, that.details));
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(new int[] { this.eventId, this.sourceLabwareId, this.destinationLabwareId,
+                this.sampleId==null ? 0 : this.sampleId });
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe("HistoryEntry")
+                .add("eventId", eventId)
+                .addRepr("type", type)
+                .add("time", time==null ? null : time.toString())
+                .add("sourceLabwareId", sourceLabwareId)
+                .add("destinationLabwareId", destinationLabwareId)
+                .add("sampleId", sampleId)
+                .add("details", details)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
@@ -1,0 +1,39 @@
+package uk.ac.sanger.sccp.stan.service.history;
+
+import uk.ac.sanger.sccp.stan.request.History;
+
+/**
+ * Service for getting the history from some kind of identifier.
+ * The history typically includes all related samples.
+ * Methods may throw {@link javax.persistence.EntityNotFoundException}.
+ */
+public interface HistoryService {
+    /**
+     * Gets the history for a particular sample (and related samples)
+     * @param sampleId the id of the sample
+     * @return the history for related samples
+     */
+    History getHistoryForSampleId(int sampleId);
+
+    /**
+     * Gets the history for samples derived from tissue identified by its external name
+     * @param externalName the name of tissue
+     * @return the history for samples from that tissue
+     */
+    History getHistoryForExternalName(String externalName);
+
+    /**
+     * Gets the history for samples derived from a specified donor
+     * @param donorName the name of a donor
+     * @return the history for samples from that donor
+     */
+    History getHistoryForDonorName(String donorName);
+
+    /**
+     * Gets history for samples related to samples in a specified piece of labware
+     * @param barcode the barcode of a piece of labware
+     * @return the history for samples in the labware (and related samples)
+     */
+    History getHistoryForLabwareBarcode(String barcode);
+
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryServiceImp.java
@@ -1,0 +1,316 @@
+package uk.ac.sanger.sccp.stan.service.history;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.History;
+import uk.ac.sanger.sccp.stan.request.HistoryEntry;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * @author dr6
+ */
+@Service
+public class HistoryServiceImp implements HistoryService {
+    private final OperationRepo opRepo;
+    private final LabwareRepo lwRepo;
+    private final SampleRepo sampleRepo;
+    private final TissueRepo tissueRepo;
+    private final DonorRepo donorRepo;
+    private final ReleaseRepo releaseRepo;
+    private final DestructionRepo destructionRepo;
+    private final OperationCommentRepo opCommentRepo;
+    private final SnapshotRepo snapshotRepo;
+
+    @Autowired
+    public HistoryServiceImp(OperationRepo opRepo, LabwareRepo lwRepo, SampleRepo sampleRepo, TissueRepo tissueRepo,
+                             DonorRepo donorRepo, ReleaseRepo releaseRepo,
+                             DestructionRepo destructionRepo, OperationCommentRepo opCommentRepo,
+                             SnapshotRepo snapshotRepo) {
+        this.opRepo = opRepo;
+        this.lwRepo = lwRepo;
+        this.sampleRepo = sampleRepo;
+        this.tissueRepo = tissueRepo;
+        this.donorRepo = donorRepo;
+        this.releaseRepo = releaseRepo;
+        this.destructionRepo = destructionRepo;
+        this.opCommentRepo = opCommentRepo;
+        this.snapshotRepo = snapshotRepo;
+    }
+
+    @Override
+    public History getHistoryForSampleId(int sampleId) {
+        Sample sample = sampleRepo.findById(sampleId).orElseThrow(() -> new EntityNotFoundException("Sample id "+ sampleId +" not found."));
+        Tissue tissue = sample.getTissue();
+        List<Sample> samples = sampleRepo.findAllByTissueIdIn(List.of(tissue.getId()));
+        return getHistoryForSamples(samples);
+    }
+
+    @Override
+    public History getHistoryForExternalName(String externalName) {
+        Tissue tissue = tissueRepo.getByExternalName(externalName);
+        List<Sample> samples = sampleRepo.findAllByTissueIdIn(List.of(tissue.getId()));
+        return getHistoryForSamples(samples);
+    }
+
+    @Override
+    public History getHistoryForDonorName(String donorName) {
+        Donor donor = donorRepo.getByDonorName(donorName);
+        List<Tissue> tissues = tissueRepo.findByDonorId(donor.getId());
+        List<Sample> samples = sampleRepo.findAllByTissueIdIn(tissues.stream().map(Tissue::getId).collect(Collectors.toList()));
+        return getHistoryForSamples(samples);
+    }
+
+    @Override
+    public History getHistoryForLabwareBarcode(String barcode) {
+        Labware lw = lwRepo.getByBarcode(barcode);
+        Set<Integer> tissueIds = lw.getSlots().stream()
+                .flatMap(slot -> slot.getSamples().stream())
+                .map(sam -> sam.getTissue().getId())
+                .collect(toSet());
+        List<Sample> samples = sampleRepo.findAllByTissueIdIn(tissueIds);
+        return getHistoryForSamples(samples);
+    }
+
+    /**
+     * Gets the history for the specifically supplied samples (which are commonly all related).
+     * @param samples the samples to get the history for
+     * @return the history involving those samples
+     */
+    public History getHistoryForSamples(List<Sample> samples) {
+        Set<Integer> sampleIds = samples.stream().map(Sample::getId).collect(toSet());
+        List<Operation> ops = opRepo.findAllBySampleIdIn(sampleIds);
+        Set<Integer> labwareIds = loadLabwareIdsForOpsAndSampleIds(ops, sampleIds);
+        List<Destruction> destructions = destructionRepo.findAllByLabwareIdIn(labwareIds);
+        List<Release> releases = releaseRepo.findAllByLabwareIdIn(labwareIds);
+        List<Labware> labware = lwRepo.findAllByIdIn(labwareIds);
+
+        List<HistoryEntry> opEntries = createEntriesForOps(ops, sampleIds, labware);
+        List<HistoryEntry> releaseEntries = createEntriesForReleases(releases, sampleIds);
+        List<HistoryEntry> destructionEntries = createEntriesForDestructions(destructions, sampleIds);
+
+        List<HistoryEntry> entries = assembleEntries(List.of(opEntries, releaseEntries, destructionEntries));
+        return new History(entries, samples, labware);
+    }
+
+
+    /**
+     * Gets labware ids from the given operations that are linked to the given sample ids.
+     * @param ops the operations
+     * @param sampleIds the ids of relevant samples
+     * @return the labware ids referenced in the operations related to the sample ids
+     */
+    public Set<Integer> loadLabwareIdsForOpsAndSampleIds(Collection<Operation> ops, Set<Integer> sampleIds) {
+        Set<Integer> labwareIds = new HashSet<>();
+        for (Operation op : ops) {
+            for (Action action : op.getActions()) {
+                if (action.getSample()!=null && sampleIds.contains(action.getSample().getId())
+                        || action.getSourceSample()!=null && sampleIds.contains(action.getSample().getId())) {
+                    labwareIds.add(action.getDestination().getLabwareId());
+                    labwareIds.add(action.getSource().getLabwareId());
+                }
+            }
+        }
+        return labwareIds;
+    }
+
+    /**
+     * Gets all comments on specified operations
+     * @param opIds ids of operations
+     * @return a map of operation id to a list of operation comments
+     */
+    public Map<Integer, List<OperationComment>> loadOpComments(Collection<Integer> opIds) {
+        List<OperationComment> opComments = opCommentRepo.findAllByOperationIdIn(opIds);
+        if (opComments.isEmpty()) {
+            return Map.of();
+        }
+        Map<Integer, List<OperationComment>> map = new HashMap<>();
+        for (OperationComment oc : opComments) {
+            map.computeIfAbsent(oc.getOperationId(), k -> new ArrayList<>()).add(oc);
+        }
+        return map;
+    }
+
+    /**
+     * Should the given operation-comment be added as a detail to the history entry under construction?
+     * It should, unless it has a field that indicates it is not relevant.
+     * @param com the operation comment to be checked
+     * @param sampleId the id of the sample for the history entry
+     * @param labwareId the id of the destination labware for the history entry
+     * @param slotIdMap a map to look up slots from their id
+     * @return true if the comment is applicable; false if it is not
+     */
+    public boolean doesCommentApply(OperationComment com, int sampleId, int labwareId, Map<Integer, Slot> slotIdMap) {
+        if (com.getSampleId()!=null && com.getSampleId()!=sampleId) {
+            return false;
+        }
+        if (com.getLabwareId()!=null) {
+            return (com.getLabwareId()==labwareId);
+        }
+        if (com.getSlotId()!=null) {
+            Slot slot = slotIdMap.get(com.getSlotId());
+            return (slot!=null && slot.getLabwareId() == labwareId);
+        }
+        return true;
+    }
+
+    /**
+     * Creates history entries for the given operations, where relevant to the specified samples
+     * @param operations the operations to represent in the history
+     * @param sampleIds the ids of relevant samples
+     * @param labware the relevant labware
+     * @return a list history entries for the given operations
+     */
+    public List<HistoryEntry> createEntriesForOps(Collection<Operation> operations, Set<Integer> sampleIds,
+                                                  Collection<Labware> labware) {
+        Set<Integer> opIds = operations.stream().map(Operation::getId).collect(toSet());
+        var opComments = loadOpComments(opIds);
+        final Map<Integer, Slot> slotIdMap;
+        if (!opComments.isEmpty()) {
+            slotIdMap = labware.stream()
+                    .flatMap(lw -> lw.getSlots().stream())
+                    .collect(toMap(Slot::getId, Function.identity()));
+        } else {
+            slotIdMap = null; // not needed
+        }
+        List<HistoryEntry> entries = new ArrayList<>();
+        for (Operation op : operations) {
+            Set<SampleAndLabwareIds> items = new LinkedHashSet<>();
+            List<OperationComment> comments = opComments.getOrDefault(op.getId(), List.of());
+            for (Action action : op.getActions()) {
+                final Integer sampleId = action.getSample().getId();
+                if (sampleIds.contains(sampleId)) {
+                    final Integer sourceId = action.getSource().getLabwareId();
+                    final Integer destId = action.getDestination().getLabwareId();
+                    items.add(new SampleAndLabwareIds(sampleId, sourceId, destId));
+                }
+            }
+            for (var item : items) {
+                HistoryEntry entry = new HistoryEntry(op.getId(), op.getOperationType().getName(),
+                        op.getPerformed(), item.sourceId, item.destId, item.sampleId);
+                comments.forEach(com -> {
+                    if (doesCommentApply(com, item.sampleId, item.destId, slotIdMap)) {
+                        String detail = com.getComment().getText();
+                        if (com.getSlotId()!=null) {
+                            assert slotIdMap != null;
+                            detail = slotIdMap.get(com.getSlotId()).getAddress()+": "+detail;
+                        }
+                        entry.addDetail(detail);
+                    }
+                });
+                entries.add(entry);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Creates history entries representing releases, where they are applicable to the specified sample
+     * @param releases the releases to represent
+     * @param sampleIds the ids of relevant samples
+     * @return a list of history entries for the given releases
+     */
+    public List<HistoryEntry> createEntriesForReleases(List<Release> releases, Set<Integer> sampleIds) {
+        Set<Integer> snapshotIds = releases.stream().map(Release::getSnapshotId).filter(Objects::nonNull).collect(toSet());
+        Map<Integer, Snapshot> snapshotMap = snapshotRepo.findAllByIdIn(snapshotIds).stream()
+                .collect(BasicUtils.toMap(Snapshot::getId, HashMap::new));
+        List<HistoryEntry> entries = new ArrayList<>();
+        for (Release release : releases) {
+            int labwareId = release.getLabware().getId();
+            List<String> details = List.of("Destination: "+release.getDestination().getName(),
+                    "Recipient: "+release.getRecipient().getUsername());
+            if (release.getSnapshotId()==null) {
+                entries.add(new HistoryEntry(release.getId(), "Release", release.getReleased(),
+                        labwareId, labwareId,null, details));
+            } else {
+                Snapshot snap = snapshotMap.get(release.getSnapshotId());
+                Set<Integer> releaseSampleIds = snap.getElements().stream()
+                        .map(SnapshotElement::getSampleId)
+                        .filter(sampleIds::contains)
+                        .collect(BasicUtils.toLinkedHashSet());
+                for (Integer sampleId : releaseSampleIds) {
+                    entries.add(new HistoryEntry(release.getId(), "Release", release.getReleased(),
+                            labwareId, labwareId, sampleId, details));
+                }
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Creates history entries representing destructions, where they are applicable to the specified sample
+     * @param destructions the destructions to represent
+     * @param sampleIds the ids of relevant samples
+     * @return a list of history entries for the given destructions
+     */
+    public List<HistoryEntry> createEntriesForDestructions(Collection<Destruction> destructions, Set<Integer> sampleIds) {
+        List<HistoryEntry> entries = new ArrayList<>();
+        for (Destruction destruction : destructions) {
+            final Labware labware = destruction.getLabware();
+            Set<Integer> destructionSampleIds = labware.getSlots().stream()
+                    .flatMap(slot -> slot.getSamples().stream().map(Sample::getId))
+                    .filter(sampleIds::contains)
+                    .collect(BasicUtils.toLinkedHashSet());
+            if (!destructionSampleIds.isEmpty()) {
+                int labwareId = labware.getId();
+                List<String> details = List.of("Reason: "+destruction.getReason().getText());
+                for (Integer sampleId : destructionSampleIds) {
+                    entries.add(new HistoryEntry(destruction.getId(), "Destruction", destruction.getDestroyed(),
+                            labwareId, labwareId, sampleId, details));
+                }
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Assembles various collections of history enties into a single list, sorted by time
+     * @param entryCollections the collections of entries to include in the combined list
+     * @return a list containing the entries from all the given collections, sorted
+     */
+    public List<HistoryEntry> assembleEntries(List<Collection<HistoryEntry>> entryCollections) {
+        int num = entryCollections.stream().mapToInt(Collection::size).sum();
+        List<HistoryEntry> entries = new ArrayList<>(num);
+        for (var entryList : entryCollections) {
+            entries.addAll(entryList);
+        }
+        entries.sort(Comparator.comparing(HistoryEntry::getTime));
+        return entries;
+    }
+
+    // region support class
+    private static class SampleAndLabwareIds {
+        final int sampleId, sourceId, destId;
+
+        public SampleAndLabwareIds(int sampleId, int sourceId, int destId) {
+            this.sampleId = sampleId;
+            this.sourceId = sourceId;
+            this.destId = destId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SampleAndLabwareIds that = (SampleAndLabwareIds) o;
+            return (this.sampleId == that.sampleId
+                    && this.sourceId == that.sourceId
+                    && this.destId == that.destId);
+        }
+
+        @Override
+        public int hashCode() {
+            return sampleId + 31 * (sourceId + 31 * destId);
+        }
+    }
+    // endregion
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryServiceImp.java
@@ -114,7 +114,7 @@ public class HistoryServiceImp implements HistoryService {
         for (Operation op : ops) {
             for (Action action : op.getActions()) {
                 if (action.getSample()!=null && sampleIds.contains(action.getSample().getId())
-                        || action.getSourceSample()!=null && sampleIds.contains(action.getSample().getId())) {
+                        || action.getSourceSample()!=null && sampleIds.contains(action.getSourceSample().getId())) {
                     labwareIds.add(action.getDestination().getLabwareId());
                     labwareIds.add(action.getSource().getLabwareId());
                 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -447,6 +447,22 @@ input FindRequest {
     createdMax: Date
 }
 
+type HistoryEntry {
+    eventId: Int!
+    type: String!
+    time: Timestamp!
+    sourceLabwareId: Int!
+    destinationLabwareId: Int!
+    sampleId: Int
+    details: [String!]!
+}
+
+type History {
+    entries: [HistoryEntry!]!
+    labware: [Labware!]!
+    samples: [Sample!]!
+}
+
 type Query {
     user: User
     tissueTypes: [TissueType!]!
@@ -464,6 +480,11 @@ type Query {
     destructionReasons(includeDisabled: Boolean): [DestructionReason!]!
     users(includeDisabled: Boolean): [User!]!
     find(request: FindRequest!): FindResult!
+
+    historyForSampleId(sampleId: Int!): History!
+    historyForExternalName(externalName: String!): History!
+    historyForDonorName(donorName: String!): History!
+    historyForLabwareBarcode(barcode: String!): History!
 
     location(locationBarcode: String!): Location!
     stored(barcodes: [String!]!): [StoredItem!]!

--- a/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
@@ -911,6 +911,64 @@ public class IntegrationTests {
         assertEquals("Fell in the bin.", chainGet(data, "data", "addComment", "text"));
     }
 
+    @Transactional
+    @Test
+    public void testHistory() throws Exception {
+        String mutation = tester.readResource("graphql/register.graphql");
+        User user = entityCreator.createUser("user1");
+        tester.setUser(user);
+
+        Map<String, ?> response = tester.post(mutation);
+        Map<String, ?> lwData = chainGet(response, "data", "register", "labware", 0);
+        String barcode = chainGet(lwData, "barcode");
+        int sampleId = chainGet(lwData, "slots", 0, "samples", 0, "id");
+
+        String[] queryHeaders = {
+                "historyForSampleId(sampleId: "+sampleId+")",
+                "historyForLabwareBarcode(barcode: \""+barcode+"\")",
+                "historyForExternalName(externalName: \"TISSUE1\")",
+                "historyForDonorName(donorName: \"DONOR1\")",
+        };
+
+        String baseQuery = tester.readResource("graphql/history.graphql");
+        String queryBody = baseQuery.substring(baseQuery.indexOf(')') + 1);
+
+        for (String queryHeader : queryHeaders) {
+            String query = "query { " + queryHeader + queryBody;
+            response = tester.post(query);
+
+            String queryName = queryHeader.substring(0, queryHeader.indexOf('('));
+            Map<String, ?> historyData = chainGet(response, "data", queryName);
+            List<Map<String,?>> entries = chainGetList(historyData, "entries");
+            assertThat(entries).hasSize(1);
+            Map<String,?> entry = entries.get(0);
+            assertNotNull(entry.get("eventId"));
+            assertEquals("Register", entry.get("type"));
+            assertEquals(sampleId, entry.get("sampleId"));
+            int labwareId = (int) entry.get("sourceLabwareId");
+            assertEquals(labwareId, entry.get("destinationLabwareId"));
+            assertNotNull(entry.get("time"));
+            assertEquals(List.of(), entry.get("details"));
+
+            List<Map<String,?>> labwareData = chainGetList(historyData, "labware");
+            assertThat(labwareData).hasSize(1);
+            lwData = labwareData.get(0);
+            assertEquals(labwareId, lwData.get("id"));
+            assertEquals(barcode, lwData.get("barcode"));
+            assertEquals("active", lwData.get("state"));
+
+            List<Map<String,?>> samplesData = chainGetList(historyData, "samples");
+            assertThat(samplesData).hasSize(1);
+            Map<String,?> sampleData = samplesData.get(0);
+            assertEquals(sampleId, sampleData.get("id"));
+            assertEquals("TISSUE1", chainGet(sampleData, "tissue", "externalName"));
+            assertEquals("Bone", chainGet(sampleData, "tissue", "spatialLocation", "tissueType", "name"));
+            assertEquals("DONOR1", chainGet(sampleData, "tissue", "donor", "donorName"));
+            assertNull(sampleData.get("section"));
+        }
+
+    }
+
     private void stubStorelightUnstore() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         ObjectNode storelightDataNode = objectMapper.createObjectNode()

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestOperationCommentRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestOperationCommentRepo.java
@@ -1,0 +1,55 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link OperationCommentRepo}
+ * @author dr6
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@Import(EntityCreator.class)
+public class TestOperationCommentRepo {
+    @Autowired
+    OperationRepo opRepo;
+    @Autowired
+    EntityCreator entityCreator;
+    @Autowired
+    OperationCommentRepo opCommentRepo;
+    @Autowired
+    CommentRepo commentRepo;
+
+    @Test
+    @Transactional
+    public void testFindAllByOperationIdIn() {
+        Tissue tissue = entityCreator.createTissue(entityCreator.createDonor("DONOR1"), "EXT1");
+        int sam1id = entityCreator.createSample(tissue, 1).getId();
+        int sam2id = entityCreator.createSample(tissue, 2).getId();
+        OperationType opType = entityCreator.createOpType("Frying", null);
+        User user = entityCreator.createUser("dr6");
+        int op1id = opRepo.save(new Operation(null, opType, null, List.of(), user)).getId();
+        int op2id = opRepo.save(new Operation(null, opType, null, List.of(), user)).getId();
+        Comment comment1 = commentRepo.save(new Comment(null, "Dropped", "Frying"));
+        Comment comment2 = commentRepo.save(new Comment(null, "Burned", "Frying"));
+        OperationComment oc1 = opCommentRepo.save(new OperationComment(null, comment1, op1id, sam1id, null, null));
+        OperationComment oc2 = opCommentRepo.save(new OperationComment(null, comment2, op1id, sam2id, null, null));
+        OperationComment oc3 = opCommentRepo.save(new OperationComment(null, comment1, op2id, sam1id, null, null));
+        OperationComment oc4 = opCommentRepo.save(new OperationComment(null, comment2, op2id, null, null, null));
+
+        assertThat(opCommentRepo.findAllByOperationIdIn(List.of(op1id, op2id))).containsExactlyInAnyOrder(oc1, oc2, oc3, oc4);
+        assertThat(opCommentRepo.findAllByOperationIdIn(List.of(op1id))).containsExactlyInAnyOrder(oc1, oc2);
+        assertThat(opCommentRepo.findAllByOperationIdIn(List.of(op1id+op2id))).isEmpty();
+    }
+
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/history/TestHistoryService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/history/TestHistoryService.java
@@ -1,0 +1,389 @@
+package uk.ac.sanger.sccp.stan.service.history;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.History;
+import uk.ac.sanger.sccp.stan.request.HistoryEntry;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link HistoryServiceImp}
+ * @author dr6
+ */
+public class TestHistoryService {
+    private OperationRepo mockOpRepo;
+    private LabwareRepo mockLwRepo;
+    private SampleRepo mockSampleRepo;
+    private TissueRepo mockTissueRepo;
+    private DonorRepo mockDonorRepo;
+    private ReleaseRepo mockReleaseRepo;
+    private DestructionRepo mockDestructionRepo;
+    private OperationCommentRepo mockOpCommentRepo;
+    private SnapshotRepo mockSnapshotRepo;
+
+    private HistoryServiceImp service;
+
+    private Sample[] samples;
+    private Labware[] labware;
+    private List<Operation> ops;
+
+    @BeforeEach
+    public void setup() {
+        mockOpRepo = mock(OperationRepo.class);
+        mockLwRepo = mock(LabwareRepo.class);
+        mockSampleRepo = mock(SampleRepo.class);
+        mockTissueRepo = mock(TissueRepo.class);
+        mockDonorRepo = mock(DonorRepo.class);
+        mockReleaseRepo = mock(ReleaseRepo.class);
+        mockDestructionRepo = mock(DestructionRepo.class);
+        mockOpCommentRepo = mock(OperationCommentRepo.class);
+        mockSnapshotRepo = mock(SnapshotRepo.class);
+
+        service = spy(new HistoryServiceImp(mockOpRepo, mockLwRepo, mockSampleRepo, mockTissueRepo, mockDonorRepo,
+                mockReleaseRepo, mockDestructionRepo, mockOpCommentRepo, mockSnapshotRepo));
+    }
+
+    @Test
+    public void testGetHistoryForSampleId() {
+        History history = new History();
+        Sample sample = EntityFactory.getSample();
+        when(mockSampleRepo.findById(sample.getId())).thenReturn(Optional.of(sample));
+        Sample sample2 = new Sample(sample.getId()+1, 10, sample.getTissue(), sample.getBioState());
+        List<Sample> samples = List.of(sample, sample2);
+        when(mockSampleRepo.findAllByTissueIdIn(List.of(sample.getTissue().getId()))).thenReturn(samples);
+        doReturn(history).when(service).getHistoryForSamples(samples);
+
+        assertSame(history, service.getHistoryForSampleId(sample.getId()));
+
+        when(mockSampleRepo.findById(-1)).thenReturn(Optional.empty());
+        assertThrows(EntityNotFoundException.class, () -> service.getHistoryForSampleId(-1));
+    }
+
+    @Test
+    public void testGetHistoryForExternalName() {
+        History history = new History();
+        Sample sample = EntityFactory.getSample();
+        Tissue tissue = sample.getTissue();
+        when(mockTissueRepo.getByExternalName(tissue.getExternalName())).thenReturn(tissue);
+        Sample sample2 = new Sample(sample.getId()+1, 10, sample.getTissue(), sample.getBioState());
+        List<Sample> samples = List.of(sample, sample2);
+        when(mockSampleRepo.findAllByTissueIdIn(List.of(tissue.getId()))).thenReturn(samples);
+        doReturn(history).when(service).getHistoryForSamples(samples);
+
+        assertSame(history, service.getHistoryForExternalName(tissue.getExternalName()));
+    }
+
+    @Test
+    public void testGetHistoryForDonorName() {
+        History history = new History();
+        Sample sample = EntityFactory.getSample();
+        Tissue tissue = sample.getTissue();
+        final Donor donor = tissue.getDonor();
+        Tissue tissue2 = EntityFactory.makeTissue(donor, EntityFactory.getSpatialLocation());
+        when(mockTissueRepo.findByDonorId(donor.getId())).thenReturn(List.of(tissue, tissue2));
+        when(mockDonorRepo.getByDonorName(donor.getDonorName())).thenReturn(donor);
+        Sample sample2 = new Sample(sample.getId()+1, 10, tissue2, sample.getBioState());
+        List<Sample> samples = List.of(sample, sample2);
+        when(mockSampleRepo.findAllByTissueIdIn(List.of(tissue.getId(), tissue2.getId()))).thenReturn(samples);
+        doReturn(history).when(service).getHistoryForSamples(samples);
+
+        assertSame(history, service.getHistoryForDonorName(donor.getDonorName()));
+    }
+
+    @Test
+    public void testGetHistoryForLabwareBarcode() {
+        History history = new History();
+        Sample sample = EntityFactory.getSample();
+        Tissue tissue = sample.getTissue();
+        Tissue tissue2 = EntityFactory.makeTissue(tissue.getDonor(), EntityFactory.getSpatialLocation());
+        Sample sample2 = new Sample(sample.getId()+1, 10, tissue2, sample.getBioState());
+        Sample sample3 = new Sample(sample2.getId()+1, 11, tissue2, sample.getBioState());
+        LabwareType lt = EntityFactory.makeLabwareType(1,2);
+        Labware lw = EntityFactory.makeLabware(lt, sample, sample2);
+        when(mockLwRepo.getByBarcode(lw.getBarcode())).thenReturn(lw);
+        List<Sample> samples = List.of(sample, sample2, sample3);
+        when(mockSampleRepo.findAllByTissueIdIn(Set.of(tissue.getId(), tissue2.getId()))).thenReturn(samples);
+        doReturn(history).when(service).getHistoryForSamples(samples);
+
+        assertSame(history, service.getHistoryForLabwareBarcode(lw.getBarcode()));
+    }
+
+    @Test
+    public void testGetHistoryForSamples() {
+        Sample sample = EntityFactory.getSample();
+        Sample sample2 = new Sample(sample.getId() + 1, 10, sample.getTissue(), sample.getBioState());
+        List<Sample> samples = List.of(sample, sample2);
+        Set<Integer> sampleIds = Set.of(sample.getId(), sample2.getId());
+        List<Operation> ops = List.of(new Operation(100, null, null, null, null));
+        LabwareType lt = EntityFactory.getTubeType();
+        List<Labware> labware = IntStream.range(0,2).mapToObj(i -> EntityFactory.makeLabware(lt, samples.get(i))).collect(toList());
+        Set<Integer> labwareIds = Set.of(labware.get(0).getId(), labware.get(1).getId());
+        List<Destruction> destructions = List.of(new Destruction());
+        List<Release> releases = List.of(new Release());
+
+        List<HistoryEntry> opEntries = List.of(new HistoryEntry(1, "op", null, 1, 1, null));
+        List<HistoryEntry> releaseEntries = List.of(new HistoryEntry(2, "release", null, 1, 1, null));
+        List<HistoryEntry> destructionEntries = List.of(new HistoryEntry(3, "destruction", null, 1, 1, null));
+
+        List<HistoryEntry> entries = List.of(opEntries.get(0), releaseEntries.get(0), destructionEntries.get(0));
+
+        when(mockOpRepo.findAllBySampleIdIn(sampleIds)).thenReturn(ops);
+        when(mockDestructionRepo.findAllByLabwareIdIn(labwareIds)).thenReturn(destructions);
+        when(mockReleaseRepo.findAllByLabwareIdIn(labwareIds)).thenReturn(releases);
+        when(mockLwRepo.findAllByIdIn(labwareIds)).thenReturn(labware);
+
+        doReturn(labwareIds).when(service).loadLabwareIdsForOpsAndSampleIds(ops, sampleIds);
+
+        doReturn(opEntries).when(service).createEntriesForOps(ops, sampleIds, labware);
+        doReturn(releaseEntries).when(service).createEntriesForReleases(releases, sampleIds);
+        doReturn(destructionEntries).when(service).createEntriesForDestructions(destructions, sampleIds);
+
+        doReturn(entries).when(service).assembleEntries(List.of(opEntries, releaseEntries, destructionEntries));
+
+        History history = service.getHistoryForSamples(samples);
+        assertEquals(history.getEntries(), entries);
+        assertEquals(history.getSamples(), samples);
+        assertEquals(history.getLabware(), labware);
+    }
+
+    private static Stream<Slot> streamSlots(Labware lw, Address... addresses) {
+        return Arrays.stream(addresses).map(lw::getSlot);
+    }
+
+    private void createSamples() {
+        if (samples==null) {
+            Sample sample = EntityFactory.getSample();
+            samples = new Sample[3];
+            samples[0] = sample;
+            for (int i = 1; i < samples.length; ++i) {
+                samples[i] = new Sample(sample.getId()+i, 10+i, sample.getTissue(), sample.getBioState());
+            }
+        }
+    }
+
+    private void createLabware() {
+        createSamples();
+        if (labware==null) {
+            LabwareType lt = EntityFactory.makeLabwareType(3,1);
+            int[][] samplesInLabware = {{0,1,2},{0,1},{1},{2}};
+            labware = Arrays.stream(samplesInLabware)
+                    .map(arr -> Arrays.stream(arr).mapToObj(i -> samples[i]).toArray(Sample[]::new))
+                    .map(contents -> EntityFactory.makeLabware(lt, contents))
+                    .toArray(Labware[]::new);
+        }
+    }
+
+    // Op 1: samples 0,1 from labware 0 to labware 1
+    //       sample 1 from labware 0 to labware 2
+    // Op 2: sample 2 from labware 0 to labware 3
+    // We are not interested in sample 1, so we should get labware 0, 1 and 3 returned.
+    private void createOps() {
+        createLabware();
+        if (ops==null) {
+            final Address A1 = new Address(1,1);
+            final Address B1 = new Address(2,1);
+            final Address C1 = new Address(3,1);
+
+            OperationType opType = EntityFactory.makeOperationType("Catapult", null);
+            ops = List.of(
+                    EntityFactory.makeOpForSlots(opType, streamSlots(labware[0], A1, B1, B1).collect(toList()),
+                            Stream.concat(streamSlots(labware[1], A1, B1), streamSlots(labware[2], A1)).collect(toList()), null),
+                    EntityFactory.makeOpForSlots(opType, List.of(labware[0].getSlot(C1)), List.of(labware[3].getFirstSlot()), null)
+            );
+        }
+    }
+
+    @Test
+    public void testLoadLabwareIdsForOpsAndSampleIds() {
+        createOps();
+        // Op 1: samples 0,1 from labware 0 to labware 1
+        //       sample 1 from labware 0 to labware 2
+        // Op 2: sample 2 from labware 0 to labware 3
+
+        Set<Integer> sampleIds = Set.of(samples[0].getId(), samples[2].getId());
+        // We are not interested in sample 1, so we should get labware 0, 1 and 3 returned.
+
+        assertEquals(Set.of(labware[0].getId(), labware[1].getId(), labware[3].getId()),
+                service.loadLabwareIdsForOpsAndSampleIds(ops, sampleIds));
+    }
+
+    @Test
+    public void testLoadOpComments() {
+        Comment com = new Comment(1, "Purple", "Observation");
+
+        List<OperationComment> opComs = List.of(
+                new OperationComment(1, com, 1, 1, 1, 1),
+                new OperationComment(2, com, 1, 2, 2, 2),
+                new OperationComment(3, com, 2, 3, 3, 3)
+        );
+        when(mockOpCommentRepo.findAllByOperationIdIn(any())).then(invocation -> {
+            Collection<Integer> opIds = invocation.getArgument(0);
+            return opComs.stream().filter(oc -> opIds.contains(oc.getOperationId())).collect(toList());
+        });
+
+        assertEquals(Map.of(1, opComs.subList(0,2), 2, opComs.subList(2,3)), service.loadOpComments(Set.of(1,2,3)));
+        assertEquals(Map.of(), service.loadOpComments(Set.of(3,4)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("doesCommentApplyData")
+    public void testDoesCommentApply(OperationComment opCom, int sampleId, int labwareId, Slot slot, boolean expected) {
+        Map<Integer, Slot> slotIdMap = (slot==null ? Map.of() : Map.of(slot.getId(), slot));
+        assertEquals(expected, service.doesCommentApply(opCom, sampleId, labwareId, slotIdMap));
+    }
+
+    static Stream<Arguments> doesCommentApplyData() {
+        Slot slot = new Slot(100, 10, new Address(1,1), null, null, null);
+        Comment com = new Comment(1, "Alabama", "Bananas");
+        return Stream.of(
+                Arguments.of(new OperationComment(1, com, 1, null, null, null), 1, 10, null, true),
+                Arguments.of(new OperationComment(1, com, 1, 1, 100, 10), 1, 10, slot, true),
+                Arguments.of(new OperationComment(1, com, 1, 1, 100, null), 1, 10, slot, true),
+                Arguments.of(new OperationComment(1, com, 1, null, 100, null), 1, 10, slot, true),
+                Arguments.of(new OperationComment(1, com, 1, 1, null, null), 1, 10, null, true),
+
+                Arguments.of(new OperationComment(1, com, 1, 2, null, null), 1, 10, null, false), // wrong sample id
+                Arguments.of(new OperationComment(1, com, 1, null, 200, null), 1, 10, slot, false), // wrong slot id
+                Arguments.of(new OperationComment(1, com, 1, null, 100, null), 1, 20, slot, false), // slot belongs to wrong labware
+                Arguments.of(new OperationComment(1, com, 1, null, null, 20), 1, 10, null, false) // wrong labware id
+        );
+    }
+
+    @Test
+    public void testCreateEntriesForOps() {
+        Comment[] coms = {
+                new Comment(1, "Alabama", "Bananas"),
+                new Comment(2, "Alaska", "Bananas"),
+                new Comment(3, "Arizona", "Bananas"),
+                new Comment(3, "Arkansas", "Bananas"),
+        };
+        createOps();
+        int[] opIds = ops.stream().mapToInt(Operation::getId).toArray();
+
+        OperationComment[] opComs = {
+                new OperationComment(1, coms[0], opIds[0], null, null, null),
+                new OperationComment(2, coms[1], opIds[0], null, labware[1].getFirstSlot().getId(), null),
+                new OperationComment(3, coms[2], opIds[1], null, null, null),
+                new OperationComment(4, coms[3], opIds[1], 400, null, null),
+        };
+
+        Map<Integer, List<OperationComment>> opComMap = Map.of(
+                opIds[0], List.of(opComs[0], opComs[1]),
+                opIds[1], List.of(opComs[2], opComs[3])
+        );
+
+        doReturn(opComMap).when(service).loadOpComments(Set.of(opIds[0], opIds[1]));
+
+        // Letting doesCommentApply actually run is easier than mocking it to return what it would return anyway
+
+        List<Labware> labwareList = Arrays.asList(this.labware);
+
+        Set<Integer> sampleIds = Set.of(samples[0].getId(), samples[2].getId());
+
+        String opTypeName = ops.get(0).getOperationType().getName();
+        List<HistoryEntry> expectedEntries = List.of(
+                new HistoryEntry(opIds[0], opTypeName, ops.get(0).getPerformed(), labware[0].getId(),
+                        labware[1].getId(), samples[0].getId(), List.of("Alabama", "A1: Alaska")),
+                new HistoryEntry(opIds[1], opTypeName, ops.get(1).getPerformed(), labware[0].getId(),
+                        labware[3].getId(), samples[2].getId(), List.of("Arizona"))
+        );
+        assertThat(service.createEntriesForOps(ops, sampleIds, labwareList)).containsExactlyElementsOf(expectedEntries);
+    }
+
+    private static LocalDateTime makeTime(int n) {
+        return LocalDateTime.of(2021,7,1+n, 2+n, 0);
+    }
+
+    @Test
+    public void testCreateEntriesForReleases() {
+        createSamples();
+        LabwareType lt = EntityFactory.makeLabwareType(2,2);
+        Labware lw1 = EntityFactory.makeLabware(lt, samples[0], samples[0], samples[1], samples[2]);
+        Labware lw2 = EntityFactory.makeLabware(lt, samples[0], samples[1]);
+        Snapshot snap = new Snapshot(1, lw1.getId(),
+                lw1.getSlots().stream().flatMap(slot -> slot.getSamples().stream()
+                            .map(sample -> new SnapshotElement(null, 1, slot.getId(), sample.getId()))
+                ).collect(toList()));
+        Release rel1 = new Release(1, lw1, null, new ReleaseDestination(1, "Mercury"),
+                new ReleaseRecipient(2, "jeff"), snap.getId(), makeTime(1));
+        Release rel2 = new Release(2, lw2, null, new ReleaseDestination(3, "Venus"),
+                new ReleaseRecipient(4, "dirk"), null, makeTime(2));
+
+        when(mockSnapshotRepo.findAllByIdIn(Set.of(1))).thenReturn(List.of(snap));
+        List<HistoryEntry> expectedEntries = List.of(
+                new HistoryEntry(1, "Release", rel1.getReleased(), lw1.getId(), lw1.getId(), samples[0].getId(),
+                        List.of("Destination: Mercury", "Recipient: jeff")),
+                new HistoryEntry(1, "Release", rel1.getReleased(), lw1.getId(), lw1.getId(), samples[2].getId(),
+                        List.of("Destination: Mercury", "Recipient: jeff")),
+                new HistoryEntry(2, "Release", rel2.getReleased(), lw2.getId(), lw2.getId(), null,
+                        List.of("Destination: Venus", "Recipient: dirk"))
+        );
+        assertThat(service.createEntriesForReleases(List.of(rel1, rel2), Set.of(samples[0].getId(), samples[2].getId())))
+                .containsExactlyElementsOf(expectedEntries);
+    }
+
+    @Test
+    public void testCreateEntriesForDestructions() {
+        createSamples();
+        LabwareType lt = EntityFactory.makeLabwareType(2,2);
+        Labware lw1 = EntityFactory.makeLabware(lt, samples[0], samples[0], samples[1], samples[2]);
+        Labware lw2 = EntityFactory.makeLabware(lt, samples[0], samples[1]);
+        Destruction d1 = new Destruction(1, lw1, null, makeTime(1),
+                new DestructionReason(1, "Dropped."));
+        Destruction d2 = new Destruction(2, lw2, null, makeTime(2),
+                new DestructionReason(2, "Sat on."));
+
+        List<HistoryEntry> expectedEntries = List.of(
+                new HistoryEntry(1, "Destruction", d1.getDestroyed(), lw1.getId(), lw1.getId(), samples[0].getId(),
+                        List.of("Reason: Dropped.")),
+                new HistoryEntry(1, "Destruction", d1.getDestroyed(), lw1.getId(), lw1.getId(), samples[2].getId(),
+                        List.of("Reason: Dropped.")),
+                new HistoryEntry(2, "Destruction", d2.getDestroyed(), lw2.getId(), lw2.getId(), samples[0].getId(),
+                        List.of("Reason: Sat on."))
+        );
+
+        assertThat(service.createEntriesForDestructions(List.of(d1, d2), Set.of(samples[0].getId(), samples[2].getId())))
+                .containsExactlyElementsOf(expectedEntries);
+    }
+
+
+    @Test
+    public void testAssembleEntries() {
+        List<HistoryEntry> e1 = List.of(
+                new HistoryEntry(1, "Register", makeTime(0), 1, 1, 1),
+                new HistoryEntry(2, "Section", makeTime(2), 1, 2, 2),
+                new HistoryEntry(3, "Section", makeTime(4), 1, 3, 3),
+                new HistoryEntry(4, "Scoop", makeTime(6), 3, 4, 3)
+        );
+        List<HistoryEntry> e2 = List.of(
+                new HistoryEntry(1, "Release", makeTime(3), 2, 2, 2),
+                new HistoryEntry(2, "Release", makeTime(8), 3, 3, 3)
+        );
+        List<HistoryEntry> e3 = List.of(
+                new HistoryEntry(1, "Destruction", makeTime(5), 1, 1, 1),
+                new HistoryEntry(2, "Destruction", makeTime(9), 4, 4, 3)
+        );
+
+        List<HistoryEntry> expectedEntries = List.of(
+                e1.get(0), e1.get(1), e2.get(0), e1.get(2), e3.get(0), e1.get(3), e2.get(1), e3.get(1)
+        );
+
+        assertEquals(expectedEntries, service.assembleEntries(List.of(e1, e2, e3)));
+    }
+}

--- a/src/test/resources/graphql/history.graphql
+++ b/src/test/resources/graphql/history.graphql
@@ -1,0 +1,27 @@
+query {
+    historyForSampleId(sampleId: 1) {
+        entries {
+            eventId
+            type
+            sampleId
+            sourceLabwareId
+            destinationLabwareId
+            time
+            details
+        }
+        labware {
+            id
+            barcode
+            state
+        }
+        samples {
+            id
+            tissue {
+                spatialLocation { tissueType { name } }
+                externalName
+                donor { donorName }
+            }
+            section
+        }
+    }
+}

--- a/src/test/resources/graphql/register.graphql
+++ b/src/test/resources/graphql/register.graphql
@@ -22,6 +22,7 @@ mutation {
             barcode
             slots {
                 samples {
+                    id
                     tissue {
                         externalName
                         donor {


### PR DESCRIPTION
Squashed commit of the following:

commit 3f295553a20316acf119a947257aa5e1f1ac4515
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Fri Jul 16 15:58:48 2021 +0100

    Integration tests for history queries

commit 37f48b4e57b67e65c0556250b40411c2238c5678
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Fri Jul 16 14:07:07 2021 +0100

    History tests in progress

commit 14c054fb15fb1f37e80a0fe6c003e451d32d0525
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Thu Jul 15 10:01:26 2021 +0100

    History seemingly working; needs unit tests

commit 1849c501265a1e4b01fc932867cdd4b973dfce33
Author: David Robinson <14000840+khelwood@users.noreply.github.com>
Date:   Wed Jul 14 16:40:10 2021 +0100

    History in progress
