### PR TITLE
x805 Aliquot operation

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -22,6 +22,7 @@ import uk.ac.sanger.sccp.stan.service.*;
 import uk.ac.sanger.sccp.stan.service.analysis.RNAAnalysisService;
 import uk.ac.sanger.sccp.stan.service.extract.ExtractService;
 import uk.ac.sanger.sccp.stan.service.label.print.LabelPrintService;
+import uk.ac.sanger.sccp.stan.service.operation.AliquotService;
 import uk.ac.sanger.sccp.stan.service.operation.InPlaceOpService;
 import uk.ac.sanger.sccp.stan.service.operation.confirm.ConfirmOperationService;
 import uk.ac.sanger.sccp.stan.service.operation.confirm.ConfirmSectionService;
@@ -78,6 +79,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
     final RNAAnalysisService rnaAnalysisService;
     final OpWithSlotMeasurementsService opWithSlotMeasurementsService;
     final ComplexStainService complexStainService;
+    final AliquotService aliquotService;
     final UserAdminService userAdminService;
 
     @Autowired
@@ -97,7 +99,8 @@ public class GraphQLMutation extends BaseGraphQLResource {
                            UnreleaseService unreleaseService, ResultService resultService, ExtractResultService extractResultService,
                            PermService permService, RNAAnalysisService rnaAnalysisService,
                            VisiumAnalysisService visiumAnalysisService, OpWithSlotMeasurementsService opWithSlotMeasurementsService,
-                           ComplexStainService complexStainService, UserAdminService userAdminService) {
+                           ComplexStainService complexStainService, AliquotService aliquotService,
+                           UserAdminService userAdminService) {
         super(objectMapper, authComp, userRepo);
         this.ldapService = ldapService;
         this.sessionConfig = sessionConfig;
@@ -133,6 +136,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         this.rnaAnalysisService = rnaAnalysisService;
         this.opWithSlotMeasurementsService = opWithSlotMeasurementsService;
         this.complexStainService = complexStainService;
+        this.aliquotService = aliquotService;
         this.userAdminService = userAdminService;
     }
 
