### PR TITLE
x860 support RNAscope and IHC stain being recorded at once

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Operation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Operation.java
@@ -35,12 +35,6 @@ public class Operation {
     private Integer planOperationId;
 
     @ManyToOne
-    @JoinTable(name="stain",
-            joinColumns = @JoinColumn(name="operation_id"),
-            inverseJoinColumns = @JoinColumn(name="stain_type_id"))
-    private StainType stainType;
-
-    @ManyToOne
     @JoinTable(name="operation_equipment",
             joinColumns = @JoinColumn(name="operation_id"),
             inverseJoinColumns = @JoinColumn(name="equipment_id"))
@@ -110,14 +104,6 @@ public class Operation {
         this.planOperationId = planOperationId;
     }
 
-    public StainType getStainType() {
-        return this.stainType;
-    }
-
-    public void setStainType(StainType stainType) {
-        this.stainType = stainType;
-    }
-
     public Equipment getEquipment() {
         return this.equipment;
     }
@@ -137,7 +123,6 @@ public class Operation {
                 && Objects.equals(this.user, that.user)
                 && Objects.equals(this.actions, that.actions)
                 && Objects.equals(this.planOperationId, that.planOperationId)
-                && Objects.equals(this.stainType, that.stainType)
                 && Objects.equals(this.equipment, that.equipment));
     }
 
