### PR TITLE
x787 change HMDMC to HuMFre in messages that are likely to be shown to the user

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
@@ -101,7 +101,7 @@ public class FieldValidation {
     public Validator<String> hmdmcValidator() {
         Set<CharacterType> charTypes = EnumSet.of(CharacterType.DIGIT, CharacterType.SLASH);
         Pattern pattern = Pattern.compile("\\d{2}/\\d{2,}");
-        return new StringValidator("HMDMC", 1, 16, charTypes, false, pattern);
+        return new StringValidator("HuMFre", 1, 16, charTypes, false, pattern);
     }
 
     @Bean

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/HmdmcAdminService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/HmdmcAdminService.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public class HmdmcAdminService extends BaseAdminService<Hmdmc, HmdmcRepo> {
     @Autowired
     public HmdmcAdminService(HmdmcRepo repo, @Qualifier("hmdmcValidator") Validator<String> hmdmcValidator) {
-        super(repo, "HMDMC", "HMDMC", hmdmcValidator);
+        super(repo, "HuMFre", "HuMFre", hmdmcValidator);
     }
 
     @Override

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterServiceImp.java
@@ -96,14 +96,14 @@ public class RegisterServiceImp implements RegisterService {
             } else {
                 hmdmc = validation.getHmdmc(block.getHmdmc());
                 if (hmdmc==null) {
-                    throw new IllegalArgumentException("Unknown HMDMC number: "+block.getHmdmc());
+                    throw new IllegalArgumentException("Unknown HuMFre number: "+block.getHmdmc());
                 }
             }
             if (donor.getSpecies().requiresHmdmc() && hmdmc==null) {
-                throw new IllegalArgumentException("No HMDMC number given for tissue "+block.getExternalIdentifier());
+                throw new IllegalArgumentException("No HuMFre number given for tissue "+block.getExternalIdentifier());
             }
             if (!donor.getSpecies().requiresHmdmc() && hmdmc!=null) {
-                throw new IllegalArgumentException("HMDMC number given for non-human tissue "+block.getExternalIdentifier());
+                throw new IllegalArgumentException("HuMFre number given for non-human tissue "+block.getExternalIdentifier());
             }
             Tissue tissue = new Tissue(null, block.getExternalIdentifier(), block.getReplicateNumber().toLowerCase(),
                     validation.getSpatialLocation(block.getTissueType(), block.getSpatialLocation()),

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationImp.java
@@ -223,20 +223,20 @@ public class RegisterValidationImp implements RegisterValidation {
             }
         }
         if (missing) {
-            addProblem("Missing HMDMC number.");
+            addProblem("Missing HuMFre number.");
         }
         if (unwanted) {
-            addProblem("Non-human tissue should not have an HMDMC number.");
+            addProblem("Non-human tissue should not have a HuMFre number.");
         }
         if (!unknownHmdmcs.isEmpty()) {
-            addProblem(pluralise("Unknown HMDMC number{s}: ", unknownHmdmcs.size()) + unknownHmdmcs);
+            addProblem(pluralise("Unknown HuMFre number{s}: ", unknownHmdmcs.size()) + unknownHmdmcs);
         }
         List<String> disabledHmdmcs = hmdmcMap.values().stream()
                 .filter(h -> h!=null && !h.isEnabled())
                 .map(Hmdmc::getHmdmc)
                 .collect(toList());
         if (!disabledHmdmcs.isEmpty()) {
-            addProblem(pluralise("HMDMC number{s} not enabled: ", disabledHmdmcs.size()) + disabledHmdmcs);
+            addProblem(pluralise("HuMFre number{s} not enabled: ", disabledHmdmcs.size()) + disabledHmdmcs);
         }
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/SectionRegisterValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/SectionRegisterValidation.java
@@ -241,7 +241,7 @@ public class SectionRegisterValidation {
         MouldSize mouldSize = mouldSizeOpt.orElse(null);
         UCMap<Hmdmc> hmdmcMap = loadAllFromSectionsToStringMap(request, SectionRegisterContent::getHmdmc,
                 Hmdmc::getHmdmc, hmdmcRepo::findAllByHmdmcIn);
-        checkEntitiesEnabled(hmdmcMap.values(), "HMDMC", Hmdmc::getHmdmc);
+        checkEntitiesEnabled(hmdmcMap.values(), "HuMFre number", Hmdmc::getHmdmc);
         UCMap<TissueType> tissueTypeMap = loadAllFromSectionsToStringMap(request, SectionRegisterContent::getTissueType,
                 TissueType::getName, tissueTypeRepo::findAllByNameIn);
         UCMap<Fixative> fixativeMap = loadAllFromSectionsToStringMap(request, SectionRegisterContent::getFixative,
@@ -268,16 +268,16 @@ public class SectionRegisterValidation {
             Hmdmc hmdmc;
             if (hmdmcString==null || hmdmcString.isEmpty()) {
                 if (needHmdmc) {
-                    addProblem("Missing HMDMC number.");
+                    addProblem("Missing HuMFre number.");
                 }
                 hmdmc = null;
             } else {
                 if (needNoHmdmc) {
-                    addProblem("Unexpected HMDMC number received for non-human tissue.");
+                    addProblem("Unexpected HuMFre number received for non-human tissue.");
                 }
                 hmdmc = hmdmcMap.get(hmdmcString);
                 if (hmdmc==null) {
-                    problemFn.accept("Unknown HMDMC number{s}", hmdmcString);
+                    problemFn.accept("Unknown HuMFre number{s}", hmdmcString);
                 }
             }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/TissueFieldChecker.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/TissueFieldChecker.java
@@ -20,7 +20,7 @@ public class TissueFieldChecker {
     }
     enum Field {
         DONOR(Tissue::getDonor, Donor::getDonorName, BlockRegisterRequest::getDonorIdentifier, "donor identifier"),
-        HMDMC(Tissue::getHmdmc, Hmdmc::getHmdmc, BlockRegisterRequest::getHmdmc, "HMDMC number"),
+        HMDMC(Tissue::getHmdmc, Hmdmc::getHmdmc, BlockRegisterRequest::getHmdmc, "HuMFre number"),
         TTYPE(Tissue::getTissueType, TissueType::getName, BlockRegisterRequest::getTissueType, "tissue type"),
         SL(Tissue::getSpatialLocation, SpatialLocation::getCode, BlockRegisterRequest::getSpatialLocation, "spatial location"),
         REPLICATE(Tissue::getReplicate, BlockRegisterRequest::getReplicateNumber, "replicate number"),

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestHmdmcAdminService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestHmdmcAdminService.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.mock;
  */
 public class TestHmdmcAdminService extends AdminServiceTestUtils<Hmdmc, HmdmcRepo, HmdmcAdminService> {
     public TestHmdmcAdminService() {
-        super("HMDMC", Hmdmc::new, HmdmcRepo::findByHmdmc, "HMDMC not supplied.");
+        super("HuMFre", Hmdmc::new, HmdmcRepo::findByHmdmc, "HuMFre not supplied.");
     }
 
     @BeforeEach

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterService.java
@@ -464,9 +464,9 @@ public class TestRegisterService {
         return Stream.of(
                 Arguments.of(human, hmdmc, null),
                 Arguments.of(hamster, null, null),
-                Arguments.of(human, null, "No HMDMC number given for tissue TISSUE"),
-                Arguments.of(hamster, hmdmc, "HMDMC number given for non-human tissue TISSUE"),
-                Arguments.of(human, "20/404", "Unknown HMDMC number: 20/404")
+                Arguments.of(human, null, "No HuMFre number given for tissue TISSUE"),
+                Arguments.of(hamster, hmdmc, "HuMFre number given for non-human tissue TISSUE"),
+                Arguments.of(human, "20/404", "Unknown HuMFre number: 20/404")
         );
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidation.java
@@ -567,17 +567,17 @@ public class TestRegisterValidation {
                 Arguments.of(List.of(h0, h1), List.of("20/001", "20/000", "20/000", ""), List.of("Human", "Human", "Human", "Hamster"),
                         List.of(h0, h1), List.of()),
                 Arguments.of(List.of(h0, h1), List.of("20/001", "20/404", "20/405"), List.of("Human", "Human", "Human"),
-                        List.of(h1), List.of("Unknown HMDMC numbers: [20/404, 20/405]")),
+                        List.of(h1), List.of("Unknown HuMFre numbers: [20/404, 20/405]")),
                 Arguments.of(List.of(h0), Arrays.asList(null, "20/000", null), List.of("Human", "Human", "Human"),
-                        List.of(h0), List.of("Missing HMDMC number.")),
+                        List.of(h0), List.of("Missing HuMFre number.")),
                 Arguments.of(List.of(h0, h1), List.of("20/000", "20/001"), List.of("Human", "Hamster"),
-                        List.of(h0), List.of("Non-human tissue should not have an HMDMC number.")),
+                        List.of(h0), List.of("Non-human tissue should not have a HuMFre number.")),
                 Arguments.of(List.of(h0, h2, h3), List.of("20/000", "20/002", "20/003", "20/002"), List.of("Human", "Human", "Human", "Human"),
-                        List.of(h0, h2, h3), List.of("HMDMC numbers not enabled: [20/002, 20/003]")),
+                        List.of(h0, h2, h3), List.of("HuMFre numbers not enabled: [20/002, 20/003]")),
                 Arguments.of(List.of(h0, h1, h2), List.of("20/000", "20/001", "20/000", "", "", "20/404", "20/002"),
                         List.of("Human", "Human", "Human", "Human", "Human", "Human", "Human"),
-                        List.of(h0, h1, h2), List.of("Missing HMDMC number.", "Unknown HMDMC number: [20/404]",
-                                "HMDMC number not enabled: [20/002]"))
+                        List.of(h0, h1, h2), List.of("Missing HuMFre number.", "Unknown HuMFre number: [20/404]",
+                                "HuMFre number not enabled: [20/002]"))
         );
     }
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterValidation.java
@@ -481,23 +481,23 @@ public class TestSectionRegisterValidation {
                         .problem("Mould size \"None\" not found."),
                 testData.get()
                         .content("EXT1", "4", "ARM", 1, "Donor1", "None", "None", null, "human")
-                        .problem("Missing HMDMC number."),
+                        .problem("Missing HuMFre number."),
                 testData.get()
                         .content("EXT1", "4", "ARM", 1, "Donor1", "None", "None", "", "human")
                         .content("EXT2", "4", "ARM", 1, "Donor1", "None", "None", "2021/01", "")
-                        .problem("Missing HMDMC number."),
+                        .problem("Missing HuMFre number."),
                 testData.get()
                         .content("EXT1", "4", "ARM", 1, "Donor1", "None", "None", "2021/404", "human")
                         .content("EXT2", "4", "ARM", 1, "Donor1", "None", "None", "2021/405", "human")
                         .content("EXT3", "4", "ARM", 1, "Donor1", "None", "None", "2021/405", "human")
-                        .problem("Unknown HMDMC numbers: [2021/404, 2021/405]"),
+                        .problem("Unknown HuMFre numbers: [2021/404, 2021/405]"),
                 testData.get()
                         .content("EXT1", "4", "ARM", 1, "Donor2", "None", "None", "2021/01", "Hamster")
-                        .problem("Unexpected HMDMC number received for non-human tissue."),
+                        .problem("Unexpected HuMFre number received for non-human tissue."),
                 testData.get()
                         .content("EXT1", "4", "ARM", 1, "Donor2", "None", "None", "2021/03", "Human")
                         .content("EXT2", "4", "ARM", 1, "Donor2", "None", "None", "2021/04", "Human")
-                        .problem("HMDMC not enabled: [2021/03, 2021/04]"),
+                        .problem("HuMFre number not enabled: [2021/03, 2021/04]"),
                 testData.get()
                         .content(null, "4", "ARM", 1, "Donor1", "None", "None", "2021/01", "Human")
                         .problem("Missing external identifier."),
@@ -555,11 +555,11 @@ public class TestSectionRegisterValidation {
                 testData.get()
                         .content(null, null, null, null, null, null, null, null, "Human")
                         .problems("Missing external identifier.", "Missing replicate number.", "Missing tissue type.", "Missing spatial location.", "Missing medium.",
-                                "Missing fixative.", "Missing HMDMC number."),
+                                "Missing fixative.", "Missing HuMFre number."),
                 testData.get()
                         .content("!X11", "!-1", "Squirrel", 2, null, "Custard", "Stapler", "2021/404", null)
                         .problems("Bad external name: !X11", "Bad replicate: !-1", "Unknown tissue type: [Squirrel]", "Unknown medium: [Custard]",
-                                "Unknown fixative: [Stapler]", "Unknown HMDMC number: [2021/404]")
+                                "Unknown fixative: [Stapler]", "Unknown HuMFre number: [2021/404]")
 
         );
     }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestTissueFieldChecker.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestTissueFieldChecker.java
