### PR TITLE
x866 Make it possible to record Visium QC without a preceding perm

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/service/BaseResultService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/BaseResultService.java
@@ -111,10 +111,11 @@ public abstract class BaseResultService {
      * @param problems receptacle for problems found
      * @param opType the type of op to look up
      * @param labware the labware that is the destinations of the operations
+     * @param required whether the operation being not found consitutes a problem
      * @return a map from labware id to operation id
      */
     public Map<Integer, Integer> lookUpLatestOpIds(Collection<String> problems, OperationType opType,
-                                                   Collection<Labware> labware) {
+                                                   Collection<Labware> labware, boolean required) {
         Set<Integer> labwareIds = labware.stream().map(Labware::getId).collect(toSet());
         List<Operation> ops = opRepo.findAllByOperationTypeAndDestinationLabwareIdIn(opType, labwareIds);
         Map<Integer, Integer> opsMap = makeLabwareOpIdMap(ops);
@@ -122,7 +123,7 @@ public abstract class BaseResultService {
                 .filter(lw -> !opsMap.containsKey(lw.getId()))
                 .map(Labware::getBarcode)
                 .collect(toList());
-        if (!unmatchedBarcodes.isEmpty()) {
+        if (required && !unmatchedBarcodes.isEmpty()) {
             problems.add("No "+opType.getName()+" operation has been recorded on the following labware: "+unmatchedBarcodes);
         }
         return opsMap;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultServiceImp.java
@@ -160,7 +160,7 @@ public class ExtractResultServiceImp extends BaseResultService implements Extrac
         if (extractOpType==null || labware.isEmpty()) {
             return Map.of();
         }
-        return lookUpLatestOpIds(problems, extractOpType, labware);
+        return lookUpLatestOpIds(problems, extractOpType, labware, true);
     }
 
     /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/extract/ExtractResultQueryService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/extract/ExtractResultQueryService.java
@@ -117,7 +117,8 @@ public class ExtractResultQueryService {
         }
 
         Map<Integer, Operation> referredToOps = Streamable.of(
-                        opRepo.findAllById(resultOps.stream().map(ResultOp::getRefersToOpId).collect(toSet()))
+                        opRepo.findAllById(resultOps.stream().map(ResultOp::getRefersToOpId).
+                                filter(Objects::nonNull).collect(toSet()))
                 ).stream()
                 .filter(op -> op.getOperationType().getName().equalsIgnoreCase(EXTRACT_OP_NAME))
                 .collect(BasicUtils.toMap(Operation::getId));

--- a/src/main/resources/db/changelog/changelog-1.9B.xml
+++ b/src/main/resources/db/changelog/changelog-1.9B.xml
@@ -21,7 +21,7 @@
                 <constraints nullable="false" foreignKeyName="fk_result_op_slot" referencedTableName="slot" referencedColumnNames="id"/>
             </column>
             <column name="refers_to_op_id" type="INT">
-                <constraints nullable="false" foreignKeyName="fk_result_op_refers_to_op" referencedTableName="operation" referencedColumnNames="id"/>
+                <constraints nullable="true" foreignKeyName="fk_result_op_refers_to_op" referencedTableName="operation" referencedColumnNames="id"/>
             </column>
             <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestExtractResultService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestExtractResultService.java
@@ -254,13 +254,13 @@ public class TestExtractResultService {
         if (opTypeExists && anyLabware) {
             idMap = Map.of(4, 5);
             if (allFine) {
-                doReturn(idMap).when(service).lookUpLatestOpIds(any(), any(), any());
+                doReturn(idMap).when(service).lookUpLatestOpIds(any(), any(), any(), anyBoolean());
             } else {
                 doAnswer(invocation -> {
                     Collection<String> problems = invocation.getArgument(0);
                     problems.add(opError);
                     return idMap;
-                }).when(service).lookUpLatestOpIds(any(), any(), any());
+                }).when(service).lookUpLatestOpIds(any(), any(), any(), anyBoolean());
             }
         } else {
             idMap = Map.of();
@@ -281,9 +281,9 @@ public class TestExtractResultService {
         }
 
         if (opTypeExists && anyLabware) {
-            verify(service).lookUpLatestOpIds(problems, opType, lwList);
+            verify(service).lookUpLatestOpIds(problems, opType, lwList, true);
         } else {
-            verify(service, never()).lookUpLatestOpIds(any(), any(), any());
+            verify(service, never()).lookUpLatestOpIds(any(), any(), any(), anyBoolean());
         }
     }
 


### PR DESCRIPTION
The result service expects a result to refer to a prior operation.
For Visium QC, that operation is Visium Perm. Now I have made that
relationship optional: the result_op.refers_to_op_id column is now
nullable, and you can record Visium QC without a prior perm op.