@@ -152,7 +137,6 @@ public class Operation {
                 .add("id", id)
                 .add("performed", performed)
                 .add("operationType", operationType)
-                .addIfNotNull("stainType", stainType)
                 .addIfNotNull("equipment", equipment)
                 .toString();
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/StainTypeRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/StainTypeRepo.java
@@ -1,13 +1,66 @@
 package uk.ac.sanger.sccp.stan.repo;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.StainType;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+
+import static java.util.stream.Collectors.toSet;
 
 public interface StainTypeRepo extends CrudRepository<StainType, Integer> {
     List<StainType> findAllByEnabled(boolean enabled);
 
     Optional<StainType> findByName(String name);
+
+    List<StainType> findAllByNameIn(Collection<String> names);
+
+    @Query(value="select operation_id as opId, stain_type_id as stainTypeId from stain where operation_id in (?1) ORDER BY stain_type_id", nativeQuery=true)
+    List<Object[]> _stains(Collection<Integer> opIds);
+
+    /**
+     * Loads the stain types for the specified operations.
+     * Operations without stain types may be omitted from the returned map.
+     * @param opIds the ids of operations
+     * @return a map from operation id to associated stain types
+     */
+    default Map<Integer, List<StainType>> loadOperationStainTypes(Collection<Integer> opIds) {
+        List<Object[]> data = _stains(opIds);
+        if (data.isEmpty()) {
+            return Map.of();
+        }
+        Set<Integer> stainIds = data.stream()
+                .map(obj -> (Integer) obj[1])
+                .collect(toSet());
+        var stainTypes = findAllById(stainIds);
+        Map<Integer, StainType> stainTypeMap = new HashMap<>();
+        for (var stainType : stainTypes) {
+            stainTypeMap.put(stainType.getId(), stainType);
+        }
+        Map<Integer, List<StainType>> opStainTypes = new HashMap<>();
+        for (Object[] item : data) {
+            Integer opId = (Integer) item[0];
+            Integer stainTypeId = (Integer) item[1];
+            StainType stainType = stainTypeMap.get(stainTypeId);
+            opStainTypes.computeIfAbsent(opId, k -> new ArrayList<>()).add(stainType);
+        }
+        return opStainTypes;
+    }
+
+    @Modifying
+    @Query(value="insert into stain (operation_id, stain_type_id) values ((?1), (?2))", nativeQuery=true)
+    void _saveStain(Integer operationId, Integer stainTypeId);
+
+    /**
+     * Saves the given stain types in association with the specified operation.
+     * Old associations are not cleared. Clashes will cause exceptions.
+     * @param opId the id of the operation
+     * @param stainTypes the stain types to associate with the operation
+     */
+    default void saveOperationStainTypes(Integer opId, Collection<StainType> stainTypes) {
+        for (StainType stainType : stainTypes) {
+            _saveStain(opId, stainType.getId());
+        }
+    }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/stain/ComplexStainLabware.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/stain/ComplexStainLabware.java
@@ -13,14 +13,21 @@ public class ComplexStainLabware {
     private String bondBarcode;
     private int bondRun;
     private String workNumber;
+    private Integer plexRNAscope;
+    private Integer plexIHC;
+    private StainPanel panel;
 
     public ComplexStainLabware() {}
 
-    public ComplexStainLabware(String barcode, String bondBarcode, int bondRun, String workNumber) {
+    public ComplexStainLabware(String barcode, String bondBarcode, int bondRun, String workNumber,
+                               Integer plexRNAscope, Integer plexIHC, StainPanel panel) {
         this.barcode = barcode;
         this.bondBarcode = bondBarcode;
         this.bondRun = bondRun;
         this.workNumber = workNumber;
+        this.plexRNAscope = plexRNAscope;
+        this.plexIHC = plexIHC;
+        this.panel = panel;
     }
 
     public String getBarcode() {
@@ -55,20 +62,47 @@ public class ComplexStainLabware {
         this.workNumber = workNumber;
     }
 
+    public Integer getPlexRNAscope() {
+        return this.plexRNAscope;
+    }
+
+    public void setPlexRNAscope(Integer plexRNAscope) {
+        this.plexRNAscope = plexRNAscope;
+    }
+
+    public Integer getPlexIHC() {
+        return this.plexIHC;
+    }
+
+    public void setPlexIHC(Integer plexIHC) {
+        this.plexIHC = plexIHC;
+    }
+
+    public StainPanel getPanel() {
+        return this.panel;
+    }
+
+    public void setPanel(StainPanel panel) {
+        this.panel = panel;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ComplexStainLabware that = (ComplexStainLabware) o;
         return (this.bondRun == that.bondRun
+                && this.panel == that.panel
                 && Objects.equals(this.barcode, that.barcode)
                 && Objects.equals(this.bondBarcode, that.bondBarcode)
-                && Objects.equals(this.workNumber, that.workNumber));
+                && Objects.equals(this.workNumber, that.workNumber)
+                && Objects.equals(this.plexRNAscope, that.plexRNAscope)
+                && Objects.equals(this.plexIHC, that.plexIHC));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(barcode, bondBarcode, bondRun, workNumber);
+        return Objects.hash(barcode, bondBarcode, bondRun, workNumber, plexRNAscope, plexIHC, panel);
     }
 
     @Override
@@ -78,6 +112,9 @@ public class ComplexStainLabware {
                 .addRepr("bondBarcode", bondBarcode)
                 .add("bondRun", bondRun)
                 .addRepr("workNumber", workNumber)
+                .add("plexRNAscope", plexRNAscope)
+                .add("plexIHC", plexIHC)
+                .add("panel", panel)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/stain/ComplexStainRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/stain/ComplexStainRequest.java
@@ -9,44 +9,24 @@ import java.util.*;
  * @author dr6
  */
 public class ComplexStainRequest {
-    private String stainType;
-    private int plex;
-    private StainPanel panel;
+    private List<String> stainTypes;
     private List<ComplexStainLabware> labware;
 
     public ComplexStainRequest() {
-        this(null, 0, null, null);
+        this(null, null);
     }
 
-    public ComplexStainRequest(String stainType, int plex, StainPanel panel, List<ComplexStainLabware> labware) {
-        this.stainType = stainType;
-        this.plex = plex;
-        this.panel = panel;
+    public ComplexStainRequest(List<String> stainTypes, List<ComplexStainLabware> labware) {
+        setStainTypes(stainTypes);
         setLabware(labware);
     }
 
-    public String getStainType() {
-        return this.stainType;
+    public List<String> getStainTypes() {
+        return this.stainTypes;
     }
 
-    public void setStainType(String stainType) {
-        this.stainType = stainType;
-    }
-
-    public int getPlex() {
-        return this.plex;
-    }
-
-    public void setPlex(int plex) {
-        this.plex = plex;
-    }
-
-    public StainPanel getPanel() {
-        return this.panel;
-    }
-
-    public void setPanel(StainPanel panel) {
-        this.panel = panel;
+    public void setStainTypes(List<String> stainTypes) {
+        this.stainTypes = (stainTypes==null ? List.of() : stainTypes);
     }
 
     public List<ComplexStainLabware> getLabware() {
@@ -62,23 +42,19 @@ public class ComplexStainRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ComplexStainRequest that = (ComplexStainRequest) o;
-        return (this.plex == that.plex
-                && Objects.equals(this.stainType, that.stainType)
-                && this.panel==that.panel
+        return (Objects.equals(this.stainTypes, that.stainTypes)
                 && Objects.equals(this.labware, that.labware));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(stainType, plex, panel, labware);
+        return Objects.hash(stainTypes, labware);
     }
 
     @Override
     public String toString() {
         return BasicUtils.describe("ComplexStainRequest")
-                .addRepr("stainType", stainType)
-                .add("plex", plex)
-                .add("panel", panel)
+                .add("stainType", stainTypes)
                 .add("labware", labware)
                 .toString();
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
@@ -401,10 +401,8 @@ public class ReleaseFileService {
         }
         Set<Integer> opIds = entryStainOp.values().stream().map(Operation::getId).collect(toSet());
 
-        // TODO : when multistain is merged in, we have to get stain types from StainTypeRepo
-        Map<Integer, String> stainOpTypes = entryStainOp.values().stream()
-                .distinct()
-                .collect(toMap(Operation::getId, op -> op.getStainType().getName()));
+        Map<Integer, String> stainOpTypes = stainTypeRepo.loadOperationStainTypes(opIds).entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, e -> e.getValue().stream().map(StainType::getName).collect(joining(", "))));
 
         Map<Integer, String> opBondBarcodes = lwNoteRepo.findAllByOperationIdIn(opIds).stream()
                 .filter(note -> ComplexStainServiceImp.LW_NOTE_BOND_BARCODE.equalsIgnoreCase(note.getName()))

--- a/src/main/resources/db/changelog/changelog-2.7.xml
+++ b/src/main/resources/db/changelog/changelog-2.7.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="2.7.0" author="dr6">
+        <dropForeignKeyConstraint baseTableName="stain" constraintName="fk_stain_operation"/>
+        <dropPrimaryKey tableName="stain"/>
+        <addPrimaryKey tableName="stain" columnNames="operation_id,stain_type_id"/>
+        <addForeignKeyConstraint baseTableName="stain" baseColumnNames="operation_id" constraintName="fk_stain_operation"
+                                 referencedTableName="operation" referencedColumnNames="id"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -13,4 +13,5 @@
     <include relativeToChangelogFile="true" file="changelog-2.1.0.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.1.1.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.6.xml"/>
+    <include relativeToChangelogFile="true" file="changelog-2.7.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -918,16 +918,18 @@ input ComplexStainLabware {
     bondRun: Int!
     """An optional work number to associate with this operation."""
     workNumber: String
+    """The plex for RNAscope if that is being recorded."""
+    plexRNAscope: Int
+    """The plex for IHC if that is being recorded."""
+    plexIHC: Int
+    """The experiment panel."""
+    panel: StainPanel!
 }
 
 """A request for a stain including bond barcodes and such."""
 input ComplexStainRequest {
-    """The name of the type of stain being recorded."""
-    stainType: String!
-    """The plex number."""
-    plex: Int!
-    """The stain panel."""
-    panel: StainPanel!
+    """The names of the types of stain being recorded."""
+    stainTypes: [String!]!
     """The details of the labware being stained."""
     labware: [ComplexStainLabware!]!
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
@@ -154,8 +154,10 @@ public class TestReleaseMutation {
     private void recordStain(Labware lw, StainType st, String bondBarcode, User user) {
         OperationType opType = opTypeRepo.getByName("Stain");
         Operation op = new Operation(null, opType, null, null, user);
-        op.setStainType(st);
         op = opRepo.save(op);
+        if (st!=null) {
+            stainTypeRepo.saveOperationStainTypes(op.getId(), List.of(st));
+        }
         Slot slot = lw.getFirstSlot();
         Sample sample = slot.getSamples().get(0);
         actionRepo.save(new Action(null, op.getId(), slot, slot, sample, sample));

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestStainAndSubsequentMutations.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestStainAndSubsequentMutations.java
@@ -44,6 +44,8 @@ public class TestStainAndSubsequentMutations {
     private TissueRepo tissueRepo;
     @Autowired
     private OperationCommentRepo opCommentRepo;
+    @Autowired
+    private StainTypeRepo stainTypeRepo;
 
     @Transactional
     @Test
@@ -65,7 +67,9 @@ public class TestStainAndSubsequentMutations {
         assertEquals("Stain", chainGet(opData, "operationType", "name"));
 
         Operation op = opRepo.findById(opId).orElseThrow();
-        assertEquals(op.getStainType().getName(), "H&E");
+        final List<StainType> stainTypes = stainTypeRepo.loadOperationStainTypes(List.of(opId)).get(opId);
+        assertThat(stainTypes).hasSize(1);
+        assertEquals("H&E", stainTypes.get(0).getName());
 
         data = tester.post(tester.readGraphQL("workprogress.graphql").replace("SGP500", work.getWorkNumber()));
         Object progressData = chainGet(data, "data", "workProgress", 0);

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestWorkProgressQuery.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestWorkProgressQuery.java
@@ -55,13 +55,6 @@ public class TestWorkProgressQuery {
     @Test
     @Transactional
     public void testWorkProgressQuery() throws Exception {
-        /*
-        existing optypes:
-        Register
-                Section
-        Extract
-        Visium cDNA
-        */
 
         OperationType sectionOpType = opTypeRepo.getByName("Section");
         OperationType cdnaOpType = opTypeRepo.getByName("Visium cDNA");
@@ -131,10 +124,12 @@ public class TestWorkProgressQuery {
 
     private Operation createOp(OperationType opType, StainType stainType, User user, Labware src, Labware dst, int day) {
         Operation op = new Operation(null, opType, null, List.of(), user);
-        op.setStainType(stainType);
         op = opRepo.save(op);
         op.setPerformed(time(day));
         op = opRepo.save(op);
+        if (stainType!=null) {
+            stainTypeRepo.saveOperationStainTypes(op.getId(), List.of(stainType));
+        }
         Sample sample = dst.getFirstSlot().getSamples().get(0);
         actionRepo.save(new Action(null, op.getId(), src.getFirstSlot(), dst.getFirstSlot(), sample, sample));
         entityManager.flush();

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestStainTypeRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestStainTypeRepo.java
@@ -1,0 +1,66 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Test {@link StainTypeRepo}
+ * @author dr6
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+public class TestStainTypeRepo {
+    @Autowired
+    StainTypeRepo stainTypeRepo;
+    @Autowired
+    UserRepo userRepo;
+    @Autowired
+    OperationTypeRepo opTypeRepo;
+    @Autowired
+    OperationRepo opRepo;
+
+    @Transactional
+    @Test
+    public void testOperationStainTypes() {
+        OperationType opType = opTypeRepo.getByName("Stain");
+        User user = userRepo.save(new User(null, "user1", User.Role.normal));
+        Operation op1 = opRepo.save(new Operation(null, opType, null, null, user));
+        Operation op2 = opRepo.save(new Operation(null, opType, null, null, user));
+
+        List<Integer> opIds = List.of(op1.getId(), op2.getId());
+
+        for (var ots : stainTypeRepo.loadOperationStainTypes(opIds).values()) {
+            assertThat(ots).isNullOrEmpty();
+        }
+
+        StainType st1 = stainTypeRepo.findByName("H&E").orElseThrow();
+        StainType st2 = stainTypeRepo.findByName("Masson's Trichrome").orElseThrow();
+
+        assertThat(st1.getId()).isLessThan(st2.getId()); // * this is a precondition of other assertions
+
+        stainTypeRepo.saveOperationStainTypes(op1.getId(), List.of(st2, st1));
+
+        var opStainTypes = stainTypeRepo.loadOperationStainTypes(opIds);
+        assertThat(opStainTypes.get(op1.getId())).containsExactly(st1, st2); // sorted by stain type id (*)
+        assertThat(opStainTypes.get(op2.getId())).isNullOrEmpty();
+
+        opStainTypes = stainTypeRepo.loadOperationStainTypes(List.of(op2.getId()));
+        assertNull(opStainTypes.get(op1.getId()));
+        assertThat(opStainTypes.get(op2.getId())).isNullOrEmpty();
+
+        stainTypeRepo.saveOperationStainTypes(op2.getId(), List.of(st1));
+        opStainTypes = stainTypeRepo.loadOperationStainTypes(opIds);
+        assertThat(opStainTypes.get(op1.getId())).containsExactly(st1, st2);
+        assertThat(opStainTypes.get(op2.getId())).containsExactly(st1);
+    }
+
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/OperationServiceTest.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/OperationServiceTest.java
@@ -145,7 +145,7 @@ public class OperationServiceTest {
 
     @Test
     public void testCreateOperationInPlace() {
-        OperationType opType = new OperationType(2, "Stain");
+        OperationType opType = new OperationType(2, "Mash");
         User user = EntityFactory.getUser();
         Sample sam1 = EntityFactory.getSample();
         Sample sam2 = new Sample(sam1.getId()+1, 2, sam1.getTissue(), sam1.getBioState());
@@ -154,9 +154,9 @@ public class OperationServiceTest {
         LabwareType lt = EntityFactory.makeLabwareType(3,1);
         Labware lw = EntityFactory.makeLabware(lt, sam1, sam2);
         lw.getFirstSlot().getSamples().add(sam2);
-        StainType st = new StainType(1, "Bananas");
+        Equipment eq = new Equipment(1, "Bananas", "Protein", true);
         Integer planId = 700;
-        Consumer<Operation> opMod = op -> op.setStainType(st);
+        Consumer<Operation> opMod = op -> op.setEquipment(eq);
         Operation op = opService.createOperationInPlace(opType, user, lw, planId, opMod);
         int slot1id = lw.getFirstSlot().getId();
         int slot2id = lw.getSlot(new Address(2,1)).getId();
@@ -166,7 +166,7 @@ public class OperationServiceTest {
         assertThat(savedActions).hasSize(3);
         assertEquals(op.getActions(), savedActions);
         assertEquals(op.getOperationType(), opType);
-        assertEquals(op.getStainType(), st);
+        assertEquals(op.getEquipment(), eq);
         assertEquals(op.getPlanOperationId(), planId);
         List<List<Integer>> slotSampleIds = new ArrayList<>(3);
         for (Action ac : op.getActions()) {

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
@@ -576,7 +576,8 @@ public class TestReleaseFileService {
 
         Operation op1 = new Operation(500, stainOpType, null, null, null, null);
         StainType st1 = new StainType(1, "Red");
-        op1.setStainType(st1);
+        StainType st2 = new StainType(2, "Blue");
+        when(mockStainTypeRepo.loadOperationStainTypes(any())).thenReturn(Map.of(op1.getId(), List.of(st1, st2)));
 
         final String bond1 = "Casino Royale";
         List<LabwareNote> notes = List.of(
@@ -598,8 +599,9 @@ public class TestReleaseFileService {
         verify(service).labwareIdToOp(List.of(op1));
         verify(service).findEntryOps(entries, lwStainMap, ancestry);
         verify(mockLwNoteRepo).findAllByOperationIdIn(Set.of(op1.getId()));
+        verify(mockStainTypeRepo).loadOperationStainTypes(Set.of(op1.getId()));
 
-        assertEquals(st1.getName(), entries.get(0).getStainType());
+        assertEquals("Red, Blue", entries.get(0).getStainType());
         assertEquals(bond1, entries.get(0).getBondBarcode());
         assertNull(entries.get(1).getStainType());
         assertNull(entries.get(1).getBondBarcode());

--- a/src/test/resources/graphql/complexstain.graphql
+++ b/src/test/resources/graphql/complexstain.graphql
@@ -1,13 +1,14 @@
 mutation {
     recordComplexStain(request: {
-        stainType: "RNAscope"
-        panel: positive
-        plex: 6
+        stainTypes: ["RNAscope", "IHC"]
         labware: [
             {
                 barcode: "STAN-A1"
                 bondBarcode: "12340ABC"
                 bondRun: 8
+                plexIHC: 12
+                plexRNAscope: 13
+                panel: positive
             }
         ]
     }) {


### PR DESCRIPTION
An operation can now have multiple stain types.
ComplexStainRequest supports multiple stain types.
Plex number and panel are now specified per labware.
Plex number is separated into RNAscope plex and IHC plex so they can both
be recorded on the same labware in the same op.
The Operation entity no longer has stain type as a field: it must
be saved/loaded explicitly using StainTypeRepo.
Bond barcodes can now be 4 to 8 characters (formerly 8 exactly).