### PR TITLE
Make sure the list of validation problems is logged

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -3,6 +3,8 @@ package uk.ac.sanger.sccp.stan;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import graphql.GraphQL;
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.AsyncSerialExecutionStrategy;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.*;
@@ -50,7 +52,10 @@ public class GraphQLProvider {
         //noinspection UnstableApiUsage
         String sdl = Resources.toString(url, Charsets.UTF_8);
         GraphQLSchema graphQLSchema = buildSchema(sdl);
-        this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+        this.graphQL = GraphQL.newGraphQL(graphQLSchema)
+                .mutationExecutionStrategy(new AsyncSerialExecutionStrategy(new StanExceptionHandler()))
+                .queryExecutionStrategy(new AsyncExecutionStrategy(new StanExceptionHandler()))
+                .build();
     }
 
     private GraphQLSchema buildSchema(String sdl) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/StanExceptionHandler.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/StanExceptionHandler.java
@@ -1,0 +1,32 @@
+package uk.ac.sanger.sccp.stan;
+
+import graphql.ExceptionWhileDataFetching;
+import graphql.execution.*;
+import graphql.language.SourceLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.sanger.sccp.stan.service.ValidationException;
+
+/**
+ * Exception handler that adds validation problems when logging a ValidationError.
+ * @author dr6
+ */
+public class StanExceptionHandler implements DataFetcherExceptionHandler {
+    private static final Logger log = LoggerFactory.getLogger(StanExceptionHandler.class);
+
+    @Override
+    public DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+        Throwable exception = handlerParameters.getException();
+        SourceLocation sourceLocation = handlerParameters.getSourceLocation();
+        ExecutionPath path = handlerParameters.getPath();
+
+        ExceptionWhileDataFetching error = new ExceptionWhileDataFetching(path, exception, sourceLocation);
+        String message = error.getMessage();
+        if (exception instanceof ValidationException) {
+            message += "\nProblems: "+((ValidationException) exception).getProblems();
+        }
+        log.warn(message, exception);
+
+        return DataFetcherExceptionHandlerResult.newResult().error(error).build();
+    }
+}


### PR DESCRIPTION
Add a custom exception handler. When a validation error is thrown,
include the problems it lists in the log, instead of just
logging a validation exception.