@@ -76,7 +76,7 @@ public class TestTissueFieldChecker {
         return Stream.of(
                 Arguments.of(toBRR(tissue, null), tissue, null),
                 Arguments.of(toBRR(tissue, br -> br.setDonorIdentifier("Foo")), tissue, "Expected donor identifier to be "+tissue.getDonor().getDonorName()+forTissue),
-                Arguments.of(toBRR(tissue, br -> br.setHmdmc("12/345")), tissue, "Expected HMDMC number to be "+tissue.getHmdmc().getHmdmc()+forTissue),
+                Arguments.of(toBRR(tissue, br -> br.setHmdmc("12/345")), tissue, "Expected HuMFre number to be "+tissue.getHmdmc().getHmdmc()+forTissue),
                 Arguments.of(toBRR(tissue, br -> br.setTissueType("Plumbus")), tissue, "Expected tissue type to be "+tissue.getTissueType().getName()+forTissue),
                 Arguments.of(toBRR(tissue, br -> br.setSpatialLocation(18)), tissue, "Expected spatial location to be "+tissue.getSpatialLocation().getCode()+forTissue),
                 Arguments.of(toBRR(tissue, br -> br.setReplicateNumber("-5")), tissue, "Expected replicate number to be "+tissue.getReplicate()+forTissue),
@@ -89,7 +89,7 @@ public class TestTissueFieldChecker {
                     br.setTissueType("Plumbus");
                 }), tissue,
                         List.of("Expected donor identifier to be "+tissue.getDonor().getDonorName()+forTissue,
-                                "Expected HMDMC number to be "+tissue.getHmdmc().getHmdmc()+forTissue,
+                                "Expected HuMFre number to be "+tissue.getHmdmc().getHmdmc()+forTissue,
                                 "Expected tissue type to be "+tissue.getTissueType().getName()+forTissue)
                 )
         );


### PR DESCRIPTION
Error messages such as "Invalid HMDMC number" now show "Invalid HuMFre number".
