### PR TITLE
Change the planning behaviour so that it creates one plan per destination

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/request/plan/PlanRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/plan/PlanRequest.java
@@ -59,7 +59,7 @@ public class PlanRequest {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("operationType", operationType)
-                .add("Labwares", labware)
+                .add("labware", labware)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/plan/PlanRequestAction.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/plan/PlanRequestAction.java
@@ -6,7 +6,7 @@ import uk.ac.sanger.sccp.stan.model.Address;
 import java.util.Objects;
 
 /**
- * An reqeust for an action (i.e. one sample moving from one slot to another slot) in a planned operation.
+ * A request for an action (i.e. one sample moving from one slot to another slot) in a planned operation.
  * @author dr6
  */
 public class PlanRequestAction {


### PR DESCRIPTION
Previously it created one plan per request. However, the client sends single requests
for multiple destination labware, but has always assumed that the plan
applies to only one destination. Now it will.