@@ -555,6 +559,15 @@ public class GraphQLMutation extends BaseGraphQLResource {
             ComplexStainRequest request = arg(dfe, "request", ComplexStainRequest.class);
             logRequest("Record complex stain", user, request);
             return complexStainService.perform(user, request);
+        };
+    }
+
+    public DataFetcher<OperationResult> aliquot() {
+        return dfe -> {
+            User user = checkUser(dfe, User.Role.normal);
+            AliquotRequest request = arg(dfe, "request", AliquotRequest.class);
+            logRequest("Aliquot", user, request);
+            return aliquotService.perform(user, request);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -161,6 +161,7 @@ public class GraphQLProvider {
                         .dataFetcher("recordVisiumQC", transact(graphQLMutation.recordVisiumQC()))
                         .dataFetcher("recordOpWithSlotMeasurements", transact(graphQLMutation.recordOpWithSlotMeasurements()))
                         .dataFetcher("recordComplexStain", transact(graphQLMutation.recordComplexStain()))
+                        .dataFetcher("aliquot", transact(graphQLMutation.aliquot()))
 
                         .dataFetcher("addUser", transact(graphQLMutation.addUser()))
                         .dataFetcher("setUserRole", transact(graphQLMutation.setUserRole()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/BarcodeSeedRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/BarcodeSeedRepo.java
@@ -1,15 +1,46 @@
 package uk.ac.sanger.sccp.stan.repo;
 
+import com.google.common.collect.Streams;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.BarcodeSeed;
 
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * A repository for creating barcode seeds, using them to generate new barcodes.
+ */
 public interface BarcodeSeedRepo extends CrudRepository<BarcodeSeed, Integer> {
+    /** The standard prefix for labware barcodes created by Stan. */
     String STAN = "STAN-";
 
+    /**
+     * Creates a new barcode with the given prefix.
+     * @param prefix the barcode prefix
+     * @return the new barcode
+     */
     default String createBarcode(String prefix) {
         return save(new BarcodeSeed()).toBarcode(prefix);
     }
 
+    /**
+     * Creates multiple new barcodes with the given prefix.
+     * @param prefix the barcode prefix
+     * @param number the number of barcodes to create
+     * @return the new barcodes
+     */
+    default List<String> createBarcodes(String prefix, int number) {
+        List<BarcodeSeed> newSeeds = IntStream.range(0, number).mapToObj(n -> new BarcodeSeed()).collect(toList());
+        return Streams.stream(saveAll(newSeeds)).map(bs -> bs.toBarcode(prefix)).collect(toList());
+    }
+
+    /**
+     * Creates a new barcode with the STAN prefix.
+     * @return the new barcode
+     * @see #STAN
+     */
     default String createStanBarcode() {
         return createBarcode(STAN);
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/AliquotRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/AliquotRequest.java
@@ -1,0 +1,112 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.util.Objects;
+
+/**
+ * A request to transfer material from one source labware into multiple new destination labware (first slot).
+ * @author dr6
+ */
+public class AliquotRequest {
+    private String operationType;
+    private String barcode;
+    private String labwareType;
+    private Integer numLabware;
+    private String workNumber;
+
+    public AliquotRequest() {}
+
+    public AliquotRequest(String operationType, String barcode, String labwareType, Integer numLabware,
+                          String workNumber) {
+        this.operationType = operationType;
+        this.barcode = barcode;
+        this.labwareType = labwareType;
+        this.numLabware = numLabware;
+        this.workNumber = workNumber;
+    }
+
+    /**
+     * The name of the operation to record.
+     */
+    public String getOperationType() {
+        return this.operationType;
+    }
+
+    public void setOperationType(String operationType) {
+        this.operationType = operationType;
+    }
+
+    /**
+     * The barcode of the source labware.
+     */
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    /**
+     * The name of the labware type for the destination labware.
+     */
+    public String getLabwareType() {
+        return this.labwareType;
+    }
+
+    public void setLabwareType(String labwareType) {
+        this.labwareType = labwareType;
+    }
+
+    /**
+     * The number of destination labware to create.
+     */
+    public Integer getNumLabware() {
+        return this.numLabware;
+    }
+
+    public void setNumLabware(Integer numLabware) {
+        this.numLabware = numLabware;
+    }
+
+    /**
+     * An optional work number to associate with this operation.
+     */
+    public String getWorkNumber() {
+        return this.workNumber;
+    }
+
+    public void setWorkNumber(String workNumber) {
+        this.workNumber = workNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AliquotRequest that = (AliquotRequest) o;
+        return (Objects.equals(this.operationType, that.operationType)
+                && Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.labwareType, that.labwareType)
+                && Objects.equals(this.numLabware, that.numLabware)
+                && Objects.equals(this.workNumber, that.workNumber));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operationType, barcode, labwareType, numLabware, workNumber);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe("AliquotRequest")
+                .add("operationType", operationType)
+                .add("barcode", barcode)
+                .add("labwareType", labwareType)
+                .add("numLabware", numLabware)
+                .add("workNumber", workNumber)
+                .reprStringValues()
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/AliquotService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/AliquotService.java
@@ -1,0 +1,20 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.request.AliquotRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.ValidationException;
+
+/**
+ * Service to perform an operation from one labware into multiple new labware (first slot).
+ */
+public interface AliquotService {
+    /**
+     * Records the specified operations.
+     * @param user the user responsible for the operations
+     * @param request the specification of the operations
+     * @return the result of the operations
+     * @exception ValidationException if the request is invalid
+     */
+    OperationResult perform(User user, AliquotRequest request) throws ValidationException;
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/AliquotServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/AliquotServiceImp.java
@@ -1,0 +1,221 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.AliquotRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.*;
+import uk.ac.sanger.sccp.stan.service.work.WorkService;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * @author dr6
+ */
+@Service
+public class AliquotServiceImp implements AliquotService {
+    private final LabwareRepo lwRepo;
+    private final LabwareTypeRepo lwTypeRepo;
+    private final SlotRepo slotRepo;
+    private final OperationTypeRepo opTypeRepo;
+    private final SampleRepo sampleRepo;
+    private final LabwareValidatorFactory lwValFactory;
+    private final WorkService workService;
+    private final LabwareService lwService;
+    private final OperationService opService;
+
+    @Autowired
+    public AliquotServiceImp(LabwareRepo lwRepo, LabwareTypeRepo lwTypeRepo, SlotRepo slotRepo,
+                             OperationTypeRepo opTypeRepo, SampleRepo sampleRepo,
+                             LabwareValidatorFactory lwValFactory,
+                             WorkService workService, LabwareService lwService, OperationService opService) {
+        this.lwRepo = lwRepo;
+        this.lwTypeRepo = lwTypeRepo;
+        this.slotRepo = slotRepo;
+        this.opTypeRepo = opTypeRepo;
+        this.sampleRepo = sampleRepo;
+        this.lwValFactory = lwValFactory;
+        this.workService = workService;
+        this.lwService = lwService;
+        this.opService = opService;
+    }
+
+    @Override
+    public OperationResult perform(User user, AliquotRequest request) throws ValidationException {
+        requireNonNull(user, "User is null");
+        requireNonNull(request, "Request is null");
+        final Set<String> problems = new LinkedHashSet<>();
+        OperationType opType = loadOpType(problems, request.getOperationType());
+        Labware sourceLw = loadSourceLabware(problems, request.getBarcode());
+        LabwareType destLwType = loadDestLabwareType(problems, request.getLabwareType());
+        Work work = workService.validateUsableWork(problems, request.getWorkNumber());
+        validateRequest(problems, request.getNumLabware(), opType, sourceLw);
+
+        if (!problems.isEmpty()) {
+            throw new ValidationException("The request could not be validated.", problems);
+        }
+
+        return execute(user, request.getNumLabware(), opType, sourceLw, destLwType, work);
+    }
+
+    /**
+     * Loads the op type
+     * @param problems receptacle for problems
+     * @param opTypeName name of the op type
+     * @return the op type loaded, if found
+     */
+    public OperationType loadOpType(Collection<String> problems, String opTypeName) {
+        if (opTypeName==null || opTypeName.isEmpty()) {
+            problems.add("No operation type specified.");
+            return null;
+        }
+        Optional<OperationType> optOpType = opTypeRepo.findByName(opTypeName);
+        if (optOpType.isEmpty()) {
+            problems.add("Unknown operation type: "+repr(opTypeName));
+            return null;
+        }
+        return optOpType.get();
+    }
+
+    /**
+     * Loads the source labware
+     * @param problems receptacle for problems
+     * @param barcode barcode of the labware
+     * @return the labware loaded, if found
+     */
+    public Labware loadSourceLabware(Collection<String> problems, String barcode) {
+        if (barcode==null || barcode.isEmpty()) {
+            problems.add("No source barcode specified.");
+            return null;
+        }
+        LabwareValidator val = lwValFactory.getValidator();
+        List<Labware> labwareList = val.loadLabware(lwRepo, List.of(barcode));
+        val.setSingleSample(true);
+        val.validateSources();
+        problems.addAll(val.getErrors());
+        return (labwareList.isEmpty() ? null : labwareList.get(0));
+    }
+
+    /**
+     * Loads the destination labware type
+     * @param problems receptacle for problems
+     * @param labwareTypeName name of the labware type
+     * @return the labware type loaded, if found
+     */
+    public LabwareType loadDestLabwareType(Collection<String> problems, String labwareTypeName) {
+        if (labwareTypeName==null || labwareTypeName.isEmpty()) {
+            problems.add("No destination labware type specified.");
+            return null;
+        }
+        Optional<LabwareType> optLwType = lwTypeRepo.findByName(labwareTypeName);
+        if (optLwType.isEmpty()) {
+            problems.add("Unknown labware type: "+repr(labwareTypeName));
+            return null;
+        }
+        return optLwType.get();
+    }
+
+    /**
+     * Checks that the request makes sense with the specified entities.
+     * @param problems receptacle for problems
+     * @param numLabware the number of new labware requested
+     * @param opType the loaded operation type (if found)
+     * @param sourceLw the loaded source labware (if found)
+     */
+    public void validateRequest(Collection<String> problems,
+                                Integer numLabware, OperationType opType, Labware sourceLw) {
+        if (numLabware==null) {
+            problems.add("Number of labware not specified.");
+        } else if (numLabware <= 0) {
+            problems.add("Number of labware must be greater than zero.");
+        }
+        if (opType!=null) {
+            if (sourceLw != null && opType.sourceMustBeBlock() && !sourceLw.getFirstSlot().isBlock()) {
+                problems.add("The source must be a block for operation type " + opType.getName() + ".");
+            }
+            if (opType.inPlace() || Stream.of(OperationTypeFlag.STAIN, OperationTypeFlag.RESULT, OperationTypeFlag.ANALYSIS)
+                    .anyMatch(opType::has)) {
+                problems.add("Operation type "+ opType.getName()+" cannot be used for aliquoting.");
+            }
+        }
+    }
+
+    /**
+     * Creates labware, populates it, records operations, links work.
+     * Discards the source labware if necessary.
+     * @param user the user responsible for the request
+     * @param numLabware the number of new labware to create
+     * @param opType the type of operation to record
+     * @param sourceLw the source labware
+     * @param work the work to link to the operations (optional)
+     * @return the new labware and operations
+     */
+    public OperationResult execute(User user, int numLabware, OperationType opType,
+                                   Labware sourceLw, LabwareType destLwType, Work work) {
+        List<Labware> destLabware = lwService.create(destLwType, numLabware);
+        if (opType.discardSource()) {
+            sourceLw.setDiscarded(true);
+            sourceLw = lwRepo.save(sourceLw);
+        }
+        final String sourceBarcode = sourceLw.getBarcode();
+        // We previously verified that the labware contained a single sample in a single slot
+        Slot sourceSlot = sourceLw.getSlots().stream()
+                .filter(slot -> !slot.getSamples().isEmpty())
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Sample not found in labware "+sourceBarcode));
+        Sample sourceSample = sourceSlot.getSamples().get(0);
+        Sample destSample;
+        if (opType.getNewBioState()!=null && !opType.getNewBioState().equals(sourceSample.getBioState())) {
+            destSample = sampleRepo.save(new Sample(null, sourceSample.getSection(), sourceSample.getTissue(),
+                    opType.getNewBioState()));
+        } else {
+            destSample = sourceSample;
+        }
+        updateDestinations(destLabware, destSample);
+        List<Operation> ops = destLabware.stream()
+                .map(lw -> createOperation(user, opType, sourceSample, sourceSlot, destSample, lw.getFirstSlot()))
+                .collect(toList());
+        if (work!=null) {
+            workService.link(work, ops);
+        }
+        return new OperationResult(ops, destLabware);
+    }
+
+    /**
+     * Puts the sample into the first slot of each item of labware
+     * @param labware the labware to put the sample in
+     * @param sample the sample
+     */
+    public void updateDestinations(Collection<Labware> labware, Sample sample) {
+        List<Slot> slotsToSave = new ArrayList<>(labware.size());
+        for (Labware lw : labware) {
+            Slot slot = lw.getFirstSlot();
+            slot.getSamples().add(sample);
+            slotsToSave.add(slot);
+        }
+        slotRepo.saveAll(slotsToSave);
+    }
+
+    /**
+     * Adds the sample to the destination slot. Creates an operation with one action between the specified slots.
+     * @param user the user responsible for the operation
+     * @param opType the type of operation
+     * @param sourceSample the source sample for the action
+     * @param sourceSlot the source slot
+     * @param destSample the sample for the action
+     * @param destSlot the destination slot
+     * @return the newly created operation
+     */
+    public Operation createOperation(User user, OperationType opType, Sample sourceSample, Slot sourceSlot,
+                                     Sample destSample, Slot destSlot) {
+        Action action = new Action(null, null, sourceSlot, destSlot, destSample, sourceSample);
+        return opService.createOperation(opType, user, List.of(action), null);
+    }
+}

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1138,6 +1138,20 @@ input StoreInput {
     address: Address
 }
 
+"""A request to transfer material from one source labware into multiple new destination labware (first slot)."""
+input AliquotRequest {
+    """The name of the operation to record."""
+    operationType: String!
+    """The barcode of the source labware."""
+    barcode: String!
+    """The name of the labware type for the destination labware."""
+    labwareType: String!
+    """The number of destination labware to create."""
+    numLabware: Int!
+    """An optional work number to associate with this operation."""
+    workNumber: String
+}
+
 """
 Get information from the application.
 These typically require no user privilege.
@@ -1328,6 +1342,8 @@ type Mutation {
     recordOpWithSlotMeasurements(request: OpWithSlotMeasurementsRequest!): OperationResult!
     """Record a stain operation with plex and bond information."""
     recordComplexStain(request: ComplexStainRequest!): OperationResult!
+    """Transfer samples from one labware into multiple labware."""
+    aliquot(request: AliquotRequest!): OperationResult!
 
     """Create a new user for the application."""
     addUser(username: String!): User!

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestAliquotMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestAliquotMutation.java
@@ -1,0 +1,133 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareRepo;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.*;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+
+/**
+ * Tests the aliquot mutation
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestAliquotMutation {
+    @Autowired
+    private GraphQLTester tester;
+    @Autowired
+    private EntityCreator entityCreator;
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private LabwareRepo lwRepo;
+    @Autowired
+    private OperationRepo opRepo;
+
+    @Test
+    @Transactional
+    public void testAliquot() throws Exception {
+        OperationType opType = entityCreator.createOpType("Aliquot", null, OperationTypeFlag.DISCARD_SOURCE);
+        LabwareType tubeType = entityCreator.getTubeType();
+        Tissue tissue = entityCreator.createTissue(null, "EXT1");
+        Sample sample = entityCreator.createSample(tissue, null);
+        Labware sourceLw = entityCreator.createLabware("STAN-1A", tubeType, sample);
+        Work work = entityCreator.createWork(null, null, null);
+        String mutation = tester.readGraphQL("aliquot.graphql")
+                .replace("SOURCE", sourceLw.getBarcode())
+                .replace("WORK", work.getWorkNumber())
+                .replace("LWTYPE", tubeType.getName());
+
+        User user = entityCreator.createUser("user1");
+        tester.setUser(user);
+
+        Object response = tester.post(mutation);
+
+        entityManager.flush();
+
+        Map<String, List<Map<String, ?>>> aliquotData = chainGet(response, "data", "aliquot");
+
+        List<Map<String, ?>> lwsData = aliquotData.get("labware");
+        List<Map<String, ?>> opsData = aliquotData.get("operations");
+
+        assertThat(lwsData).hasSize(2);
+        assertThat(opsData).hasSize(2);
+
+        Set<String> barcodes = lwsData.stream()
+                .map(ld -> (String) ld.get("barcode"))
+                .collect(toSet());
+        assertThat(barcodes).hasSize(2);
+        for (String bc : barcodes) {
+            assertThat(bc).matches("^STAN-[A-F0-9]+$");
+        }
+
+        Set<Integer> opIds = new HashSet<>(2);
+        for (var od : opsData) {
+            assertEquals("Aliquot", chainGet(od, "operationType", "name"));
+            Integer opId = (Integer) od.get("id");
+            assertNotNull(opId);
+            assertTrue(opIds.add(opId));
+            List<Map<String, ?>> actionsData = chainGet(od, "actions");
+            assertThat(actionsData).hasSize(1);
+            Map<String, ?> destData = chainGet(actionsData, 0, "destination");
+            assertEquals("A1", destData.get("address"));
+            List<Map<String, ?>> samplesData = chainGet(destData, "samples");
+            assertThat(samplesData).hasSize(1);
+            assertEquals(sample.getId(), chainGet(samplesData, 0, "id"));
+        }
+
+        entityManager.refresh(sourceLw);
+        assertTrue(sourceLw.isDiscarded());
+
+        List<Labware> destLws = lwRepo.findByBarcodeIn(barcodes);
+        Set<Slot> destSlots = new HashSet<>(2);
+        assertThat(destLws).hasSize(2);
+        for (Labware lw : destLws) {
+            assertEquals(Labware.State.active, lw.getState());
+            Slot slot = lw.getFirstSlot();
+            assertThat(slot.getSamples()).hasSize(1).contains(sample);
+            destSlots.add(slot);
+        }
+
+        Iterable<Operation> opsIterable = opRepo.findAllById(opIds);
+        Collection<Operation> ops;
+        if (opsIterable instanceof Collection) {
+            ops = (Collection<Operation>) opsIterable;
+        } else {
+            ops = new ArrayList<>(2);
+            for (Operation op : opsIterable) {
+                ops.add(op);
+            }
+        }
+        assertThat(ops).hasSize(2);
+        Set<Slot> dests = new HashSet<>(2);
+        for (Operation op : ops) {
+            assertEquals(opType, op.getOperationType());
+            assertThat(op.getActions()).hasSize(1);
+            Action action = op.getActions().get(0);
+            assertEquals(sample, action.getSample());
+            assertEquals(sample, action.getSourceSample());
+            assertEquals(sourceLw.getFirstSlot(), action.getSource());
+            dests.add(action.getDestination());
+        }
+        assertEquals(destSlots, dests);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestBarcodeSeedRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestBarcodeSeedRepo.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.transaction.Transactional;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -32,5 +33,21 @@ public class TestBarcodeSeedRepo {
         assertThat(barcode1).matches("STAN-[0-9A-F]{5,}");
         assertThat(barcode2).matches("STAN-[0-9A-F]{5,}");
         assertNotEquals(barcode1, barcode2);
+    }
+
+    @Test
+    @Transactional
+    public void testCreateBarcodes() {
+        List<String> barcodes = barcodeSeedRepo.createBarcodes(BarcodeSeedRepo.STAN, 3);
+        List<String> more = barcodeSeedRepo.createBarcodes(BarcodeSeedRepo.STAN, 2);
+        assertThat(barcodes).hasSize(3);
+        assertThat(more).hasSize(2);
+        Set<String> allBarcodes = new HashSet<>(5);
+        allBarcodes.addAll(barcodes);
+        allBarcodes.addAll(more);
+        for (String barcode : allBarcodes) {
+            assertThat(barcode).matches("STAN-[0-9A-F]{5,}");
+        }
+        assertThat(allBarcodes).hasSize(5);
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestAliquotService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestAliquotService.java
@@ -1,0 +1,381 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.Matchers;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.AliquotRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.*;
+import uk.ac.sanger.sccp.stan.service.work.WorkService;
+
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link AliquotServiceImp}
+ * @author dr6
+ */
+public class TestAliquotService {
+    private LabwareRepo mockLwRepo;
+    private SlotRepo mockSlotRepo;
+    private LabwareTypeRepo mockLwTypeRepo;
+    private OperationTypeRepo mockOpTypeRepo;
+    private SampleRepo mockSampleRepo;
+    private LabwareValidatorFactory mockLwValFactory;
+    private WorkService mockWorkService;
+    private LabwareService mockLwService;
+    private OperationService mockOpService;
+
+    private AliquotServiceImp service;
+
+    @BeforeEach
+    void setup() {
+        mockLwRepo = mock(LabwareRepo.class);
+        mockSlotRepo = mock(SlotRepo.class);
+        mockLwTypeRepo = mock(LabwareTypeRepo.class);
+        mockOpTypeRepo = mock(OperationTypeRepo.class);
+        mockSampleRepo = mock(SampleRepo.class);
+        mockLwValFactory = mock(LabwareValidatorFactory.class);
+        mockWorkService = mock(WorkService.class);
+        mockLwService = mock(LabwareService.class);
+        mockOpService = mock(OperationService.class);
+
+        service = spy(new AliquotServiceImp(mockLwRepo, mockLwTypeRepo, mockSlotRepo, mockOpTypeRepo, mockSampleRepo,
+                mockLwValFactory, mockWorkService, mockLwService, mockOpService));
+    }
+
+    private static <R> Answer<R> addProblem(String problem, R returnValue) {
+        return invocation -> {
+            if (problem!=null) {
+                Collection<String> problems = invocation.getArgument(0);
+                problems.add(problem);
+            }
+            return returnValue;
+        };
+    }
+
+    @Test
+    public void testPerform_valid() {
+        final User user = EntityFactory.getUser();
+        OperationType opType = EntityFactory.makeOperationType("Aliquot", null);
+        LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Labware sourceLw = EntityFactory.getTube();
+        Work work = new Work(50, "SGP50", null, null, null, Work.Status.active);
+        OperationResult result = new OperationResult(List.of(), List.of());
+
+        doReturn(opType).when(service).loadOpType(any(), any());
+        doReturn(sourceLw).when(service).loadSourceLabware(any(), any());
+        doReturn(lt).when(service).loadDestLabwareType(any(), any());
+        doReturn(work).when(mockWorkService).validateUsableWork(any(), any());
+        doNothing().when(service).validateRequest(any(), any(), any(), any());
+        doReturn(result).when(service).execute(any(), anyInt(), any(), any(), any(), any());
+
+        AliquotRequest request = new AliquotRequest(opType.getName(), sourceLw.getBarcode(), lt.getName(),
+                3, work.getWorkNumber());
+        assertSame(result, service.perform(user, request));
+
+        verify(service).loadOpType(anyCollection(), eq(request.getOperationType()));
+        verify(service).loadSourceLabware(anyCollection(), eq(request.getBarcode()));
+        verify(service).loadDestLabwareType(anyCollection(), eq(request.getLabwareType()));
+        verify(mockWorkService).validateUsableWork(anyCollection(), eq(request.getWorkNumber()));
+        verify(service).validateRequest(anyCollection(), same(request.getNumLabware()), same(opType), same(sourceLw));
+        verify(service).execute(same(user), eq((int) request.getNumLabware()), same(opType), same(sourceLw),
+                same(lt), same(work));
+    }
+
+    @Test
+    public void testPerform_invalid() {
+        final User user = EntityFactory.getUser();
+        OperationType opType = EntityFactory.makeOperationType("Aliquot", null);
+        LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Labware sourceLw = EntityFactory.getTube();
+        AliquotRequest request = new AliquotRequest(opType.getName(), sourceLw.getBarcode(), lt.getName(),
+                -5, "SGPF");
+
+        doAnswer(addProblem("Bad op", opType)).when(service).loadOpType(any(), any());
+        doAnswer(addProblem("Bad lw", sourceLw)).when(service).loadSourceLabware(any(), any());
+        doAnswer(addProblem("Bad lt", lt)).when(service).loadDestLabwareType(any(), any());
+        doAnswer(addProblem("Bad work", null)).when(mockWorkService).validateUsableWork(any(), any());
+        doAnswer(addProblem("Bad request", null)).when(service).validateRequest(any(), any(), any(), any());
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> service.perform(user, request));
+        //noinspection unchecked
+        assertThat((Collection<Object>) ex.getProblems()).containsExactlyInAnyOrder(
+                "Bad op", "Bad lw", "Bad lt", "Bad work", "Bad request"
+        );
+
+        verify(service).loadOpType(anyCollection(), eq(request.getOperationType()));
+        verify(service).loadSourceLabware(anyCollection(), eq(request.getBarcode()));
+        verify(service).loadDestLabwareType(anyCollection(), eq(request.getLabwareType()));
+        verify(mockWorkService).validateUsableWork(anyCollection(), eq(request.getWorkNumber()));
+        verify(service).validateRequest(anyCollection(), same(request.getNumLabware()), same(opType), same(sourceLw));
+        verify(service, never()).execute(any(), anyInt(), any(), any(), any(), any());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Aliquot, true,",
+            "Foozle, false, Unknown operation type: \"Foozle\"",
+            ", false, No operation type specified.",
+            "'', false, No operation type specified.",
+    })
+    public void testLoadOpType(String name, boolean exists, String expectedProblem) {
+        OperationType opType = (exists ? EntityFactory.makeOperationType(name, null) : null);
+        if (name!=null) {
+            when(mockOpTypeRepo.findByName(name)).thenReturn(Optional.ofNullable(opType));
+        }
+        List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        assertSame(opType, service.loadOpType(problems, name));
+        if (expectedProblem==null) {
+            assertThat(problems).isEmpty();
+        } else {
+            assertThat(problems).containsExactly(expectedProblem);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "STAN-01, true,,",
+            "STAN-404, false, Not found.,",
+            "STAN-01, true, Bad labware.,",
+            ",false,,No source barcode specified.",
+            "'',false,,No source barcode specified.",
+    })
+    public void testLoadSourceLabware(String barcode, boolean exists, String valError, String expectedProblem) {
+        Labware lw;
+        if (exists) {
+            lw = EntityFactory.getTube();
+        } else {
+            lw = null;
+        }
+        if (expectedProblem==null) {
+            expectedProblem = valError;
+        }
+        List<Labware> lws = (lw==null) ? List.of() : List.of(lw);
+        LabwareValidator val = mock(LabwareValidator.class);
+        when(mockLwValFactory.getValidator()).thenReturn(val);
+        when(val.loadLabware(any(), any())).thenReturn(lws);
+        when(val.getErrors()).thenReturn(valError==null ? List.of() : List.of(valError));
+
+        final List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        assertSame(lw, service.loadSourceLabware(problems, barcode));
+        if (expectedProblem==null) {
+            assertThat(problems).isEmpty();
+        } else {
+            assertThat(problems).containsExactly(expectedProblem);
+        }
+        if (expectedProblem==null || valError!=null) {
+            verify(mockLwValFactory).getValidator();
+            verify(val).loadLabware(mockLwRepo, List.of(barcode));
+            verify(val).setSingleSample(true);
+            verify(val).validateSources();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "lt1, true,",
+            "lt4, false, Unknown labware type: \"lt4\"",
+            ", false, No destination labware type specified.",
+            "'', false, No destination labware type specified.",
+    })
+    public void testLoadDestLabwareType(String name, boolean exists, String expectedProblem) {
+        LabwareType lt;
+        if (exists) {
+            lt = EntityFactory.makeLabwareType(1,1);
+            lt.setName(name);
+        } else {
+            lt = null;
+        }
+        if (name!=null && !name.isEmpty()) {
+            when(mockLwTypeRepo.findByName(name)).thenReturn(Optional.ofNullable(lt));
+        }
+
+        final List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        assertSame(lt, service.loadDestLabwareType(problems, name));
+        if (expectedProblem==null) {
+            assertThat(problems).isEmpty();
+        } else {
+            assertThat(problems).containsExactly(expectedProblem);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateRequestArgs")
+    public void testValidateRequest(Integer numLabware, OperationType opType, Labware sourceLw,
+                                    List<String> expectedProblems) {
+        final List<String> problems = new ArrayList<>(expectedProblems.size());
+        service.validateRequest(problems, numLabware, opType, sourceLw);
+        assertThat(problems).containsExactlyInAnyOrderElementsOf(expectedProblems);
+    }
+
+    static Stream<Arguments> validateRequestArgs() {
+        OperationType aliquotOp =  EntityFactory.makeOperationType("Aliquot", null);
+        OperationType inPlaceOp = EntityFactory.makeOperationType("Bloop", null, OperationTypeFlag.IN_PLACE);
+        OperationType analysisOp = EntityFactory.makeOperationType("Floop", null, OperationTypeFlag.ANALYSIS);
+        OperationType sectionOp = EntityFactory.makeOperationType("Section", null, OperationTypeFlag.SOURCE_IS_BLOCK);
+
+        Sample sample = new Sample(50, null, EntityFactory.getTissue(), EntityFactory.getBioState());
+        Labware block = EntityFactory.makeBlock(sample);
+        Labware section = EntityFactory.getTube();
+
+        return Arrays.stream(new Object[][]{
+                {3, aliquotOp, block},
+                {1, aliquotOp, section},
+                {null, aliquotOp, section, "Number of labware not specified."},
+                {0, aliquotOp, section, "Number of labware must be greater than zero."},
+                {-1, aliquotOp, section, "Number of labware must be greater than zero."},
+                {1, null, null},
+                {2, aliquotOp, null},
+                {1, null, section},
+                {2, sectionOp, block},
+                {3, sectionOp, null},
+                {3, sectionOp, section, "The source must be a block for operation type Section."},
+                {2, inPlaceOp, section, "Operation type Bloop cannot be used for aliquoting."},
+                {1, analysisOp, section, "Operation type Floop cannot be used for aliquoting."},
+                {null, inPlaceOp, section, "Number of labware not specified.", "Operation type Bloop cannot be used for aliquoting."},
+        }).map(arr -> {
+            List<String> expectedProblems = IntStream.range(3, arr.length)
+                    .mapToObj(i -> (String) arr[i])
+                    .collect(toList());
+            return Arguments.of(arr[0], arr[1], arr[2], expectedProblems);
+        });
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "true,true,false,0",
+            "true,true,false,1",
+            "true,true,true,0",
+            "true,false,false,0",
+            "false,true,true,0",
+            "false,false,true,1",
+    })
+    public void testExecute(boolean discard, boolean hasWork, boolean setBioState, int sourceSlotIndex) {
+        final int numLabware = 2;
+        LabwareType destLwType = EntityFactory.getTubeType();
+        Labware sourceLw = EntityFactory.makeEmptyLabware(EntityFactory.makeLabwareType(2,1));
+        List<Labware> destLw = List.of(
+                EntityFactory.makeEmptyLabware(destLwType),
+                EntityFactory.makeEmptyLabware(destLwType)
+        );
+        OperationType opType;
+        BioState bs = (setBioState ? new BioState(300, "Bananas") : null);
+        if (discard) {
+            opType = EntityFactory.makeOperationType("Aliquot", bs, OperationTypeFlag.DISCARD_SOURCE);
+            when(mockLwRepo.save(any())).then(Matchers.returnArgument());
+        } else {
+            opType = EntityFactory.makeOperationType("Aliquot", bs);
+        }
+        Work work = (hasWork ?
+                    new Work(50, "SGP50", null, null, null, Work.Status.active)
+                    : null);
+        User user = EntityFactory.getUser();
+        Sample srcSample = EntityFactory.getSample();
+        Slot srcSlot = sourceLw.getSlots().get(sourceSlotIndex);
+        srcSlot.getSamples().add(srcSample);
+        final Integer newSampleId = 600;
+        if (bs!=null) {
+            when(mockSampleRepo.save(any())).then(invocation -> {
+                Sample sample = invocation.getArgument(0);
+                assertNull(sample.getId());
+                sample.setId(newSampleId);
+                return sample;
+            });
+        }
+        when(mockLwService.create(destLwType, numLabware)).thenReturn(destLw);
+        doNothing().when(service).updateDestinations(any(), any());
+        List<Operation> ops = IntStream.range(0, destLw.size())
+                .mapToObj(i -> new Operation(50+i, opType, null, null, user))
+                .collect(toList());
+        doReturn(ops.get(0), ops.get(1)).when(service).createOperation(any(), any(), any(), any(), any(), any());
+
+        OperationResult result = service.execute(user, numLabware, opType, sourceLw, destLwType, work);
+
+        assertEquals(destLw, result.getLabware());
+        assertEquals(ops, result.getOperations());
+
+        verify(mockLwService).create(destLwType, numLabware);
+        assertEquals(discard, sourceLw.isDiscarded());
+        if (discard) {
+            verify(mockLwRepo).save(sourceLw);
+        } else {
+            verifyNoInteractions(mockLwRepo);
+        }
+        Sample dstSample;
+        if (bs==null) {
+            dstSample = srcSample;
+            verifyNoInteractions(mockSampleRepo);
+        } else {
+            ArgumentCaptor<Sample> sampleCaptor = ArgumentCaptor.forClass(Sample.class);
+            verify(mockSampleRepo).save(sampleCaptor.capture());
+            dstSample = sampleCaptor.getValue();
+            assertEquals(newSampleId, dstSample.getId());
+            assertEquals(srcSample.getTissue(), dstSample.getTissue());
+            assertEquals(srcSample.getSection(), dstSample.getSection());
+            assertEquals(bs, dstSample.getBioState());
+        }
+        verify(service).updateDestinations(destLw, dstSample);
+        verify(service, times(2)).createOperation(any(), any(), any(), any(), any(), any());
+        for (Labware lw : destLw) {
+            verify(service).createOperation(user, opType, srcSample, srcSlot, dstSample, lw.getFirstSlot());
+        }
+        if (work==null) {
+            verifyNoInteractions(mockWorkService);
+        } else {
+            verify(mockWorkService).link(work, ops);
+        }
+    }
+
+    @Test
+    public void testUpdateDestinations() {
+        LabwareType lt = EntityFactory.makeLabwareType(2,1);
+        List<Labware> labware = IntStream.range(0,2)
+                .mapToObj(i -> EntityFactory.makeEmptyLabware(lt))
+                .collect(toList());
+        Sample sample = EntityFactory.getSample();
+
+        service.updateDestinations(labware, sample);
+
+        List<Slot> slots = new ArrayList<>(labware.size());
+        for (Labware lw : labware) {
+            final Slot slot = lw.getFirstSlot();
+            assertThat(slot.getSamples()).hasSize(1).contains(sample);
+            slots.add(slot);
+            assertThat(lw.getSlots().get(1).getSamples()).isEmpty();
+        }
+        verify(mockSlotRepo).saveAll(slots);
+    }
+
+    @Test
+    public void testCreateOperation() {
+        Slot source = EntityFactory.getTube().getFirstSlot();
+        Slot dest = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType()).getFirstSlot();
+        User user = EntityFactory.getUser();
+        OperationType opType = EntityFactory.makeOperationType("Aliquot", null);
+        Sample srcSam = EntityFactory.getSample();
+        Sample dstSam = new Sample(srcSam.getId()+1, srcSam.getSection(), srcSam.getTissue(), srcSam.getBioState());
+
+        Operation op = new Operation(500, opType, null, null, user);
+        when(mockOpService.createOperation(any(), any(), any(), any())).thenReturn(op);
+
+        assertSame(op, service.createOperation(user, opType, srcSam, source, dstSam, dest));
+
+        Action expectedAction = new Action(null, null, source, dest, dstSam, srcSam);
+
+        verify(mockOpService).createOperation(opType, user, List.of(expectedAction), null);
+    }
+}

--- a/src/test/resources/graphql/aliquot.graphql
+++ b/src/test/resources/graphql/aliquot.graphql
@@ -1,0 +1,21 @@
+mutation {
+    aliquot(request: {
+        operationType: "Aliquot"
+        barcode: "SOURCE"
+        labwareType: "LWTYPE"
+        workNumber: "WORK"
+        numLabware: 2
+    }) {
+        labware { barcode }
+        operations {
+            id
+            operationType { name }
+            actions {
+                destination {
+                    address
+                    samples { id }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Support an operation to transfer a sample from one source into
multiple destinations.
Aliquot service transfers one sample from a labware containing one
samples, to the first slot of each of N new labware.
BarcodeSeedRepo: support getting multiple new barcodes in one shot.
LabwareService: support creating multiple new labware in one shot.
(Update existing LabwareService method to use saveAll instead of save
for slots.)
