### PR TITLE
x789 work progress for multiple statuses or work types

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -269,9 +269,9 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     public DataFetcher<List<WorkProgress>> workProgress() {
         return dfe -> {
             String workNumber = dfe.getArgument("workNumber");
-            String workTypeName = dfe.getArgument("workType");
-            Work.Status status = arg(dfe, "status", Work.Status.class);
-            return workProgressService.getProgress(workNumber, workTypeName, status);
+            List<String> workTypeNames = arg(dfe, "workTypes", new TypeReference<List<String>>() {});
+            List<Work.Status> statuses = arg(dfe, "statuses", new TypeReference<List<Work.Status>>() {});
+            return workProgressService.getProgress(workNumber, workTypeNames, statuses);
         };
     }
   

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/WorkTypeRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/WorkTypeRepo.java
@@ -24,7 +24,7 @@ public interface WorkTypeRepo extends CrudRepository<WorkType, Integer> {
 
     List<WorkType> findAllByNameIn(Collection<String> names);
 
-    default List<WorkType> getAllByNameIn(Collection<String> names) {
+    default List<WorkType> getAllByNameIn(Collection<String> names) throws EntityNotFoundException {
         List<WorkType> found = findAllByNameIn(names);
         if (found.size() == names.size()) {
             return found;
@@ -33,7 +33,7 @@ public interface WorkTypeRepo extends CrudRepository<WorkType, Integer> {
             throw new EntityNotFoundException("Unknown work types: "+names);
         }
         Set<String> foundNamesUc = found.stream().map(wt -> wt.getName().toUpperCase()).collect(toSet());
-        List<String> missing = names.stream().filter(name -> !foundNamesUc.contains(name)).collect(toList());
+        List<String> missing = names.stream().filter(name -> !foundNamesUc.contains(name.toUpperCase())).collect(toList());
         if (!missing.isEmpty()) {
             throw new EntityNotFoundException("Unknown work types: "+missing);
         }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/WorkTypeRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/WorkTypeRepo.java
@@ -4,9 +4,10 @@ import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.WorkType;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
 
 /**
@@ -20,4 +21,22 @@ public interface WorkTypeRepo extends CrudRepository<WorkType, Integer> {
     }
 
     List<WorkType> findAllByEnabled(boolean enabled);
+
+    List<WorkType> findAllByNameIn(Collection<String> names);
+
+    default List<WorkType> getAllByNameIn(Collection<String> names) {
+        List<WorkType> found = findAllByNameIn(names);
+        if (found.size() == names.size()) {
+            return found;
+        }
+        if (found.isEmpty()) {
+            throw new EntityNotFoundException("Unknown work types: "+names);
+        }
+        Set<String> foundNamesUc = found.stream().map(wt -> wt.getName().toUpperCase()).collect(toSet());
+        List<String> missing = names.stream().filter(name -> !foundNamesUc.contains(name)).collect(toList());
+        if (!missing.isEmpty()) {
+            throw new EntityNotFoundException("Unknown work types: "+missing);
+        }
+        return found;
+    }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/WorkProgressService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/WorkProgressService.java
@@ -13,8 +13,9 @@ public interface WorkProgressService {
     /**
      * Gets the applicable work progresses.
      * @param workNumber the specific work number (if any) to look up, or null
-     * @param workTypeName the work type (if any) to look up, or null
+     * @param workTypeNames the work type (if any) to look up, or null
+     * @param statuses the statuses of works to look up, or null
      * @return a list of work progresses for matching works.
      */
-    List<WorkProgress> getProgress(String workNumber, String workTypeName, Work.Status status);
+    List<WorkProgress> getProgress(String workNumber, List<String> workTypeNames, List<Work.Status> statuses);
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -739,7 +739,7 @@ type Query {
     historyForExternalName(externalName: String!): History!
     historyForDonorName(donorName: String!): History!
     historyForLabwareBarcode(barcode: String!): History!
-    workProgress(workNumber: String, workType: String, status: WorkStatus): [WorkProgress!]!
+    workProgress(workNumber: String, workTypes: [String!], statuses: [WorkStatus!]): [WorkProgress!]!
 
     location(locationBarcode: String!): Location!
     stored(barcodes: [String!]!): [StoredItem!]!

--- a/src/test/resources/graphql/workprogress.graphql
+++ b/src/test/resources/graphql/workprogress.graphql
@@ -1,5 +1,5 @@
 query {
-    workProgress(workNumber: "SGP500", status: active) {
+    workProgress(workNumber: "SGP500", statuses: [active]) {
         work { workNumber, workType { name }}
         timestamps { type, timestamp }
     }


### PR DESCRIPTION
Support looking up work progress using
* a work number
* a list of work types
* a list of statuses
or any/all/none of those in combination.

NB an empty list is different from null.
If you search with null for workTypes, then works of any type may be
returned; if you search with [] for workTypes, you will get no results.
