### PR TITLE
Correct spelling of permeabilisation

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementType.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementType.java
@@ -9,7 +9,7 @@ public enum MeasurementType {
     Eosin(MeasurementValueType.TIME),
     Blueing(MeasurementValueType.TIME),
     Concentration(MeasurementValueType.DECIMAL, "ng/μL"),
-    Permabilisation_time(MeasurementValueType.TIME),
+    Permeabilisation_time(MeasurementValueType.TIME),
     Selected_time(MeasurementValueType.TIME),
     DV200(MeasurementValueType.DECIMAL, "%"),
     ;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/PermServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/PermServiceImp.java
@@ -167,7 +167,7 @@ public class PermServiceImp implements PermService {
             return;
         }
         if (permData == null || permData.isEmpty()) {
-            problems.add("No permabilisation data provided.");
+            problems.add("No permeabilisation data provided.");
             return;
         }
         validateAddresses(problems, lw, permData);
@@ -271,7 +271,7 @@ public class PermServiceImp implements PermService {
      * @return the operation recorded and the labware
      */
     public OperationResult record(User user, Labware lw, Collection<PermData> permData, Labware controlLabware, Work work) {
-        OperationType opType = opTypeRepo.getByName("Visium permabilisation");
+        OperationType opType = opTypeRepo.getByName("Visium permeabilisation");
 
         Operation addControlOp;
         if (controlLabware!=null) {
@@ -338,7 +338,7 @@ public class PermServiceImp implements PermService {
                         measurementName = "control";
                         measurementValue = pd.getControlType().name();
                     } else {
-                        measurementName = "permabilisation time";
+                        measurementName = "permeabilisation time";
                         measurementValue = pd.getSeconds().toString();
                     }
                     Slot slot = lw.getSlot(pd.getAddress());

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ResultServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ResultServiceImp.java
@@ -49,7 +49,7 @@ public class ResultServiceImp extends BaseResultService implements ResultService
 
     @Override
     public OperationResult recordVisiumQC(User user, ResultRequest request) {
-        return recordResultForOperation(user, request, "Visium permabilisation");
+        return recordResultForOperation(user, request, "Visium permeabilisation");
     }
 
     public OperationResult recordResultForOperation(User user, ResultRequest request, String refersToOpName) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/VisiumAnalysisServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/VisiumAnalysisServiceImp.java
@@ -107,9 +107,9 @@ public class VisiumAnalysisServiceImp implements VisiumAnalysisService {
         }
         List<Measurement> measurements = measurementRepo.findAllBySlotIdIn(List.of(slot.getId()));
         String value = time.toString();
-        if (measurements.stream().noneMatch(meas -> meas.getName().equalsIgnoreCase("permabilisation time") &&
+        if (measurements.stream().noneMatch(meas -> meas.getName().equalsIgnoreCase("permeabilisation time") &&
                 meas.getValue().equalsIgnoreCase(value))) {
-            problems.add(String.format("A permabilisation measurement of %s seconds was not found in slot %s of labware %s.",
+            problems.add(String.format("A permeabilisation measurement of %s seconds was not found in slot %s of labware %s.",
                     value, slot.getAddress(), lw.getBarcode()));
         }
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/VisiumPermDataService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/VisiumPermDataService.java
@@ -19,7 +19,7 @@ import static java.util.stream.Collectors.toMap;
  */
 @Service
 public class VisiumPermDataService {
-    static final String PERM_TIME = "permabilisation time",
+    static final String PERM_TIME = "permeabilisation time",
             SELECTED_TIME = "selected time",
             CONTROL = "control";
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestStainAndSubsequentMutations.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestStainAndSubsequentMutations.java
@@ -105,7 +105,7 @@ public class TestStainAndSubsequentMutations {
         Sample controlSample = entityCreator.createSample(tissue, 50);
         Labware controlLabware = entityCreator.createLabware("STAN-C0", entityCreator.getTubeType(), controlSample);
 
-        entityCreator.createOpType("Visium permabilisation", null, OperationTypeFlag.IN_PLACE);
+        entityCreator.createOpType("Visium permeabilisation", null, OperationTypeFlag.IN_PLACE);
         Object data = tester.post(tester.readGraphQL("perm.graphql"));
         List<?> ops = chainGet(data, "data", "recordPerm", "operations");
         assertThat(ops).hasSize(2);
@@ -124,7 +124,7 @@ public class TestStainAndSubsequentMutations {
         List<Measurement> measurements = measurementRepo.findAllByOperationIdIn(List.of(permId));
         assertThat(measurements).hasSize(2);
         Measurement timeMeasurement = measurements.stream()
-                .filter(m -> m.getName().equalsIgnoreCase("permabilisation time"))
+                .filter(m -> m.getName().equalsIgnoreCase("permeabilisation time"))
                 .findAny().orElseThrow();
         Measurement controlMeasurement = measurements.stream()
                 .filter(m -> m.getName().equalsIgnoreCase("control"))

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestPermService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestPermService.java
@@ -268,7 +268,7 @@ public class TestPermService {
             service.validatePermData(problems, lw, permData);
             verify(service, never()).validateAddresses(any(), any(), any());
             verify(service, never()).validatePermValues(any(), any());
-            assertThat(problems).containsExactly("No permabilisation data provided.");
+            assertThat(problems).containsExactly("No permeabilisation data provided.");
             return;
         }
         doAnswer(invocation -> {
@@ -364,7 +364,7 @@ public class TestPermService {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testRecord(boolean hasControlLabware) {
-        OperationType opType = EntityFactory.makeOperationType("Visium permabilisation", null);
+        OperationType opType = EntityFactory.makeOperationType("Visium permeabilisation", null);
         Work work = new Work(14, "SGP14", null, null, null, Work.Status.active);
         User user = EntityFactory.getUser();
         Labware lw = EntityFactory.getTube();
@@ -448,8 +448,8 @@ public class TestPermService {
         Integer sam1id = sam1.getId();
         Integer sam2id = sam2.getId();
         List<Measurement> expectedMeasurements = List.of(
-                new Measurement(null, "permabilisation time", "4", sam1id, opId, slot1id),
-                new Measurement(null, "permabilisation time", "4", sam2id, opId, slot1id),
+                new Measurement(null, "permeabilisation time", "4", sam1id, opId, slot1id),
+                new Measurement(null, "permeabilisation time", "4", sam2id, opId, slot1id),
                 new Measurement(null, "control", "positive", sam2id, opId, slot2id)
         );
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestResultService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestResultService.java
@@ -86,7 +86,7 @@ public class TestResultService {
         doReturn(opRes).when(service).recordResultForOperation(any(), any(), any());
 
         assertSame(opRes, service.recordVisiumQC(user, request));
-        verify(service).recordResultForOperation(same(user), same(request), eq("Visium permabilisation"));
+        verify(service).recordResultForOperation(same(user), same(request), eq("Visium permeabilisation"));
         assertEquals(resultOpName, request.getOperationType());
     }
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestVisiumAnalysisService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestVisiumAnalysisService.java
@@ -180,7 +180,7 @@ public class TestVisiumAnalysisService {
                 A3 = new Address(1,3);
         List<Measurement> a1Measurements = List.of(
                 new Measurement(10, "bananaas", "360", 10, 20, 30),
-                new Measurement(11, "permabilisation time", "240", 10, 20, 30)
+                new Measurement(11, "permeabilisation time", "240", 10, 20, 30)
         );
 
         return Arrays.stream(new Object[][] {
@@ -189,7 +189,7 @@ public class TestVisiumAnalysisService {
                 {lw, A3, 240, null, "Slot A3 does not exist in labware STAN-500."},
                 {lw, A2, 240, null, "There are no samples in slot A2 of labware STAN-500."},
                 {lw, A1, null, null, "No selected time specified."},
-                {lw, A1, 360, a1Measurements, "A permabilisation measurement of 360 seconds was not found " +
+                {lw, A1, 360, a1Measurements, "A permeabilisation measurement of 360 seconds was not found " +
                         "in slot A1 of labware STAN-500."},
                 {lw, A1, 240, a1Measurements, null},
         }).map(Arguments::of);


### PR DESCRIPTION
It was misspelled "permabilisation" in lots of places, include the database.
There are also db patches.