### PR TITLE
x753 save labware location before release

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Release.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Release.java
@@ -1,8 +1,8 @@
 package uk.ac.sanger.sccp.stan.model;
 
-import com.google.common.base.MoreObjects;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.GenerationTime;
+import uk.ac.sanger.sccp.utils.BasicUtils;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -38,13 +38,25 @@ public class Release {
 
     private Integer snapshotId;
 
+    private String locationBarcode;
+
+    @AttributeOverrides({
+            @AttributeOverride(name = "row", column = @Column(name = "storage_row")),
+            @AttributeOverride(name = "column", column = @Column(name = "storage_col"))
+    })
+    @Embedded
+    private Address storageAddress;
+
     public Release() {}
 
     public Release(Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient, Integer snapshotId) {
-        this(null, labware, user, destination, recipient, snapshotId, null);
+        this(null, labware, user, destination, recipient, snapshotId, null, null, null);
     }
-
     public Release(Integer id, Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient, Integer snapshotId, LocalDateTime released) {
+        this(id, labware, user, destination, recipient, snapshotId, released, null, null);
+    }
+    public Release(Integer id, Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient,
+                   Integer snapshotId, LocalDateTime released, String locationBarcode, Address storageAddress) {
         this.id = id;
         this.labware = labware;
         this.user = user;
@@ -52,6 +64,8 @@ public class Release {
         this.recipient = recipient;
         this.released = released;
         this.snapshotId = snapshotId;
+        this.locationBarcode = locationBarcode;
+        this.storageAddress = storageAddress;
     }
 
     public Integer getId() {
@@ -110,6 +124,22 @@ public class Release {
         this.snapshotId = snapshotId;
     }
 
+    public String getLocationBarcode() {
+        return this.locationBarcode;
+    }
+
+    public void setLocationBarcode(String locationBarcode) {
+        this.locationBarcode = locationBarcode;
+    }
+
+    public Address getStorageAddress() {
+        return this.storageAddress;
+    }
+
+    public void setStorageAddress(Address storageAddress) {
+        this.storageAddress = storageAddress;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -121,7 +151,10 @@ public class Release {
                 && Objects.equals(this.recipient, that.recipient)
                 && Objects.equals(this.released, that.released)
                 && Objects.equals(this.user, that.user)
-                && Objects.equals(this.snapshotId, that.snapshotId));
+                && Objects.equals(this.snapshotId, that.snapshotId)
+                && Objects.equals(this.locationBarcode, that.locationBarcode)
+                && Objects.equals(this.storageAddress, that.storageAddress)
+        );
     }
 
     @Override
@@ -131,7 +164,7 @@ public class Release {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
+        return BasicUtils.describe(this)
                 .add("id", id)
                 .add("labware", labware==null ? null : repr(labware.getBarcode()))
                 .add("user", user==null ? null : repr(user.getUsername()))
@@ -139,6 +172,8 @@ public class Release {
                 .add("recipient", recipient)
                 .add("released", released)
                 .add("snapshotId", snapshotId)
+                .addReprIfNotNull("locationBarcode", locationBarcode)
+                .addIfNotNull("storageAddress", storageAddress)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/store/BasicLocation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/store/BasicLocation.java
@@ -1,0 +1,56 @@
+package uk.ac.sanger.sccp.stan.model.store;
+
+import uk.ac.sanger.sccp.stan.model.Address;
+
+import java.util.Objects;
+
+/**
+ * The location barcode and item address (if any) of an item in storage.
+ * @author dr6
+ */
+public class BasicLocation {
+    private String barcode;
+    private Address address;
+
+    public BasicLocation() {}
+
+    public BasicLocation(String barcode, Address address) {
+        this.barcode = barcode;
+        this.address = address;
+    }
+
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    public Address getAddress() {
+        return this.address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BasicLocation that = (BasicLocation) o;
+        return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.address, that.address));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(barcode, address);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(%s:%s)", barcode, address);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
@@ -1,10 +1,12 @@
 package uk.ac.sanger.sccp.stan.service.releasefile;
 
 import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.utils.BasicUtils;
 
 import java.util.Objects;
 
 /**
+ * A helper data type used to return information about releases to be put into a file
  * @author dr6
  */
 public class ReleaseEntry {
@@ -18,9 +20,14 @@ public class ReleaseEntry {
     private Address storageAddress;
 
     public ReleaseEntry(Labware labware, Slot slot, Sample sample) {
+        this(labware, slot, sample, null);
+    }
+
+    public ReleaseEntry(Labware labware, Slot slot, Sample sample, Address storageAddress) {
         this.labware = labware;
         this.slot = slot;
         this.sample = sample;
+        this.storageAddress = storageAddress;
     }
 
     public Labware getLabware() {
@@ -93,5 +100,18 @@ public class ReleaseEntry {
     @Override
     public int hashCode() {
         return Objects.hash(slot, sample);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe("ReleaseEntry")
+                .add("labware", labware==null ? null : labware.getBarcode())
+                .add("sample", sample==null ? null : sample.getId())
+                .add("lastSection", lastSection)
+                .add("sourceBarcode", sourceBarcode)
+                .add("sourceAddress", sourceAddress)
+                .add("sectionThickness", sectionThickness)
+                .add("storageAddress", storageAddress)
+                .toString();
     }
 }

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -939,6 +939,15 @@
             <column name="snapshot_id" type="INT">
                 <constraints nullable="false" foreignKeyName="fk_labware_release_snapshot" referencedTableName="snapshot" referencedColumnNames="id"/>
             </column>
+            <column name="location_barcode" type="VARCHAR(16)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="storage_row" type="INT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="storage_col" type="INT">
+                <constraints nullable="true"/>
+            </column>
             <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>

--- a/src/main/resources/storelight/storedBasicLocation.graphql
+++ b/src/main/resources/storelight/storedBasicLocation.graphql
@@ -1,0 +1,7 @@
+{
+    stored(barcodes: []) {
+        barcode
+        address
+        location { barcode }
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/IntegrationTests.java
@@ -17,8 +17,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.ac.sanger.sccp.stan.model.*;
-import uk.ac.sanger.sccp.stan.model.store.Location;
-import uk.ac.sanger.sccp.stan.model.store.StoredItem;
+import uk.ac.sanger.sccp.stan.model.store.*;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.service.label.LabelPrintRequest;
 import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData;
@@ -26,6 +25,7 @@ import uk.ac.sanger.sccp.stan.service.label.LabwareLabelData.LabelContent;
 import uk.ac.sanger.sccp.stan.service.label.print.PrintClient;
 import uk.ac.sanger.sccp.stan.service.store.StorelightClient;
 import uk.ac.sanger.sccp.utils.GraphQLClient.GraphQLResponse;
+import uk.ac.sanger.sccp.utils.UCMap;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
@@ -333,6 +333,10 @@ public class IntegrationTests {
                 .replace("RECIPIENT", recipient.getUsername());
 
         stubStorelightUnstore();
+        UCMap<BasicLocation> basicLocationMap = new UCMap<>(2);
+        basicLocationMap.put("STAN-001", new BasicLocation("STO-1", new Address(1,2)));
+        basicLocationMap.put("STAN-002", new BasicLocation("STO-1", new Address(3,4)));
+        stubStorelightBasicLocation(basicLocationMap);
 
         Object result = tester.post(mutation);
 
@@ -353,14 +357,6 @@ public class IntegrationTests {
         List<Integer> releaseIds = releaseData.stream()
                 .map(rd -> (Integer) rd.get("id"))
                 .collect(toList());
-        Location location = new Location();
-        location.setBarcode("STO-33");
-        location.setId(33);
-        List<StoredItem> storedItems = List.of(
-                new StoredItem("STAN-001", location, new Address(1,2)),
-                new StoredItem("STAN-002", location, new Address(3,4))
-        );
-        stubStorelightLocation(storedItems);
 
         String tsvString = getReleaseFile(releaseIds);
         var tsvMaps = tsvToMap(tsvString);
@@ -1343,23 +1339,44 @@ public class IntegrationTests {
         when(mockStorelightClient.postQuery(ArgumentMatchers.contains("unstoreBarcodes("), anyString())).thenReturn(storelightResponse);
     }
 
-    private void stubStorelightLocation(List<StoredItem> storedItems) throws IOException {
+    private void stubStorelightBasicLocation(Map<String, BasicLocation> locations) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         ObjectNode storelightDataNode;
-        if (storedItems==null || storedItems.isEmpty()) {
+        if (locations==null || locations.isEmpty()) {
             storelightDataNode = objectMapper.createObjectNode()
                     .set("stored", objectMapper.createArrayNode());
         } else {
             ArrayNode itemArrayNode = objectMapper.createArrayNode();
-            for (StoredItem item : storedItems) {
-                itemArrayNode.add(storedItemNode(objectMapper, item));
+            for (var entry : locations.entrySet()) {
+                var loc = entry.getValue();
+                ObjectNode node = objectMapper.createObjectNode()
+                        .put("barcode", entry.getKey())
+                        .put("address", loc.getAddress()!=null ? loc.getAddress().toString() : null)
+                        .set("location", objectMapper.createObjectNode().put("barcode", loc.getBarcode()));
+                itemArrayNode.add(node);
             }
-            storelightDataNode = objectMapper.createObjectNode()
-                    .set("stored", itemArrayNode);
+            storelightDataNode = objectMapper.createObjectNode().set("stored", itemArrayNode);
         }
         GraphQLResponse storelightResponse = new GraphQLResponse(storelightDataNode, null);
         when(mockStorelightClient.postQuery(ArgumentMatchers.contains("stored("), any())).thenReturn(storelightResponse);
     }
+//
+//    private void stubStorelightLocation(List<StoredItem> storedItems) throws IOException {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        ObjectNode storelightDataNode;
+//        if (storedItems==null || storedItems.isEmpty()) {
+//            storelightDataNode = objectMapper.createObjectNode()
+//                    .set("stored", objectMapper.createArrayNode());
+//        } else {
+//            ArrayNode itemArrayNode = objectMapper.createArrayNode();
+//            for (StoredItem item : storedItems) {
+//                itemArrayNode.add(storedItemNode(objectMapper, item));
+//            }
+//            storelightDataNode = objectMapper.createObjectNode().set("stored", itemArrayNode);
+//        }
+//        GraphQLResponse storelightResponse = new GraphQLResponse(storelightDataNode, null);
+//        when(mockStorelightClient.postQuery(ArgumentMatchers.contains("stored("), any())).thenReturn(storelightResponse);
+//    }
 
     private static ObjectNode locationNode(ObjectMapper objectMapper, Location location) {
         return objectMapper.createObjectNode()


### PR DESCRIPTION
Previously we would look up the storage locations in storelight
when a release file is requested. The problem with that is that
the labware typically are not stored anywhere any more because they
have already been released.
So now, we validate the request and look up storage locations before
the release transactions, and we save the storage information in
the labware_release record. The release file service then only
has to pull out the recorded storage information from the release table
instead of making a storelight query.

You'll have to drop your old unit test database and allow
liquibase to recreate it, because the schema has changed
to support storage storage locations in the labware_release table.