### PR TITLE
x653 record result following extract op

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -69,6 +69,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
     final WorkService workService;
     final StainService stainService;
     final ResultService resultService;
+    final ExtractResultService extractResultService;
     final UserAdminService userAdminService;
 
     @Autowired
@@ -85,7 +86,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
                            ReleaseRecipientAdminService releaseRecipientAdminService, SpeciesAdminService speciesAdminService,
                            ProjectService projectService, CostCodeService costCodeService, FixativeService fixativeService,
                            WorkTypeService workTypeService, WorkService workService,
-                           StainService stainService, ResultService resultService,
+                           StainService stainService, ResultService resultService, ExtractResultService extractResultService,
                            UserAdminService userAdminService) {
         super(objectMapper, authComp, userRepo);
         this.ldapService = ldapService;
@@ -115,6 +116,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         this.workService = workService;
         this.stainService = stainService;
         this.resultService = resultService;
+        this.extractResultService = extractResultService;
         this.userAdminService = userAdminService;
     }
 
@@ -424,6 +426,15 @@ public class GraphQLMutation extends BaseGraphQLResource {
             ResultRequest request = arg(dfe, "request", ResultRequest.class);
             logRequest("Record stain result", user, request);
             return resultService.recordStainResult(user, request);
+        };
+    }
+
+    public DataFetcher<OperationResult> recordExtractResult() {
+        return dfe -> {
+            User user = checkUser(dfe, User.Role.normal);
+            ExtractResultRequest request = arg(dfe, "request", ExtractResultRequest.class);
+            logRequest("Record extract result", user, request);
+            return extractResultService.recordExtractResult(user, request);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -143,6 +143,7 @@ public class GraphQLProvider {
                         .dataFetcher("updateWorkStatus", transact(graphQLMutation.updateWorkStatus()))
                         .dataFetcher("stain", transact(graphQLMutation.stain()))
                         .dataFetcher("recordStainResult", transact(graphQLMutation.recordStainResult()))
+                        .dataFetcher("recordExtractResult", transact(graphQLMutation.recordExtractResult()))
 
                         .dataFetcher("addUser", transact(graphQLMutation.addUser()))
                         .dataFetcher("setUserRole", transact(graphQLMutation.setUserRole()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
@@ -2,9 +2,8 @@ package uk.ac.sanger.sccp.stan.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import uk.ac.sanger.sccp.stan.service.StringValidator;
+import uk.ac.sanger.sccp.stan.service.*;
 import uk.ac.sanger.sccp.stan.service.StringValidator.CharacterType;
-import uk.ac.sanger.sccp.stan.service.Validator;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -159,5 +158,10 @@ public class FieldValidation {
         Set<CharacterType> charTypes = EnumSet.of(CharacterType.ALPHA, CharacterType.DIGIT);
         Pattern pattern = Pattern.compile("[A-Z][0-9]+", Pattern.CASE_INSENSITIVE);
         return new StringValidator("Cost code", 2, 10, charTypes, false, pattern);
+    }
+
+    @Bean
+    public Sanitiser<String> concentrationSanitiser() {
+        return new ConcentrationSanitiser();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementType.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementType.java
@@ -7,7 +7,9 @@ public enum MeasurementType {
     Thickness(MeasurementValueType.INT),
     Haematoxylin(MeasurementValueType.TIME),
     Eosin(MeasurementValueType.TIME),
-    Blueing(MeasurementValueType.TIME);
+    Blueing(MeasurementValueType.TIME),
+    Concentration(MeasurementValueType.DECIMAL_2),
+    ;
 
     private final MeasurementValueType valueType;
 
@@ -20,12 +22,11 @@ public enum MeasurementType {
     }
 
     public static MeasurementType forName(String name) {
-        if (name==null) {
-            return null;
-        }
-        for (MeasurementType mt : values()) {
-            if (mt.name().equalsIgnoreCase(name)) {
-                return mt;
+        if (name!=null) {
+            for (MeasurementType mt : values()) {
+                if (mt.name().equalsIgnoreCase(name)) {
+                    return mt;
+                }
             }
         }
         return null;

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementValueType.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementValueType.java
@@ -4,5 +4,7 @@ package uk.ac.sanger.sccp.stan.model;
  * @author dr6
  */
 public enum MeasurementValueType {
-    INT, TIME
+    INT, // An integer
+    TIME, // A duration in seconds
+    DECIMAL_2, // A positive or negative rational number with two decimal places
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/ExtractResultRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/ExtractResultRequest.java
@@ -1,0 +1,144 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.stan.model.PassFail;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.util.*;
+
+/**
+ * A request to record a result for extract operations
+ * @author dr6
+ */
+public class ExtractResultRequest {
+    public static class ExtractResultLabware {
+        private String barcode;
+        private PassFail result;
+        private String concentration;
+        private Integer commentId;
+
+        public ExtractResultLabware() {}
+
+        public ExtractResultLabware(String barcode, PassFail result, String concentration, Integer commentId) {
+            this.barcode = barcode;
+            this.result = result;
+            this.concentration = concentration;
+            this.commentId = commentId;
+        }
+
+        public ExtractResultLabware(String barcode, PassFail result, String concentration) {
+            this(barcode, result, concentration, null);
+        }
+
+        public ExtractResultLabware(String barcode, PassFail result, Integer commentId) {
+            this(barcode, result, null, commentId);
+        }
+
+        public String getBarcode() {
+            return this.barcode;
+        }
+
+        public void setBarcode(String barcode) {
+            this.barcode = barcode;
+        }
+
+        public PassFail getResult() {
+            return this.result;
+        }
+
+        public void setResult(PassFail result) {
+            this.result = result;
+        }
+
+        public String getConcentration() {
+            return this.concentration;
+        }
+
+        public void setConcentration(String concentration) {
+            this.concentration = concentration;
+        }
+
+        public Integer getCommentId() {
+            return this.commentId;
+        }
+
+        public void setCommentId(Integer commentId) {
+            this.commentId = commentId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ExtractResultLabware that = (ExtractResultLabware) o;
+            return (Objects.equals(this.barcode, that.barcode)
+                    && this.result == that.result
+                    && Objects.equals(this.concentration, that.concentration)
+                    && Objects.equals(this.commentId, that.commentId));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(barcode, result, concentration, commentId);
+        }
+
+        @Override
+        public String toString() {
+            return BasicUtils.describe(this)
+                    .addRepr("barcode", barcode)
+                    .add("result", result)
+                    .addRepr("concentration", concentration)
+                    .add("commentId", commentId)
+                    .toString();
+        }
+    }
+
+    private List<ExtractResultLabware> labware;
+    private String workNumber;
+
+    public ExtractResultRequest() {
+        this(null, null);
+    }
+
+    public ExtractResultRequest(List<ExtractResultLabware> labware, String workNumber) {
+        setLabware(labware);
+        this.workNumber = workNumber;
+    }
+
+    public List<ExtractResultLabware> getLabware() {
+        return this.labware;
+    }
+
+    public void setLabware(List<ExtractResultLabware> labware) {
+        this.labware = (labware==null ? new ArrayList<>() : labware);
+    }
+
+    public String getWorkNumber() {
+        return this.workNumber;
+    }
+
+    public void setWorkNumber(String workNumber) {
+        this.workNumber = workNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtractResultRequest that = (ExtractResultRequest) o;
+        return (Objects.equals(this.labware, that.labware)
+                && Objects.equals(this.workNumber, that.workNumber));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labware, workNumber);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe("ExtractResultRequest")
+                .add("labware", labware)
+                .addRepr("workNumber", workNumber)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/BaseResultService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/BaseResultService.java
@@ -1,0 +1,128 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * Base class for some other result services
+ * @author dr6
+ */
+public abstract class BaseResultService {
+    protected final LabwareValidatorFactory labwareValidatorFactory;
+    protected final OperationTypeRepo opTypeRepo;
+    protected final OperationRepo opRepo;
+    protected final LabwareRepo lwRepo;
+
+    protected BaseResultService(LabwareValidatorFactory labwareValidatorFactory,
+                             OperationTypeRepo opTypeRepo, OperationRepo opRepo, LabwareRepo lwRepo) {
+        this.labwareValidatorFactory = labwareValidatorFactory;
+        this.opTypeRepo = opTypeRepo;
+        this.opRepo = opRepo;
+        this.lwRepo = lwRepo;
+    }
+
+    /**
+     * Loads an operation type by name
+     * @param problems receptacle for problems
+     * @param opTypeName the name of the op type
+     * @return the op type loaded
+     */
+    public OperationType loadOpType(Collection<String> problems, String opTypeName) {
+        Optional<OperationType> opt = opTypeRepo.findByName(opTypeName);
+        if (opt.isEmpty()) {
+            problems.add("Unknown operation type: "+repr(opTypeName));
+            return null;
+        }
+        return opt.get();
+    }
+
+    /**
+     * Loads the labware indicated by the given barcodes, using {@link LabwareValidator}.
+     * @param problems receptacle for problems
+     * @param barcodes the barcodes to load
+     * @return the labware found, mapped from their barcodes
+     */
+    public UCMap<Labware> loadLabware(Collection<String> problems, Collection<String> barcodes) {
+        LabwareValidator validator = labwareValidatorFactory.getValidator();
+        validator.loadLabware(lwRepo, barcodes);
+        problems.addAll(validator.getErrors());
+        return UCMap.from(validator.getLabware(), Labware::getBarcode);
+    }
+
+    /**
+     * This is used when making the labware-op map to decide whether the op under consideration
+     * takes precedence over the current op listed (if any)
+     * @param a the op under consideration
+     * @param b the op already listed (or null)
+     * @return True if any of the following:<ul>
+     *     <li>{@code b} is null</li>
+     *     <li>the timestamp of {@code a} is later than that of {@code b}</li>
+     *     <li>they have the same timestamp and {@code a} has a higher ID</li>
+     * </ul>
+     * False otherwise
+     */
+    public boolean supersedes(Operation a, Operation b) {
+        if (b==null) {
+            return true;
+        }
+        int c = a.getPerformed().compareTo(b.getPerformed());
+        if (c == 0) {
+            c = a.getId().compareTo(b.getId());
+        }
+        return (c > 0);
+    }
+
+    /**
+     * Makes a map of labware id to op id from the given operations.
+     * Where a labware id is linked to multiple operations, the latest op is selected.
+     * @see #supersedes(Operation, Operation)
+     * @param ops the operations
+     * @return a map of labware id to operation id
+     */
+    public Map<Integer, Integer> makeLabwareOpIdMap(Collection<Operation> ops) {
+        Map<Integer, Operation> opMap = new HashMap<>(ops.size());
+        for (Operation op : ops) {
+            Set<Integer> labwareIds = op.getActions().stream()
+                    .map(a -> a.getDestination().getLabwareId())
+                    .collect(toSet());
+            for (Integer lwId : labwareIds) {
+                if (supersedes(op, opMap.get(lwId))) {
+                    opMap.put(lwId, op);
+                }
+            }
+        }
+        return opMap.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().getId()));
+    }
+
+    /**
+     * Looks up the latest operations of the given type on each of the given labware (as the destination).
+     * If any labware do not have a matching operation, then a problem will be added that includes a list of those barcodes.
+     * Where multiple operations match for the same item of labware, {@link #supersedes} is used to determine
+     * which should be kept.
+     * @param problems receptacle for problems found
+     * @param opType the type of op to look up
+     * @param labware the labware that is the destinations of the operations
+     * @return a map from labware id to operation id
+     */
+    public Map<Integer, Integer> lookUpLatestOpIds(Collection<String> problems, OperationType opType,
+                                                   Collection<Labware> labware) {
+        Set<Integer> labwareIds = labware.stream().map(Labware::getId).collect(toSet());
+        List<Operation> ops = opRepo.findAllByOperationTypeAndDestinationLabwareIdIn(opType, labwareIds);
+        Map<Integer, Integer> opsMap = makeLabwareOpIdMap(ops);
+        List<String> unmatchedBarcodes = labware.stream()
+                .filter(lw -> !opsMap.containsKey(lw.getId()))
+                .map(Labware::getBarcode)
+                .collect(toList());
+        if (!unmatchedBarcodes.isEmpty()) {
+            problems.add("No "+opType.getName()+" operation has been recorded on the following labware: "+unmatchedBarcodes);
+        }
+        return opsMap;
+
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ConcentrationSanitiser.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ConcentrationSanitiser.java
@@ -1,0 +1,37 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Helper to validate and sanitise concentration values.
+ * A valid value is a positive or negative number with up to two 2 decimal places.
+ * The sanitised format is a plain number string (not in scientific notation) with exactly two decimal places.
+ * The string representation of the value can be at most 16 characters long, otherwise the value is invalid.
+ * @author dr6
+ */
+public class ConcentrationSanitiser implements Sanitiser<String> {
+    private static final int MAX_MEASUREMENT_VALUE_LENGTH = 16;
+
+    @Override
+    public String sanitise(String value) {
+        if (value==null || value.isEmpty()) {
+            return null;
+        }
+        try {
+            BigDecimal bd = new BigDecimal(value);
+            String string = bd.setScale(2, RoundingMode.UNNECESSARY).toString();
+            if (string.length() > MAX_MEASUREMENT_VALUE_LENGTH) {
+                return null;
+            }
+            return string;
+        } catch (NumberFormatException | ArithmeticException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String fieldName() {
+        return "concentration";
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultService.java
@@ -1,0 +1,12 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.request.ExtractResultRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+
+/**
+ * Service for recording the result for an extract op.
+ */
+public interface ExtractResultService {
+    OperationResult recordExtractResult(User user, ExtractResultRequest request) throws ValidationException;
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultServiceImp.java
@@ -1,0 +1,243 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.ExtractResultRequest;
+import uk.ac.sanger.sccp.stan.request.ExtractResultRequest.ExtractResultLabware;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.work.WorkService;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author dr6
+ */
+@Service
+public class ExtractResultServiceImp extends BaseResultService implements ExtractResultService {
+    private final Sanitiser<String> concentrationSanitiser;
+    private final WorkService workService;
+    private final CommentValidationService commentValidationService;
+    private final OperationService opService;
+    private final OperationCommentRepo opCommentRepo;
+    private final MeasurementRepo measurementRepo;
+    private final ResultOpRepo resultOpRepo;
+
+    public ExtractResultServiceImp(LabwareValidatorFactory labwareValidatorFactory,
+                                   @Qualifier("concentrationSanitiser") Sanitiser<String> concentrationSanitiser,
+                                   WorkService workService,
+                                   CommentValidationService commentValidationService, OperationService opService,
+                                   LabwareRepo lwRepo, OperationTypeRepo opTypeRepo, OperationRepo opRepo,
+                                   OperationCommentRepo opCommentRepo, MeasurementRepo measurementRepo,
+                                   ResultOpRepo resultOpRepo) {
+        super(labwareValidatorFactory, opTypeRepo, opRepo, lwRepo);
+        this.concentrationSanitiser = concentrationSanitiser;
+        this.workService = workService;
+        this.commentValidationService = commentValidationService;
+        this.opService = opService;
+        this.opCommentRepo = opCommentRepo;
+        this.measurementRepo = measurementRepo;
+        this.resultOpRepo = resultOpRepo;
+    }
+
+    @Override
+    public OperationResult recordExtractResult(User user, ExtractResultRequest request) {
+        final Collection<String> problems = new LinkedHashSet<>();
+        if (user==null) {
+            problems.add("No user specified.");
+        }
+
+        OperationType resultOpType = loadOpType(problems, "Record result");
+        UCMap<Labware> labware = validateLabware(problems, request.getLabware());
+        validateResults(problems, request.getLabware());
+        Map<Integer, Comment> commentMap = validateComments(problems, request.getLabware());
+        validateMeasurements(problems, request.getLabware());
+        Work work = workService.validateUsableWork(problems, request.getWorkNumber());
+        Map<Integer, Integer> latestExtracts = lookUpExtracts(problems, labware.values());
+
+        if (!problems.isEmpty()) {
+            throw new ValidationException("The request could not be validated.", problems);
+        }
+
+        return createResults(user, resultOpType, request.getLabware(), labware, latestExtracts, commentMap, work);
+    }
+
+    /**
+     * Loads the indicated labware and records any problems. Uses {@link #loadLabware}.
+     * @param problems receptacle for problems
+     * @param requestLabware the parts of the request that specify the labware barcodes
+     * @return the found labware mapped from their barcodes
+     */
+    public UCMap<Labware> validateLabware(Collection<String> problems, Collection<ExtractResultLabware> requestLabware) {
+        if (requestLabware.isEmpty()) {
+            problems.add("No labware specified.");
+            return new UCMap<>();
+        }
+        List<String> barcodes = requestLabware.stream().map(ExtractResultLabware::getBarcode).collect(toList());
+        return loadLabware(problems, barcodes);
+    }
+
+    /**
+     * Checks that the correct result fields are supplied for the request labware.
+     * <ul>
+     *     <li>The result field should be {@code pass} or {@code fail}</li>
+     *     <li>If the result is {@code pass}, then a concentration should be supplied, and no comment id</li>
+     *     <li>If the result is {@code fail}, then a comment id should be supplied, and no concentration</li>
+     * </ul>
+     * @param problems receptacle for problems
+     * @param labware the request labware to validate
+     */
+    public void validateResults(Collection<String> problems, Collection<ExtractResultLabware> labware) {
+        for (ExtractResultLabware erl : labware) {
+            if (erl.getResult()==null) {
+                problems.add("No result specified for labware "+erl.getBarcode()+".");
+            } else if (erl.getResult()==PassFail.pass) {
+                if (erl.getCommentId()!=null) {
+                    problems.add("Unexpected comment specified for pass on labware "+erl.getBarcode()+".");
+                }
+                if (erl.getConcentration()==null) {
+                    problems.add("No concentration specified for pass on labware "+erl.getBarcode()+".");
+                }
+            } else {
+                if (erl.getCommentId()==null) {
+                    problems.add("No comment specified for fail on labware "+erl.getBarcode()+".");
+                }
+                if (erl.getConcentration()!=null) {
+                    problems.add("Unexpected concentration specified for fail on labware "+erl.getBarcode()+".");
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the comment using {@link CommentValidationService}
+     * @param problems the receptacle for problems found
+     * @param labware the requests that include comment ids
+     * @return the comments found, mapped from their ids
+     */
+    public Map<Integer, Comment> validateComments(Collection<String> problems, Collection<ExtractResultLabware> labware) {
+        var commentIdStream = labware.stream()
+                .map(ExtractResultLabware::getCommentId)
+                .filter(Objects::nonNull);
+
+        List<Comment> comments = commentValidationService.validateCommentIds(problems, commentIdStream);
+        return comments.stream().collect(BasicUtils.toMap(Comment::getId));
+    }
+
+    /**
+     * Checks the values given for concentration using {@link ConcentrationSanitiser}.
+     * Null values in requests are skipped.
+     * @param problems receptacle for problems found
+     * @param labware the requests including the given concentration values
+     */
+    public void validateMeasurements(Collection<String> problems, Collection<ExtractResultLabware> labware) {
+        Set<String> badConcentrations = labware.stream()
+                .map(ExtractResultLabware::getConcentration)
+                .filter(value -> value!=null && !concentrationSanitiser.isValid(value))
+                .collect(BasicUtils.toLinkedHashSet());
+
+        if (!badConcentrations.isEmpty()) {
+            problems.add(String.format("Invalid %s given for concentration: %s",
+                    badConcentrations.size()==1 ? "value" : "values",
+                    badConcentrations));
+        }
+    }
+
+    /**
+     * Looks up the latest extract ops on the given labware and returns a map of labware id to extract op id.
+     * @param problems receptacle for any problems found
+     * @param labware the labware to look up
+     * @return a map of labware id to op id
+     */
+    public Map<Integer, Integer> lookUpExtracts(Collection<String> problems, Collection<Labware> labware) {
+        OperationType extractOpType = loadOpType(problems, "Extract");
+        if (extractOpType==null || labware.isEmpty()) {
+            return Map.of();
+        }
+        return lookUpLatestOpIds(problems, extractOpType, labware);
+    }
+
+    /**
+     * Records the operations, results, comments and measurements specified.
+     * Uses {@link OperationService} to record the ops.
+     * Uses {@link #addResultData} to create all the other information; then this method saves it all.
+     * @param user the user responsible for the operations
+     * @param resultOpType the type of operation to record
+     * @param erls the requests specifying what to record
+     * @param labwareMap a map to look up labware by its barcode
+     * @param latestExtracts a map to look up a prior extract op from a labware id
+     * @param commentMap a map to look up comment by its id
+     * @param work the work to link to the op (or null)
+     * @return the operations created and the labware involved
+     */
+    public OperationResult createResults(User user, OperationType resultOpType, Collection<ExtractResultLabware> erls,
+                                         UCMap<Labware> labwareMap, Map<Integer, Integer> latestExtracts,
+                                         Map<Integer, Comment> commentMap, Work work) {
+        final List<Operation> ops = new ArrayList<>(erls.size());
+        final List<ResultOp> resultOps = new ArrayList<>();
+        final List<Labware> labwareList = new ArrayList<>(erls.size());
+        final List<OperationComment> opComments = new ArrayList<>();
+        final List<Measurement> measurements = new ArrayList<>();
+        for (ExtractResultLabware erl : erls) {
+            Labware lw = labwareMap.get(erl.getBarcode());
+            labwareList.add(lw);
+            Operation op = opService.createOperationInPlace(resultOpType, user, lw, null, null);
+            ops.add(op);
+            Integer refersToOpId = latestExtracts.get(lw.getId());
+            String concentrationValue = (erl.getConcentration()==null ? null : concentrationSanitiser.sanitise(erl.getConcentration()));
+            for (Slot slot : lw.getSlots()) {
+                for (Sample sample : slot.getSamples()) {
+                    addResultData(resultOps, opComments, measurements, erl, commentMap, op.getId(), refersToOpId,
+                            concentrationValue, slot.getId(), sample.getId());
+                }
+            }
+        }
+        resultOpRepo.saveAll(resultOps);
+        if (!opComments.isEmpty()) {
+            opCommentRepo.saveAll(opComments);
+        }
+        if (!measurements.isEmpty()) {
+            measurementRepo.saveAll(measurements);
+        }
+        if (work != null) {
+            workService.link(work, ops);
+        }
+        return new OperationResult(ops, labwareList);
+    }
+
+    /**
+     * Adds new unsaved results, op-comments and measurements to the given lists as appropriate for the given request.
+     * @param resultOps receptacle for result ops
+     * @param opComments receptacle for op-comments
+     * @param measurements receptacle for measurements
+     * @param erl the request details for the labware
+     * @param commentMap a map to look up comments by their id
+     * @param resultOpId the new operation to link the data to
+     * @param refersToOpId the previous operation the results are linked to
+     * @param concentration the sanitised value to record for concentration (or null)
+     * @param slotId the id of the slot
+     * @param sampleId the id of the sample
+     */
+    public void addResultData(final Collection<ResultOp> resultOps, final Collection<OperationComment> opComments,
+                              final Collection<Measurement> measurements, ExtractResultLabware erl,
+                              Map<Integer, Comment> commentMap, Integer resultOpId, Integer refersToOpId,
+                              String concentration, Integer slotId, Integer sampleId) {
+        ResultOp ro = new ResultOp(null, erl.getResult(), resultOpId, sampleId, slotId, refersToOpId);
+        resultOps.add(ro);
+        if (concentration!=null) {
+            Measurement measurement = new Measurement(null, "Concentration", concentration, sampleId,
+                    resultOpId, slotId);
+            measurements.add(measurement);
+        }
+        if (erl.getCommentId()!=null) {
+            Comment comment = commentMap.get(erl.getCommentId());
+            OperationComment opCom = new OperationComment(null, comment, resultOpId, sampleId, slotId, null);
+            opComments.add(opCom);
+        }
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ResultServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ResultServiceImp.java
@@ -14,18 +14,13 @@ import uk.ac.sanger.sccp.utils.UCMap;
 
 import java.util.*;
 
-import static java.util.stream.Collectors.*;
-import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+import static java.util.stream.Collectors.toList;
 
 @Service
-public class ResultServiceImp implements ResultService {
-    private final OperationTypeRepo opTypeRepo;
-    private final LabwareRepo lwRepo;
-    private final OperationRepo opRepo;
+public class ResultServiceImp extends BaseResultService implements ResultService {
     private final OperationCommentRepo opCommentRepo;
     private final ResultOpRepo resOpRepo;
 
-    private final LabwareValidatorFactory labwareValidatorFactory;
     private final OperationService opService;
     private final WorkService workService;
     private final CommentValidationService commentValidationService;
@@ -36,12 +31,9 @@ public class ResultServiceImp implements ResultService {
                             LabwareValidatorFactory labwareValidatorFactory,
                             OperationService opService, WorkService workService,
                             CommentValidationService commentValidationService) {
-        this.opTypeRepo = opTypeRepo;
-        this.lwRepo = lwRepo;
-        this.opRepo = opRepo;
+        super(labwareValidatorFactory, opTypeRepo, opRepo, lwRepo);
         this.opCommentRepo = opCommentRepo;
         this.resOpRepo = resOpRepo;
-        this.labwareValidatorFactory = labwareValidatorFactory;
         this.opService = opService;
         this.workService = workService;
         this.commentValidationService = commentValidationService;
@@ -58,28 +50,13 @@ public class ResultServiceImp implements ResultService {
         validateLabwareContents(problems, labware, request.getLabwareResults());
         Map<Integer, Comment> commentMap = validateComments(problems, request.getLabwareResults());
         Work work = workService.validateUsableWork(problems, request.getWorkNumber());
-        Map<Integer, Integer> latestStain = lookUpStains(problems, labware.values());
+        Map<Integer, Integer> latestStains = lookUpStains(problems, labware.values());
 
         if (!problems.isEmpty()) {
             throw new ValidationException("The result request could not be validated.", problems);
         }
 
-        return createResults(user, opType, request.getLabwareResults(), labware, latestStain, commentMap, work);
-    }
-
-    /**
-     * Loads an operation type by name
-     * @param problems receptacle for problems
-     * @param opTypeName the name of the op type
-     * @return the op type loaded
-     */
-    public OperationType loadOpType(Collection<String> problems, String opTypeName) {
-        Optional<OperationType> opt = opTypeRepo.findByName(opTypeName);
-        if (opt.isEmpty()) {
-            problems.add("Unknown operation type: "+repr(opTypeName));
-            return null;
-        }
-        return opt.get();
+        return createResults(user, opType, request.getLabwareResults(), labware, latestStains, commentMap, work);
     }
 
     /**
@@ -88,14 +65,11 @@ public class ResultServiceImp implements ResultService {
      * @param labwareResults the requested labware results
      * @return a map of labware from its barcode
      */
-    public UCMap<Labware> validateLabware(Collection<String> problems, Collection<LabwareResult> labwareResults) {
-        LabwareValidator validator = labwareValidatorFactory.getValidator();
+    public UCMap<Labware> validateLabware(Collection<String> problems, Collection<ResultRequest.LabwareResult> labwareResults) {
         List<String> barcodes = labwareResults.stream()
-                .map(LabwareResult::getBarcode)
+                .map(ResultRequest.LabwareResult::getBarcode)
                 .collect(toList());
-        validator.loadLabware(lwRepo, barcodes);
-        problems.addAll(validator.getErrors());
-        return UCMap.from(validator.getLabware(), Labware::getBarcode);
+        return loadLabware(problems, barcodes);
     }
 
     /**
@@ -202,62 +176,7 @@ public class ResultServiceImp implements ResultService {
         if (stainOpType==null || labware.isEmpty()) {
             return Map.of();
         }
-        Set<Integer> labwareIds = labware.stream().map(Labware::getId).collect(toSet());
-        List<Operation> ops = opRepo.findAllByOperationTypeAndDestinationLabwareIdIn(stainOpType, labwareIds);
-        Map<Integer, Integer> opsMap = makeLabwareOpIdMap(ops);
-        List<String> unstainedBarcodes = labware.stream()
-                .filter(lw -> !opsMap.containsKey(lw.getId()))
-                .map(Labware::getBarcode)
-                .collect(toList());
-        if (!unstainedBarcodes.isEmpty()) {
-            problems.add("No stain has been recorded on the following labware: "+unstainedBarcodes);
-        }
-        return opsMap;
-    }
-
-    /**
-     * This is used when making the labware-op map to decide whether the op under consideration
-     * takes precedence over the current op listed (if any)
-     * @param a the op under consideration
-     * @param b the op already listed (or null)
-     * @return True if any of the following:<ul>
-     *     <li>{@code b} is null</li>
-     *     <li>the timestamp of {@code a} is later than that of {@code b}</li>
-     *     <li>they have the same timestamp and {@code a} has a higher ID</li>
-     * </ul>
-     * False otherwise
-     */
-    public boolean supersedes(Operation a, Operation b) {
-        if (b==null) {
-            return true;
-        }
-        int c = a.getPerformed().compareTo(b.getPerformed());
-        if (c == 0) {
-            c = a.getId().compareTo(b.getId());
-        }
-        return (c > 0);
-    }
-
-    /**
-     * Makes a map of labware id to op id from the given operations.
-     * Where a labware id is linked to multiple operations, the latest op is selected.
-     * @see #supersedes(Operation, Operation)
-     * @param ops the operations
-     * @return a map of labware id to operation id
-     */
-    public Map<Integer, Integer> makeLabwareOpIdMap(Collection<Operation> ops) {
-        Map<Integer, Operation> opMap = new HashMap<>(ops.size());
-        for (Operation op : ops) {
-            Set<Integer> labwareIds = op.getActions().stream()
-                    .map(a -> a.getDestination().getLabwareId())
-                    .collect(toSet());
-            for (Integer lwId : labwareIds) {
-                if (supersedes(op, opMap.get(lwId))) {
-                    opMap.put(lwId, op);
-                }
-            }
-        }
-        return opMap.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().getId()));
+        return lookUpLatestOpIds(problems, stainOpType, labware);
     }
 
     /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/Sanitiser.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/Sanitiser.java
@@ -1,0 +1,53 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import java.util.Collection;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * A utility to perform sanitisation: that is, to give a sanitised version of a given value.
+ * @param <E>
+ */
+public interface Sanitiser<E> {
+    /**
+     * Puts a value into the sanitised form.
+     * @param value the value to sanitise
+     * @return the sanitised value; or null if the given value is invalid
+     */
+    E sanitise(E value);
+
+    /**
+     * Puts the value into the sanitised form.
+     * If it fails, adds a problem to the given receptacle.
+     * The default problem is not very descriptive.
+     * @param problems receptacle for problems (optional)
+     * @param value the value to sanitise
+     * @return the sanitised value; or null if the given value is invalid
+     */
+    default E sanitise(Collection<String> problems, E value) {
+        E san = this.sanitise(value);
+        if (san==null && problems!=null) {
+            problems.add("Invalid " + this.fieldName()+": "+repr(value));
+        }
+        return san;
+    }
+
+    /**
+     * This string is used in the {@link #sanitise(Collection, E)} method to generate a problem message.
+     * By default, this method returns the string {@code "value"}.
+     * @return a name for the field being sanitised
+     */
+    default String fieldName() {
+        return "value";
+    }
+
+    /**
+     * Is the value valid?
+     * This method tries to {@link #sanitise} the value to determine if it is valid.
+     * @param value the given value
+     * @return true if the sanitisation succeeds; false if it fails
+     */
+    default boolean isValid(E value) {
+        return sanitise(value) != null;
+    }
+}

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -561,6 +561,18 @@ input ResultRequest {
     workNumber: String
 }
 
+input ExtractResultLabware {
+    barcode: String!
+    result: PassFail!
+    concentration: String
+    commentId: Int
+}
+
+input ExtractResultRequest {
+    labware: [ExtractResultLabware!]!
+    workNumber: String
+}
+
 type Query {
     user: User
     tissueTypes: [TissueType!]!
@@ -636,6 +648,7 @@ type Mutation {
     stain(request: StainRequest!): OperationResult!
     recordInPlace(request: InPlaceOpRequest!): OperationResult!
     recordStainResult(request: ResultRequest!): OperationResult!
+    recordExtractResult(request: ExtractResultRequest!): OperationResult!
 
     addUser(username: String!): User!
     setUserRole(username: String!, role: UserRole!): User!

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestConcentrationSanitiser.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestConcentrationSanitiser.java
@@ -1,0 +1,61 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests {@link ConcentrationSanitiser}
+ * @author dr6
+ */
+public class TestConcentrationSanitiser {
+    private final ConcentrationSanitiser sanitiser = new ConcentrationSanitiser();
+
+    static Stream<Arguments> sanitiserData() {
+        return Arrays.stream(new String[][] {
+                {null, null},
+                {"", null},
+                {"  ", null},
+                {"-", null},
+                {"Hello", null},
+                {"-500", "-500.00"},
+                {"-1234567890.220000000000", "-1234567890.22"},
+                {"+411.5", "411.50"},
+                {"11.50E6", "11500000.00"},
+                {"24E14", null},
+                {"0001234567890123", "1234567890123.00"},
+                {"12345678901234", null},
+        }).map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("sanitiserData")
+    public void testSanitise(String input, String expected) {
+        assertEquals(expected, sanitiser.sanitise(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("sanitiserData")
+    public void testIsValid(String input, String expected) {
+        assertEquals(expected!=null, sanitiser.isValid(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("sanitiserData")
+    public void testSanitiseWithProblems(String input, String expected) {
+        List<String> problems = new ArrayList<>(expected==null ? 1 : 0);
+        assertEquals(expected, sanitiser.sanitise(problems, input));
+        if (expected==null) {
+            assertThat(problems).containsExactly(input==null ? "Invalid concentration: null"
+                    : "Invalid concentration: \""+input+"\"");
+        } else {
+            assertThat(problems).isEmpty();
+        }
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestExtractResultService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestExtractResultService.java
@@ -1,0 +1,380 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.ExtractResultRequest;
+import uk.ac.sanger.sccp.stan.request.ExtractResultRequest.ExtractResultLabware;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.work.WorkService;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link ExtractResultServiceImp}
+ * @author dr6
+ */
+public class TestExtractResultService {
+    private LabwareValidatorFactory mockLabwareValidatorFactory;
+    private Sanitiser<String> mockConcentrationSanitiser;
+    private WorkService mockWorkService;
+    private CommentValidationService mockCommentValidationService;
+    private OperationService mockOpService;
+    private LabwareRepo mockLwRepo;
+    private OperationCommentRepo mockOpCommentRepo;
+    private MeasurementRepo mockMeasurementRepo;
+    private ResultOpRepo mockResultOpRepo;
+
+    private ExtractResultServiceImp service;
+
+    @BeforeEach
+    void setup() {
+        mockLabwareValidatorFactory = mock(LabwareValidatorFactory.class);
+        //noinspection unchecked
+        mockConcentrationSanitiser = mock(Sanitiser.class);
+        mockWorkService = mock(WorkService.class);
+        mockCommentValidationService = mock(CommentValidationService.class);
+        mockOpService = mock(OperationService.class);
+        mockLwRepo = mock(LabwareRepo.class);
+        OperationTypeRepo mockOpTypeRepo = mock(OperationTypeRepo.class);
+        OperationRepo mockOpRepo = mock(OperationRepo.class);
+        mockOpCommentRepo = mock(OperationCommentRepo.class);
+        mockMeasurementRepo = mock(MeasurementRepo.class);
+        mockResultOpRepo = mock(ResultOpRepo.class);
+
+        service = spy(new ExtractResultServiceImp(mockLabwareValidatorFactory, mockConcentrationSanitiser,
+                mockWorkService, mockCommentValidationService, mockOpService, mockLwRepo, mockOpTypeRepo,
+                mockOpRepo, mockOpCommentRepo, mockMeasurementRepo, mockResultOpRepo));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false, true})
+    public void testRecordExtractResult(boolean succeeds) {
+        OperationType opType = new OperationType(1, "Record result");
+        doReturn(opType).when(service).loadOpType(anyCollection(), any());
+        Labware lw = EntityFactory.getTube();
+        UCMap<Labware> lwMap = UCMap.from(Labware::getBarcode, lw);
+        doReturn(lwMap).when(service).loadLabware(anyCollection(), any());
+        doNothing().when(service).validateResults(anyCollection(), any());
+        Map<Integer, Comment> commentMap = Map.of(7, new Comment(7, "Bananas", "fruit"));
+        doReturn(commentMap).when(service).validateComments(anyCollection(), any());
+        doNothing().when(service).validateMeasurements(anyCollection(), any());
+        final String workNumber = "SGP50";
+        Work work = new Work(4, workNumber, null, null, null, Work.Status.active);
+        doReturn(work).when(mockWorkService).validateUsableWork(anyCollection(), any());
+        Map<Integer, Integer> extractMap = Map.of(44,55);
+        doReturn(extractMap).when(service).lookUpExtracts(anyCollection(), any());
+
+        List<ExtractResultLabware> erls = List.of(
+                new ExtractResultLabware(lw.getBarcode(), PassFail.pass, 7)
+        );
+        ExtractResultRequest request = new ExtractResultRequest(erls, workNumber);
+
+        if (succeeds) {
+            User user = EntityFactory.getUser();
+            OperationResult opRes = new OperationResult(List.of(), List.of(lw));
+            doReturn(opRes).when(service).createResults(any(), any(), any(), any(), any(), any(), any());
+
+            assertSame(opRes, service.recordExtractResult(user, request));
+            verify(service).createResults(user, opType, erls, lwMap, extractMap, commentMap, work);
+        } else {
+            ValidationException ex = assertThrows(ValidationException.class, () ->
+                    service.recordExtractResult(null, request));
+            assertThat(ex).hasMessage("The request could not be validated.");
+            //noinspection unchecked
+            assertThat((Collection<Object>) ex.getProblems()).containsExactly("No user specified.");
+            verify(service, never()).createResults(any(), any(), any(), any(), any(), any(), any());
+        }
+
+        //noinspection unchecked
+        ArgumentCaptor<Collection<String>> problemsCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(service).loadOpType(problemsCaptor.capture(), eq("Record result"));
+        Collection<String> problems = problemsCaptor.getValue();
+        assertNotNull(problems);
+        verify(service).validateLabware(same(problems), eq(erls));
+        verify(service).validateResults(same(problems), eq(erls));
+        verify(service).validateComments(same(problems), eq(erls));
+        verify(service).validateMeasurements(same(problems), eq(erls));
+        verify(service).lookUpExtracts(same(problems), eq(lwMap.values()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false, true})
+    public void testValidateLabware(boolean any) {
+        List<String> problems = new ArrayList<>(1);
+        if (!any) {
+            assertThat(service.validateLabware(problems, List.of())).isEmpty();
+            assertThat(problems).containsExactly("No labware specified.");
+            verifyNoInteractions(mockLabwareValidatorFactory);
+            return;
+        }
+        LabwareValidator val = mock(LabwareValidator.class);
+        when(mockLabwareValidatorFactory.getValidator()).thenReturn(val);
+        String lwError = "Bears broke it.";
+        when(val.getErrors()).thenReturn(List.of(lwError));
+        Labware lw1 = EntityFactory.getTube();
+        Labware lw2 = EntityFactory.makeEmptyLabware(lw1.getLabwareType());
+        when(val.getLabware()).thenReturn(List.of(lw1, lw2));
+        List<ExtractResultLabware> erls = List.of(
+                new ExtractResultLabware(lw1.getBarcode(), null, null, null),
+                new ExtractResultLabware(lw2.getBarcode(), null, null, null)
+        );
+        UCMap<Labware> lwMap = service.validateLabware(problems, erls);
+        assertThat(lwMap.values()).containsExactlyInAnyOrder(lw1, lw2);
+        assertThat(problems).containsExactly(lwError);
+        verify(val).loadLabware(mockLwRepo, List.of(lw1.getBarcode(), lw2.getBarcode()));
+    }
+
+    @Test
+    public void testValidateResults() {
+        List<ExtractResultLabware> erls = List.of(
+                new ExtractResultLabware("STAN-1", PassFail.pass, "10.1"),
+                new ExtractResultLabware("STAN-2", PassFail.fail, 2),
+                new ExtractResultLabware("STAN-3", null, null, null),
+                new ExtractResultLabware("STAN-4", PassFail.pass, "40.1", 4),
+                new ExtractResultLabware("STAN-5", PassFail.fail, "50.1", 5),
+                new ExtractResultLabware("STAN-6", PassFail.pass, null, null),
+                new ExtractResultLabware("STAN-7", PassFail.fail, null, null)
+        );
+        List<String> problems = new ArrayList<>(5);
+        service.validateResults(problems, erls);
+
+        assertThat(problems).containsExactlyInAnyOrder(
+                "No result specified for labware STAN-3.",
+                "Unexpected comment specified for pass on labware STAN-4.",
+                "No concentration specified for pass on labware STAN-6.",
+                "No comment specified for fail on labware STAN-7.",
+                "Unexpected concentration specified for fail on labware STAN-5."
+        );
+    }
+
+    @Test
+    public void testValidateComments() {
+        List<ExtractResultLabware> erls = List.of(
+                new ExtractResultLabware("STAN-1", PassFail.pass, "11.5"),
+                new ExtractResultLabware("STAN-1", PassFail.fail, 14),
+                new ExtractResultLabware("STAN-1", PassFail.fail, 15)
+        );
+        final Comment com1 = new Comment(14, "Custard", "vegetables");
+        final Comment com2 = new Comment(15, "Crumble", "vitamins");
+        when(mockCommentValidationService.validateCommentIds(any(), any())).then(invocation -> {
+            Collection<String> problems = invocation.getArgument(0);
+            Stream<Integer> ids = invocation.getArgument(1);
+            problems.add("Bad comment ids: "+ids.collect(toList()));
+            return List.of(com1, com2);
+        });
+        List<String> problems = new ArrayList<>(1);
+
+        Map<Integer, Comment> commentMap = service.validateComments(problems, erls);
+
+        assertThat(commentMap).containsExactlyInAnyOrderEntriesOf(Map.of(com1.getId(), com1, com2.getId(), com2));
+        assertThat(problems).containsExactly("Bad comment ids: [14, 15]");
+        verify(mockCommentValidationService).validateCommentIds(any(), any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testValidateMeasurements(boolean anyBad) {
+        when(mockConcentrationSanitiser.isValid(any())).then(invocation -> {
+            String string = invocation.getArgument(0);
+            return (string!=null && string.indexOf('!') < 0);
+        });
+        List<String> problems = new ArrayList<>(anyBad ? 1 : 0);
+        List<String> concs;
+        if (anyBad) {
+            concs = Arrays.asList("5.5", null, "!alpha", "6.5", null, "!beta", "7.6");
+        } else {
+            concs = Arrays.asList("5.5", null, "6.5", null, "7.6");
+        }
+        List<ExtractResultLabware> erls = concs.stream()
+                .map(conc -> new ExtractResultLabware("STAN-X", PassFail.pass, conc))
+                .collect(toList());
+
+        service.validateMeasurements(problems, erls);
+
+        if (anyBad) {
+            assertThat(problems).containsOnly("Invalid values given for concentration: [!alpha, !beta]");
+        } else {
+            assertThat(problems).isEmpty();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings={"No such op type.", "Missing ops.", "No labware.", "No problem."})
+    public void testLookUpExtracts(String condition) {
+        boolean opTypeExists = true;
+        boolean anyLabware = true;
+        boolean allFine = true;
+        final String opTypeError = "No such op type.";
+        final String opError = "Missing ops.";
+        final String noLw = "No labware.";
+        final String noProblem = "No problem.";
+        switch (condition) {
+            case opTypeError: opTypeExists = false; break;
+            case noLw: anyLabware = false; break;
+            case opError: allFine = false; break;
+            case noProblem: break;
+            default: throw new IllegalArgumentException("Unexpected condition: "+condition);
+        }
+        OperationType opType;
+        if (opTypeExists) {
+            opType = new OperationType(5, "Extract");
+            doReturn(opType).when(service).loadOpType(any(), any());
+        } else {
+            opType = null;
+            doAnswer(invocation -> {
+                Collection<String> problems = invocation.getArgument(0);
+                problems.add(opTypeError);
+                return null;
+            }).when(service).loadOpType(any(), any());
+        }
+
+        List<Labware> lwList;
+        if (anyLabware) {
+            lwList = List.of(EntityFactory.getTube());
+        } else {
+            lwList = List.of();
+        }
+        Map<Integer, Integer> idMap;
+        if (opTypeExists && anyLabware) {
+            idMap = Map.of(4, 5);
+            if (allFine) {
+                doReturn(idMap).when(service).lookUpLatestOpIds(any(), any(), any());
+            } else {
+                doAnswer(invocation -> {
+                    Collection<String> problems = invocation.getArgument(0);
+                    problems.add(opError);
+                    return idMap;
+                }).when(service).lookUpLatestOpIds(any(), any(), any());
+            }
+        } else {
+            idMap = Map.of();
+        }
+
+        List<String> problems = new ArrayList<>(1);
+
+        Map<Integer, Integer> result = service.lookUpExtracts(problems, lwList);
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(idMap);
+
+        verify(service).loadOpType(problems, "Extract");
+        if (!opTypeExists) {
+            assertThat(problems).containsExactly(opTypeError);
+        } else if (allFine) {
+            assertThat(problems).isEmpty();
+        } else {
+            assertThat(problems).containsExactly(opError);
+        }
+
+        if (opTypeExists && anyLabware) {
+            verify(service).lookUpLatestOpIds(problems, opType, lwList);
+        } else {
+            verify(service, never()).lookUpLatestOpIds(any(), any(), any());
+        }
+    }
+
+    @Test
+    public void testCreateResults() {
+        Sample sample = EntityFactory.getSample();
+        Labware lw1 = EntityFactory.makeLabware(EntityFactory.getTubeType(), sample);
+        Labware lw2 = EntityFactory.makeLabware(lw1.getLabwareType(), sample);
+        int sampleId = sample.getId();
+        int slot1id = lw1.getFirstSlot().getId();
+        int slot2id = lw2.getFirstSlot().getId();
+        UCMap<Labware> lwMap = UCMap.from(Labware::getBarcode, lw1, lw2);
+        Map<Integer, Integer> extractMap = Map.of(lw1.getId(), 400, lw2.getId(), 401);
+        final Comment comment = new Comment(17, "pi", "greek");
+        Map<Integer, Comment> commentMap = Map.of(comment.getId(), comment);
+        Work work = new Work(5, "SGP50", null, null, null, Work.Status.active);
+        OperationType resultOpType = new OperationType(5, "Record result");
+        User user = EntityFactory.getUser();
+        List<ExtractResultLabware> erls = List.of(
+                new ExtractResultLabware(lw1.getBarcode(), PassFail.pass, "55"),
+                new ExtractResultLabware(lw2.getBarcode(), PassFail.fail, 17)
+        );
+        Operation op1 = new Operation(21, resultOpType, null, null, null);
+        Operation op2 = new Operation(22, resultOpType, null, null, null);
+
+        when(mockConcentrationSanitiser.sanitise("55")).thenReturn("55.00");
+
+        when(mockOpService.createOperationInPlace(resultOpType, user, lw1, null, null))
+                .thenReturn(op1);
+        when(mockOpService.createOperationInPlace(resultOpType, user, lw2, null, null))
+                .thenReturn(op2);
+
+        // NB we let addResultData run, because that's easier than mocking it
+
+        OperationResult result = service.createResults(user, resultOpType, erls, lwMap, extractMap, commentMap, work);
+        assertThat(result.getOperations()).containsExactly(op1, op2);
+        assertThat(result.getLabware()).containsExactly(lw1, lw2);
+
+        verify(service).addResultData(anyCollection(), anyCollection(), anyCollection(), same(erls.get(0)),
+                same(commentMap), eq(op1.getId()), eq(400), eq("55.00"), eq(slot1id), eq(sampleId));
+        verify(service).addResultData(anyCollection(), anyCollection(), anyCollection(), same(erls.get(1)),
+                same(commentMap), eq(op2.getId()), eq(401), isNull(), eq(slot2id), eq(sampleId));
+
+        verify(service, times(2)).addResultData(any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any());
+
+        verify(mockResultOpRepo).saveAll(List.of(
+                new ResultOp(null, PassFail.pass, op1.getId(), sampleId, slot1id, 400),
+                new ResultOp(null, PassFail.fail, op2.getId(), sampleId, slot2id, 401)
+        ));
+        verify(mockOpCommentRepo).saveAll(List.of(
+                new OperationComment(null, comment, op2.getId(), sampleId, slot2id, null)
+        ));
+        verify(mockMeasurementRepo).saveAll(List.of(
+                new Measurement(null, "Concentration", "55.00", sampleId, op1.getId(), slot1id)
+        ));
+        verify(mockWorkService).link(work, List.of(op1, op2));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value={
+            "pass,,",
+            "pass,55.00,",
+            "fail,,4",
+    })
+    public void testAddResultData(PassFail pf, String concentrationValue, Integer commentId) {
+        List<ResultOp> ros = new ArrayList<>(1);
+        List<OperationComment> opComs = new ArrayList<>(commentId==null ? 0 : 1);
+        List<Measurement> measurements = new ArrayList<>(concentrationValue==null ? 0 : 1);
+
+        ExtractResultLabware erl = new ExtractResultLabware("STAN-1", pf, concentrationValue==null ? null : "splf", commentId);
+        Comment comment = (commentId==null ? null : new Comment(commentId, "Alpha", "Alabama"));
+        Map<Integer, Comment> commentMap = (commentId==null ? Map.of() : Map.of(commentId, comment));
+
+        Integer resultOpId = 40;
+        Integer refersToOpId = 30;
+        Integer slotId = 500;
+        Integer sampleId = 100;
+
+        service.addResultData(ros, opComs, measurements, erl, commentMap, resultOpId, refersToOpId, concentrationValue,
+                slotId, sampleId);
+
+        assertThat(ros).containsExactly(new ResultOp(null, pf, resultOpId, sampleId, slotId, refersToOpId));
+        if (concentrationValue!=null) {
+            assertThat(measurements).containsExactly(new Measurement(null, "Concentration", concentrationValue,
+                    sampleId, resultOpId, slotId));
+        } else {
+            assertThat(measurements).isEmpty();
+        }
+        if (commentId!=null) {
+            assertThat(opComs).containsExactly(new OperationComment(null, comment, resultOpId, sampleId, slotId, null));
+        } else {
+            assertThat(opComs).isEmpty();
+        }
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestResultService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestResultService.java
@@ -408,7 +408,7 @@ public class TestResultService {
         verify(service).makeLabwareOpIdMap(ops);
 
         if (anyUnstained) {
-            assertThat(problems).containsExactly("No stain has been recorded on the following labware: [STAN-U]");
+            assertThat(problems).containsExactly("No Stain operation has been recorded on the following labware: [STAN-U]");
         } else {
             assertThat(problems).isEmpty();
         }

--- a/src/test/resources/graphql/extract_result.graphql
+++ b/src/test/resources/graphql/extract_result.graphql
@@ -1,0 +1,21 @@
+mutation {
+    recordExtractResult(request: {
+        labware: [
+            {
+                barcode: "$BARCODE1$"
+                result: pass
+                concentration: "-200"
+            }
+            {
+                barcode: "$BARCODE2$"
+                result: fail
+                commentId: 1
+            }
+        ]
+    }) {
+        operations {
+            operationType { name }
+            id
+        }
+    }
+}


### PR DESCRIPTION
A result specifies a pass with a concentration, or a fail with a reason,
for each specified item of labware. The concentration will be recorded
as a measurement. The reason is recorded as a comment. The pass/fail is
recorded as a result (ResultOp).

New comment category "extract result" set up in static data patch.

I accidentally merged the first pull request for this, so I reset devel and opened a new one.