### PR TITLE
x743: Add work numbers in history

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/request/HistoryEntry.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/HistoryEntry.java
@@ -17,10 +17,11 @@ public class HistoryEntry {
     private int destinationLabwareId;
     private Integer sampleId;
     private String username;
+    private String workNumber;
     private final List<String> details = new ArrayList<>();
 
     public HistoryEntry(int eventId, String type, LocalDateTime time, int sourceLabwareId, int destinationLabwareId,
-                        Integer sampleId, String username, Collection<String> details) {
+                        Integer sampleId, String username, String workNumber, Collection<String> details) {
         this.eventId = eventId;
         this.type = type;
         this.time = time;
@@ -28,12 +29,13 @@ public class HistoryEntry {
         this.destinationLabwareId = destinationLabwareId;
         this.sampleId = sampleId;
         this.username = username;
+        this.workNumber = workNumber;
         setDetails(details);
     }
 
     public HistoryEntry(int eventId, String type, LocalDateTime time, int sourceLabwareId, int destinationLabwareId,
-                        Integer sampleId, String username) {
-        this(eventId, type, time, sourceLabwareId, destinationLabwareId, sampleId, username, null);
+                        Integer sampleId, String username, String workNumber) {
+        this(eventId, type, time, sourceLabwareId, destinationLabwareId, sampleId, username, workNumber, null);
     }
 
     public HistoryEntry() {}
@@ -111,6 +113,14 @@ public class HistoryEntry {
         this.username = username;
     }
 
+    public String getWorkNumber() {
+        return this.workNumber;
+    }
+
+    public void setWorkNumber(String workNumber) {
+        this.workNumber = workNumber;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -123,7 +133,8 @@ public class HistoryEntry {
                 && Objects.equals(this.type, that.type)
                 && Objects.equals(this.time, that.time)
                 && Objects.equals(this.details, that.details)
-                && Objects.equals(this.username, that.username));
+                && Objects.equals(this.username, that.username)
+                && Objects.equals(this.workNumber, that.workNumber));
     }
 
     @Override
@@ -143,6 +154,7 @@ public class HistoryEntry {
                 .add("sampleId", sampleId)
                 .add("details", details)
                 .addRepr("username", username)
+                .addRepr("workNumber", workNumber)
                 .toString();
     }
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -462,6 +462,7 @@ type HistoryEntry {
     destinationLabwareId: Int!
     sampleId: Int
     username: String!
+    workNumber: String
     details: [String!]!
 }
 


### PR DESCRIPTION
Currently we only expect one (at most) work number for any operation,
but the database schema supports multiple work numbers per operation,
so there is a little bit of kludge between the two.
The field in HistoryEntry is a single (nullable) string field for
the work number.
