### PR TITLE
x672: add Tissue.collectionDate

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Tissue.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Tissue.java
@@ -3,6 +3,7 @@ package uk.ac.sanger.sccp.stan.model;
 import com.google.common.base.MoreObjects;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.util.Objects;
 
 /**
@@ -26,11 +27,12 @@ public class Tissue {
     private Fixative fixative;
     @ManyToOne
     private Hmdmc hmdmc;
+    private LocalDate collectionDate;
 
     public Tissue() {}
 
     public Tissue(Integer id, String externalName, String replicate, SpatialLocation spatialLocation, Donor donor,
-                  Medium medium, Fixative fixative, Hmdmc hmdmc) {
+                  Medium medium, Fixative fixative, Hmdmc hmdmc, LocalDate collectionDate) {
         this.id = id;
         this.externalName = externalName;
         this.replicate = replicate;
@@ -39,6 +41,7 @@ public class Tissue {
         this.medium = medium;
         this.fixative = fixative;
         this.hmdmc = hmdmc;
+        this.collectionDate = collectionDate;
     }
 
     public Integer getId() {
@@ -109,6 +112,14 @@ public class Tissue {
         this.hmdmc = hmdmc;
     }
 
+    public LocalDate getCollectionDate() {
+        return this.collectionDate;
+    }
+
+    public void setCollectionDate(LocalDate collectionDate) {
+        this.collectionDate = collectionDate;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -121,7 +132,9 @@ public class Tissue {
                 && Objects.equals(this.medium, that.medium)
                 && Objects.equals(this.donor, that.donor)
                 && Objects.equals(this.hmdmc, that.hmdmc)
-                && Objects.equals(this.fixative, that.fixative));
+                && Objects.equals(this.fixative, that.fixative)
+                && Objects.equals(this.collectionDate, that.collectionDate)
+        );
     }
 
     @Override
@@ -140,6 +153,7 @@ public class Tissue {
                 .add("medium", medium)
                 .add("fixative", fixative)
                 .add("hmdmc", hmdmc)
+                .add("collectionDate", collectionDate)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/register/BlockRegisterRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/register/BlockRegisterRequest.java
@@ -3,6 +3,7 @@ package uk.ac.sanger.sccp.stan.request.register;
 import com.google.common.base.MoreObjects;
 import uk.ac.sanger.sccp.stan.model.LifeStage;
 
+import java.time.LocalDate;
 import java.util.Objects;
 
 /**
@@ -23,6 +24,7 @@ public class BlockRegisterRequest {
     private String fixative;
     private String species;
     private boolean existingTissue;
+    private LocalDate sampleCollectionDate;
 
     public String getDonorIdentifier() {
         return this.donorIdentifier;
@@ -128,6 +130,14 @@ public class BlockRegisterRequest {
         this.existingTissue = existingTissue;
     }
 
+    public LocalDate getSampleCollectionDate() {
+        return this.sampleCollectionDate;
+    }
+
+    public void setSampleCollectionDate(LocalDate sampleCollectionDate) {
+        this.sampleCollectionDate = sampleCollectionDate;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -145,7 +155,9 @@ public class BlockRegisterRequest {
                 && Objects.equals(this.labwareType, that.labwareType)
                 && Objects.equals(this.medium, that.medium)
                 && Objects.equals(this.fixative, that.fixative)
-                && Objects.equals(this.species, that.species));
+                && Objects.equals(this.species, that.species)
+                && Objects.equals(this.sampleCollectionDate, that.sampleCollectionDate)
+        );
     }
 
     @Override
@@ -169,6 +181,7 @@ public class BlockRegisterRequest {
                 .add("fixative", fixative)
                 .add("species", species)
                 .add("existingTissue", existingTissue)
+                .add("sampleCollectionDate", sampleCollectionDate)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/SectionRegisterValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/SectionRegisterValidation.java
@@ -328,7 +328,7 @@ public class SectionRegisterValidation {
             }
 
             Tissue tissue = new Tissue(null, externalIdentifier, content.getReplicateNumber().toLowerCase(),
-                    spatialLocation, donor, medium, fixative, hmdmc);
+                    spatialLocation, donor, medium, fixative, hmdmc, null);
             tissueMap.put(externalIdentifier, tissue);
         }
 

--- a/src/main/resources/db/changelog/changelog-2.7.xml
+++ b/src/main/resources/db/changelog/changelog-2.7.xml
@@ -10,5 +10,13 @@
         <addForeignKeyConstraint baseTableName="stain" baseColumnNames="operation_id" constraintName="fk_stain_operation"
                                  referencedTableName="operation" referencedColumnNames="id"/>
     </changeSet>
+    
+    <changeSet id="2.7.1" author="dr6">
+        <addColumn tableName="tissue">
+            <column name="collection_date" type="DATE" defaultValue="NULL">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -145,6 +145,8 @@ type Tissue {
     medium: Medium!
     """The fixative used on this tissue."""
     fixative: Fixative!
+    """The date the original sample was collected, if known."""
+    collectionDate: Date
 }
 
 """A particular sample of tissue, in a particular state."""
@@ -223,6 +225,8 @@ input BlockRegisterRequest {
     species: String!
     """Is this a new block of tissue already in the application's database?"""
     existingTissue: Boolean
+    """The date the original sample was collected, if known."""
+    sampleCollectionDate: Date
 }
 
 """A request to register one or more blocks of tissue."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/EntityCreator.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/EntityCreator.java
@@ -97,7 +97,7 @@ public class EntityCreator {
             donor = createDonor("DONOR1");
         }
         return tissueRepo.save(new Tissue(null, externalName, replicate, getAny(slRepo), donor,
-                getAny(mediumRepo), getAny(fixativeRepo), getAny(hmdmcRepo)));
+                getAny(mediumRepo), getAny(fixativeRepo), getAny(hmdmcRepo), null));
     }
 
     public Sample createSample(Tissue tissue, Integer section) {

--- a/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/EntityFactory.java
@@ -102,7 +102,7 @@ public class EntityFactory {
     public static Tissue getTissue() {
         if (tissue==null) {
             tissue = new Tissue(80, "TISSUE1", "1", getSpatialLocation(), getDonor(),
-                    getMedium(), getFixative(), getHmdmc());
+                    getMedium(), getFixative(), getHmdmc(), null);
         }
         return tissue;
     }
@@ -188,7 +188,7 @@ public class EntityFactory {
 
     public static Tissue makeTissue(Donor donor, SpatialLocation sl) {
         int id = ++idCounter;
-        return new Tissue(id, "TISSUE "+id, String.valueOf(id%7), sl, donor, getMedium(), getFixative(), getHmdmc());
+        return new Tissue(id, "TISSUE "+id, String.valueOf(id%7), sl, donor, getMedium(), getFixative(), getHmdmc(), null);
     }
 
     public static ReagentPlate makeReagentPlate(String barcode) {

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterMutation.java
@@ -56,6 +56,7 @@ public class TestRegisterMutation {
         Map<String, ?> tissueData = chainGet(data, "labware", 0, "slots", 0, "samples", 0, "tissue");
         assertEquals("TISSUE1", tissueData.get("externalName"));
         assertEquals("Human", chainGet(tissueData, "donor", "species", "name"));
+        assertEquals("2021-02-03", tissueData.get("collectionDate"));
 
         result = tester.post(mutation);
         data = chainGet(result, "data", "register");

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestPlanActionRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestPlanActionRepo.java
@@ -74,7 +74,7 @@ public class TestPlanActionRepo {
         Donor donor = new Donor(null, "DONOR", LifeStage.adult, entityCreator.getHuman());
         donorRepo.save(donor);
         Tissue tissue = new Tissue(null, "TISSUE1", "1", any(slRepo), donor,
-                any(mediumRepo), any(fixativeRepo), any(hmdmcRepo));
+                any(mediumRepo), any(fixativeRepo), any(hmdmcRepo), null);
         BioState bioState = any(bioStateRepo);
         tissueRepo.save(tissue);
         final Sample sample = new Sample(null, 3, tissue, bioState);

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestTissueRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestTissueRepo.java
@@ -68,7 +68,7 @@ public class TestTissueRepo {
         String rep2 = "2";
 
         Tissue tissue = tissueRepo.save(new Tissue(null, "TISSUE1", rep1, sl1, donor1,
-                med1, fix1, entityCreator.getAny(hmdmcRepo)));
+                med1, fix1, entityCreator.getAny(hmdmcRepo), null));
 
         assertThat(tissueRepo.findByDonorIdAndSpatialLocationIdAndMediumIdAndFixativeIdAndReplicate(donor1.getId(), sl1.getId(), med1.getId(), fix1.getId(), rep1))
                 .contains(tissue);
@@ -126,7 +126,7 @@ public class TestTissueRepo {
         Hmdmc hmdmc = entityCreator.getAny(hmdmcRepo);
         Tissue[] tissues = IntStream.range(0, 3)
                 .mapToObj(i -> tissueRepo.save(new Tissue(null, "TISSUE"+i, String.valueOf(i+1), sls[i],
-                        donor, med, fix, hmdmc)))
+                        donor, med, fix, hmdmc, null)))
                 .toArray(Tissue[]::new);
         assertThat(tissueRepo.findByTissueTypeId(tt1.getId())).containsExactly(tissues[0], tissues[1]);
     }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestFindService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestFindService.java
@@ -329,7 +329,7 @@ public class TestFindService {
         SpatialLocation sl2 = new SpatialLocation(201, "SL2", 2, tt2);
         Donor donor2 = new Donor(null, "DONOR2", LifeStage.fetal, species);
         Tissue tissue2 = new Tissue(201, "TISSUE2", "4", sl2, donor2, tissue1.getMedium(),
-                tissue1.getFixative(), tissue1.getHmdmc());
+                tissue1.getFixative(), tissue1.getHmdmc(), null);
         Sample sample2 = new Sample(202, 2, tissue2, EntityFactory.getBioState());
 
         List<LabwareSample> lss = List.of(

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterService.java
@@ -114,9 +114,9 @@ public class TestSectionRegisterService {
     public void testAssembleResult() {
         Tissue tissue1 = EntityFactory.getTissue();
         Tissue tissue2 = new Tissue(tissue1.getId() + 1, "TISSUE 2", "10", tissue1.getSpatialLocation(), tissue1.getDonor(),
-                tissue1.getMedium(), tissue1.getFixative(), tissue1.getHmdmc());
+                tissue1.getMedium(), tissue1.getFixative(), tissue1.getHmdmc(), null);
         Tissue tissue3 = new Tissue(tissue1.getId() + 2, "TISSUE 3", "10", tissue1.getSpatialLocation(), tissue1.getDonor(),
-                tissue1.getMedium(), tissue1.getFixative(), tissue1.getHmdmc());
+                tissue1.getMedium(), tissue1.getFixative(), tissue1.getHmdmc(), null);
         UCMap<Tissue> tissueMap = UCMap.from(Tissue::getExternalName, tissue1, tissue2, tissue3);
 
         BioState bs = EntityFactory.getBioState();

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterValidation.java
@@ -466,9 +466,9 @@ public class TestSectionRegisterValidation {
                         .content("EXT1", "4", "Arm", 1, "Donor1", "None", "None", "2021/01", "human")
                         .content("EXT2", "5", "Leg", 2, "Donor1", "butter", "Formalin", "2021/02", "human")
                         .content("EXT3", "5", "Leg", 1, "Donor2", "butter", "Formalin", null, "hamster")
-                        .tissues(new Tissue(null, "EXT1", "4", ARM.getSpatialLocations().get(0), DONOR1, mediumNone, fixNone, hmdmc1),
-                                new Tissue(null, "EXT2", "5", LEG.getSpatialLocations().get(1), DONOR1, medium, fix, hmdmc2),
-                                new Tissue(null, "EXT3", "5", LEG.getSpatialLocations().get(0), DONOR2, medium, fix, null)),
+                        .tissues(new Tissue(null, "EXT1", "4", ARM.getSpatialLocations().get(0), DONOR1, mediumNone, fixNone, hmdmc1, null),
+                                new Tissue(null, "EXT2", "5", LEG.getSpatialLocations().get(1), DONOR1, medium, fix, hmdmc2, null),
+                                new Tissue(null, "EXT3", "5", LEG.getSpatialLocations().get(0), DONOR2, medium, fix, null, null)),
 
                 // Single problems
                 testData.get()
@@ -510,8 +510,8 @@ public class TestSectionRegisterValidation {
                         .content("TISSUE1", "4", "ARM", 1, "Donor1", "none", "none", "2021/01", "human")
                         .content("TISSUE2", "4", "ARM", 1, "Donor1", "none", "none", "2021/01", "human")
                         .content("TISSUE3", "4", "ARM", 1, "Donor1", "none", "none", "2021/01", "human")
-                        .existing(new Tissue(1, "TISSUE1", "3", ARM.getSpatialLocations().get(0), DONOR1, medium, fix, hmdmcs.get(0)),
-                                new Tissue(2, "TISSUE2", "3", ARM.getSpatialLocations().get(0), DONOR1, medium, fix, hmdmcs.get(0)))
+                        .existing(new Tissue(1, "TISSUE1", "3", ARM.getSpatialLocations().get(0), DONOR1, medium, fix, hmdmcs.get(0), null),
+                                new Tissue(2, "TISSUE2", "3", ARM.getSpatialLocations().get(0), DONOR1, medium, fix, hmdmcs.get(0), null))
                         .problem("External identifiers already in use: [TISSUE1, TISSUE2]"),
                 testData.get()
                         .content("EXT1", "4", null, 1, "Donor1", "None", "None", "2021/01", "Human")

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestTissueFieldChecker.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestTissueFieldChecker.java
@@ -8,6 +8,7 @@ import uk.ac.sanger.sccp.stan.EntityFactory;
 import uk.ac.sanger.sccp.stan.model.Tissue;
 import uk.ac.sanger.sccp.stan.request.register.BlockRegisterRequest;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -72,9 +73,13 @@ public class TestTissueFieldChecker {
     static Stream<Arguments> checkArgs() {
         final Tissue tissue = EntityFactory.getTissue();
         final String forTissue = " for existing tissue "+tissue.getExternalName()+".";
+        final Tissue tissueWithDate = EntityFactory.makeTissue(tissue.getDonor(), tissue.getSpatialLocation());
+        tissueWithDate.setCollectionDate(LocalDate.of(2021,2,3));
 
         return Stream.of(
                 Arguments.of(toBRR(tissue, null), tissue, null),
+                Arguments.of(toBRR(tissueWithDate, null), tissueWithDate, null),
+                Arguments.of(toBRR(tissue, br -> br.setSampleCollectionDate(LocalDate.of(2020,1,2))), tissue, null),
                 Arguments.of(toBRR(tissue, br -> br.setDonorIdentifier("Foo")), tissue, "Expected donor identifier to be "+tissue.getDonor().getDonorName()+forTissue),
                 Arguments.of(toBRR(tissue, br -> br.setHmdmc("12/345")), tissue, "Expected HuMFre number to be "+tissue.getHmdmc().getHmdmc()+forTissue),
                 Arguments.of(toBRR(tissue, br -> br.setTissueType("Plumbus")), tissue, "Expected tissue type to be "+tissue.getTissueType().getName()+forTissue),
@@ -82,6 +87,7 @@ public class TestTissueFieldChecker {
                 Arguments.of(toBRR(tissue, br -> br.setReplicateNumber("-5")), tissue, "Expected replicate number to be "+tissue.getReplicate()+forTissue),
                 Arguments.of(toBRR(tissue, br -> br.setMedium("Custard")), tissue, "Expected medium to be "+tissue.getMedium().getName()+forTissue),
                 Arguments.of(toBRR(tissue, br -> br.setFixative("Glue")), tissue, "Expected fixative to be "+tissue.getFixative().getName()+forTissue),
+                Arguments.of(toBRR(tissueWithDate, br -> br.setSampleCollectionDate(LocalDate.of(2020,1,2))), tissueWithDate, "Expected sample collection date to be "+tissueWithDate.getCollectionDate()+" for existing tissue "+tissueWithDate.getExternalName()+"."),
                 Arguments.of(toBRR(tissue, br -> {
                     br.setDonorIdentifier("Foo");
                     br.setHmdmc("12/345");
@@ -105,6 +111,7 @@ public class TestTissueFieldChecker {
         br.setReplicateNumber(tissue.getReplicate());
         br.setMedium(tissue.getMedium().getName());
         br.setFixative(tissue.getFixative().getName());
+        br.setSampleCollectionDate(tissue.getCollectionDate());
         if (adjuster!=null) {
             adjuster.accept(br);
         }

--- a/src/test/resources/graphql/register.graphql
+++ b/src/test/resources/graphql/register.graphql
@@ -14,6 +14,7 @@ mutation {
                 medium:"None",
                 fixative:"None",
                 highestSection:0,
+                sampleCollectionDate: "2021-02-03",
             }
         ]
     }) {
@@ -27,6 +28,7 @@ mutation {
                         donor {
                             species { name }
                         }
+                        collectionDate
                     }
                 }
             }


### PR DESCRIPTION
Support a "sampleCollectionDate" field in block registration.
The date is compulsory when registering human fetal samples; optional
for other samples. It is saved in the tissue table. Existing tissues still have
null for this column.
When existing tissue is registered, the date must be consistent;
except you may specify a date for tissue that previously had no date.
In that case the existing tissue will be updated with the given date.
