### PR TITLE
x869 Add labware.used

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Labware.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Labware.java
@@ -18,7 +18,7 @@ import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
 public class Labware {
 
     public enum State {
-        empty, active, discarded, released, destroyed
+        empty, active, discarded, released, destroyed, used
     }
 
     @Id
@@ -38,6 +38,7 @@ public class Labware {
     private boolean discarded;
     private boolean released;
     private boolean destroyed;
+    private boolean used;
 
     @Generated(GenerationTime.INSERT)
     private LocalDateTime created;
@@ -159,6 +160,14 @@ public class Labware {
         this.destroyed = destroyed;
     }
 
+    public boolean isUsed() {
+        return this.used;
+    }
+
+    public void setUsed(boolean used) {
+        this.used = used;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -171,7 +180,9 @@ public class Labware {
                 && Objects.equals(this.slots, that.slots)
                 && this.discarded == that.discarded
                 && this.released == that.released
-                && this.destroyed == that.destroyed);
+                && this.destroyed == that.destroyed
+                && this.used == that.used
+        );
     }
 
     @Override
@@ -185,7 +196,7 @@ public class Labware {
     }
 
     @JsonIgnore
-    public boolean isUsable() {
+    public boolean isStorable() {
         return !(isReleased() || isDestroyed() || isDiscarded());
     }
 
@@ -200,6 +211,7 @@ public class Labware {
         if (isReleased()) return State.released;
         if (isDiscarded()) return State.discarded;
         if (isEmpty()) return State.empty;
+        if (isUsed()) return State.used;
         return State.active;
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/OperationType.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/OperationType.java
@@ -88,6 +88,10 @@ public class OperationType implements HasName, HasIntId {
         return this.has(OperationTypeFlag.DISCARD_SOURCE);
     }
 
+    public boolean markSourceUsed() {
+        return this.has(OperationTypeFlag.MARK_SOURCE_USED);
+    }
+
     public boolean transfersReagent() {
         return this.has(OperationTypeFlag.REAGENT_TRANSFER);
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/OperationTypeFlag.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/OperationTypeFlag.java
@@ -8,6 +8,7 @@ public enum OperationTypeFlag {
     RESULT,
     ANALYSIS,
     REAGENT_TRANSFER,
+    MARK_SOURCE_USED,
 
     // Current limit: 32 flags
     ;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/DestructionServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/DestructionServiceImp.java
@@ -90,6 +90,7 @@ public class DestructionServiceImp implements DestructionService {
     public List<Labware> loadAndValidateLabware(Collection<String> barcodes) {
         LabwareValidator validator = labwareValidatorFactory.getValidator();
         validator.setUniqueRequired(true);
+        validator.setUsedAllowed(true);
         List<Labware> labware = validator.loadLabware(labwareRepo, barcodes);
         validator.validateSources();
         validator.throwError(IllegalArgumentException::new);

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/FindService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/FindService.java
@@ -144,7 +144,7 @@ public class FindService {
             return List.of();
         }
         List<Labware> labware = labwareService.findBySample(samples).stream()
-                .filter(Labware::isUsable)
+                .filter(Labware::isStorable)
                 .collect(toList());
         if (labware.isEmpty()) {
             return List.of();

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareValidator.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareValidator.java
@@ -21,6 +21,7 @@ public class LabwareValidator {
     private Collection<String> givenBarcodes;
     private boolean uniqueRequired = true;
     private boolean singleSample = false;
+    private boolean usedAllowed = false;
 
     /**
      * Creates a new validator with no labware specified
@@ -77,6 +78,22 @@ public class LabwareValidator {
      */
     public boolean isSingleSample() {
         return this.singleSample;
+    }
+
+    /**
+     * Are used labware allowed? By default they are not allowed.
+     * @return whether used labware are allowed
+     */
+    public boolean isUsedAllowed() {
+        return this.usedAllowed;
+    }
+
+    /**
+     * Sets whether used labware are allowed. By default they are not allowed.
+     * @param usedAllowed whether to allow used labware
+     */
+    public void setUsedAllowed(boolean usedAllowed) {
+        this.usedAllowed = usedAllowed;
     }
 
     /**
@@ -247,7 +264,7 @@ public class LabwareValidator {
     }
 
     /**
-     * Checks the labware is not discarded, released or destroyed.
+     * Checks the labware is not discarded, released, destroyed, or used.
      * Adds an error for each of those cases.
      */
     public void validateStates() {
@@ -257,6 +274,9 @@ public class LabwareValidator {
         validateState(Labware::isDiscarded, "discarded");
         validateState(Labware::isReleased, "released");
         validateState(Labware::isDestroyed, "destroyed");
+        if (!isUsedAllowed()) {
+            validateState(Labware::isUsed, "used");
+        }
     }
 
     /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyServiceImp.java
@@ -220,6 +220,9 @@ public class SlotCopyServiceImp implements SlotCopyService {
         if (opType.discardSource()) {
             discardSources(labwareMap.values());
         }
+        if (opType.markSourceUsed()) {
+            markSourcesUsed(labwareMap.values());
+        }
         Operation op = createOperation(user, contents, opType, labwareMap, filledLabware, oldSampleIdToNewSample);
         List<Operation> ops = List.of(op);
         if (work!=null) {
@@ -321,6 +324,13 @@ public class SlotCopyServiceImp implements SlotCopyService {
     public void discardSources(Collection<Labware> labware) {
         for (Labware lw : labware) {
             lw.setDiscarded(true);
+        }
+        lwRepo.saveAll(labware);
+    }
+
+    public void markSourcesUsed(Collection<Labware> labware) {
+        for (Labware lw : labware) {
+            lw.setUsed(true);
         }
         lwRepo.saveAll(labware);
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/extract/ExtractServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/extract/ExtractServiceImp.java
@@ -88,6 +88,9 @@ public class ExtractServiceImp implements ExtractService {
         if (opType.discardSource()) {
             sources = discardSources(sources);
         }
+        if (opType.markSourceUsed()) {
+            sources = markSourcesUsed(sources);
+        }
         Map<Labware, Labware> labwareMap = createNewLabware(labwareType, sources);
         createSamples(labwareMap, bioState);
         List<Operation> ops = createOperations(user, opType, labwareMap);
@@ -139,6 +142,20 @@ public class ExtractServiceImp implements ExtractService {
         return sources.stream()
                 .map(lw -> {
                     lw.setDiscarded(true);
+                    return labwareRepo.save(lw);
+                }).collect(toList());
+    }
+
+
+    /**
+     * Updates the given labware as used (and saves them). Returns a list of updated labware.
+     * @param sources the labware to update
+     * @return the updated labware
+     */
+    public List<Labware> markSourcesUsed(List<Labware> sources) {
+        return sources.stream()
+                .map(lw -> {
+                    lw.setUsed(true);
                     return labwareRepo.save(lw);
                 }).collect(toList());
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/AliquotServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/AliquotServiceImp.java
@@ -164,6 +164,10 @@ public class AliquotServiceImp implements AliquotService {
             sourceLw.setDiscarded(true);
             sourceLw = lwRepo.save(sourceLw);
         }
+        if (opType.markSourceUsed()) {
+            sourceLw.setUsed(true);
+            sourceLw = lwRepo.save(sourceLw);
+        }
         final String sourceBarcode = sourceLw.getBarcode();
         // We previously verified that the labware contained a single sample in a single slot
         Slot sourceSlot = sourceLw.getSlots().stream()

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/confirm/ConfirmOperationValidationImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/confirm/ConfirmOperationValidationImp.java
@@ -78,6 +78,8 @@ public class ConfirmOperationValidationImp implements ConfirmOperationValidation
                 addProblem("Labware %s is released.", col.getBarcode());
             } else if (lw.isDiscarded()) {
                 addProblem("Labware %s is already discarded.", col.getBarcode());
+            } else if (lw.isUsed()) {
+                addProblem("Labware %s is already used.", col.getBarcode());
             }
 
             if (!lw.isEmpty()) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/confirm/ConfirmSectionValidationServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/confirm/ConfirmSectionValidationServiceImp.java
@@ -81,6 +81,8 @@ public class ConfirmSectionValidationServiceImp implements ConfirmSectionValidat
                 addProblem(problems, "Labware %s is released.", bc);
             } else if (lw.isDiscarded()) {
                 addProblem(problems, "Labware %s is already discarded.", bc);
+            } else if (lw.isUsed()) {
+                addProblem(problems, "Labware %s is already used.", bc);
             } else if (!lw.isEmpty()) {
                 addProblem(problems, "Labware %s already has contents.", bc);
             }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanServiceImp.java
@@ -188,12 +188,13 @@ public class PlanServiceImp implements PlanService {
     }
 
     public void validateLabwareForPlanData(Labware labware) {
-        String[] errors = { "already contains samples", "is destroyed", "is released", "is discarded" };
+        String[] errors = { "already contains samples", "is destroyed", "is released", "is discarded", "is used" };
         List<Predicate<Labware>> predicates = List.of(
                 lw -> !lw.isEmpty(),
                 Labware::isDestroyed,
                 Labware::isReleased,
-                Labware::isDiscarded
+                Labware::isDiscarded,
+                Labware::isUsed
         );
         for (int i = 0; i < errors.length; ++i) {
             if (predicates.get(i).test(labware)) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationImp.java
@@ -51,6 +51,7 @@ public class PlanValidationImp implements PlanValidation {
         Set<String> destroyedBarcodes = new LinkedHashSet<>();
         Set<String> releasedBarcodes = new LinkedHashSet<>();
         Set<String> discardedBarcodes = new LinkedHashSet<>();
+        Set<String> usedBarcodes = new LinkedHashSet<>();
         for (PlanRequestAction action : (Iterable<PlanRequestAction>) (actions()::iterator)) {
             PlanRequestSource source = action.getSource();
             if (source==null || source.getBarcode()==null || source.getBarcode().isEmpty()) {
@@ -76,6 +77,8 @@ public class PlanValidationImp implements PlanValidation {
                     releasedBarcodes.add(lw.getBarcode());
                 } else if (lw.isDiscarded()) {
                     discardedBarcodes.add(lw.getBarcode());
+                } else if (lw.isUsed()) {
+                    usedBarcodes.add(lw.getBarcode());
                 }
             }
             Address address = (source.getAddress()==null ? new Address(1,1) : source.getAddress());
@@ -108,6 +111,9 @@ public class PlanValidationImp implements PlanValidation {
         }
         if (!discardedBarcodes.isEmpty()) {
             addProblem("Labware already discarded: "+discardedBarcodes);
+        }
+        if (!usedBarcodes.isEmpty()) {
+            addProblem("Labware already used: "+usedBarcodes);
         }
         return labwareMap;
     }

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -343,6 +343,9 @@
             <column name="destroyed" type="BOOLEAN" defaultValue="FALSE">
                 <constraints nullable="false"/>
             </column>
+            <column name="used" type="BOOLEAN" defaultValue="FALSE">
+                <constraints nullable="false"/>
+            </column>
             <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>

--- a/src/main/resources/db/operationtypes.tsv
+++ b/src/main/resources/db/operationtypes.tsv
@@ -2,4 +2,4 @@ name	flags	new_bio_state_id
 Register	1	1
 Section	2	null
 Extract	4	2
-Visium cDNA	4	3
+Visium cDNA	128	3

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -27,6 +27,8 @@ enum LabwareState {
     released
     """The labware has been destroyed for a specific reason."""
     destroyed
+    """The labware has been used but may still be stored."""
+    used
 }
 
 """A pass or fail result."""
@@ -189,6 +191,8 @@ type Labware {
     destroyed: Boolean!
     """Has this labware been discarded?"""
     discarded: Boolean!
+    """Has this labware been marked as used?"""
+    used: Boolean!
     """The state, derived from the contents and other fields on the labware."""
     state: LabwareState!
     """The time when this labware was created in the application."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestSlotCopyMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestSlotCopyMutation.java
@@ -22,6 +22,7 @@ import java.util.stream.IntStream;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.*;
 
 /**
@@ -126,7 +127,7 @@ public class TestSlotCopyMutation {
 
         entityManager.flush();
         entityManager.refresh(slide1);
-        assertTrue(slide1.isDiscarded());
+        assertTrue(slide1.isUsed());
         Operation op = opRepo.findById(opId).orElseThrow();
         assertNotNull(op.getPerformed());
         assertEquals("Visium cDNA", op.getOperationType().getName());
@@ -137,7 +138,8 @@ public class TestSlotCopyMutation {
         assertThat(newLabware.getSlot(A2).getSamples()).hasSize(2);
         assertTrue(newLabware.getSlot(A2).getSamples().stream().allMatch(sam -> sam.getBioState().getName().equals("cDNA")));
 
-        verifyStorelightQuery(mockStorelightClient, List.of("STAN-01"), user.getUsername());
+        verifyNoInteractions(mockStorelightClient);
+        //verifyStorelightQuery(mockStorelightClient, List.of("STAN-01"), user.getUsername());
         entityManager.refresh(work);
         assertThat(work.getOperationIds()).containsExactly(opId);
         assertThat(work.getSampleSlotIds()).hasSize(3);

--- a/src/test/java/uk/ac/sanger/sccp/stan/model/TestLabware.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/model/TestLabware.java
@@ -2,6 +2,7 @@ package uk.ac.sanger.sccp.stan.model;
 
 import org.junit.jupiter.api.Test;
 import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.Labware.State;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,17 +14,19 @@ public class TestLabware {
     @Test
     public void testLabwareState() {
         Labware lw = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType());
-        assertEquals(Labware.State.empty, lw.getState());
+        assertEquals(State.empty, lw.getState());
         lw.getFirstSlot().getSamples().add(EntityFactory.getSample());
-        assertEquals(Labware.State.active, lw.getState());
+        assertEquals(State.active, lw.getState());
+        lw.setUsed(true);
+        assertEquals(State.used, lw.getState());
         lw.setDiscarded(true);
-        assertEquals(Labware.State.discarded, lw.getState());
+        assertEquals(State.discarded, lw.getState());
         lw.setReleased(true);
-        assertEquals(Labware.State.released, lw.getState());
+        assertEquals(State.released, lw.getState());
         lw.setReleased(false);
         lw.setDestroyed(true);
-        assertEquals(Labware.State.destroyed, lw.getState());
+        assertEquals(State.destroyed, lw.getState());
         lw.getFirstSlot().getSamples().clear();
-        assertEquals(Labware.State.destroyed, lw.getState());
+        assertEquals(State.destroyed, lw.getState());
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestDestructionService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestDestructionService.java
@@ -159,6 +159,7 @@ public class TestDestructionService {
             assertThrows(IllegalArgumentException.class, () -> destructionService.loadAndValidateLabware(barcodes));
         }
 
+        verify(mockValidator).setUsedAllowed(true);
         verify(mockValidator).setUniqueRequired(true);
         verify(mockValidator).loadLabware(mockLabwareRepo, barcodes);
         verify(mockValidator).validateSources();

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestReleaseService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestReleaseService.java
@@ -264,6 +264,8 @@ public class TestReleaseService {
         LabwareType lt = EntityFactory.getTubeType();
         Sample sample = EntityFactory.getSample();
         Labware good = EntityFactory.makeLabware(lt, sample);
+        Labware used = EntityFactory.makeLabware(lt, sample);
+        used.setUsed(true);
         Labware empty = EntityFactory.makeEmptyLabware(lt);
         Labware destroyed = EntityFactory.makeLabware(lt, sample);
         destroyed.setDestroyed(true);
@@ -277,7 +279,7 @@ public class TestReleaseService {
         String destroyedError = "Labware cannot be released because it is destroyed: ["+destroyed.getBarcode()+"]";
         String discardedError = "Labware cannot be released because it is discarded: ["+discarded.getBarcode()+"]";
         return Stream.of(
-                Arguments.of(List.of(good), null),
+                Arguments.of(List.of(good, used), null),
                 Arguments.of(List.of(good, empty), emptyError),
                 Arguments.of(List.of(empty, good), emptyError),
                 Arguments.of(List.of(destroyed), destroyedError),

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/extract/TestExtractService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/extract/TestExtractService.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
-import uk.ac.sanger.sccp.stan.EntityFactory;
-import uk.ac.sanger.sccp.stan.Transactor;
+import uk.ac.sanger.sccp.stan.*;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.ExtractRequest;
@@ -148,6 +147,7 @@ public class TestExtractService {
 
         verify(service, never()).loadAndValidateLabware(any());
         verify(service, never()).discardSources(any());
+        verify(service, never()).markSourcesUsed(any());
         verify(service, never()).createNewLabware(any(), any());
         verify(service, never()).createSamples(any(), any());
         verify(service, never()).createOperations(any(), any(), any());
@@ -202,12 +202,24 @@ public class TestExtractService {
 
     @Test
     public void testDiscardSources() {
-        when(mockLwRepo.save(any())).then(invocation -> invocation.getArgument(0));
+        when(mockLwRepo.save(any())).then(Matchers.returnArgument());
         List<Labware> labware = List.of(EntityFactory.makeEmptyLabware(lwType), EntityFactory.makeEmptyLabware(lwType));
         assertEquals(labware, service.discardSources(labware));
 
         for (Labware lw : labware) {
             assertTrue(lw.isDiscarded());
+            verify(mockLwRepo).save(lw);
+        }
+    }
+
+    @Test
+    public void testMarkSourcesUsed() {
+        when(mockLwRepo.save(any())).then(Matchers.returnArgument());
+        List<Labware> labware = List.of(EntityFactory.makeEmptyLabware(lwType), EntityFactory.makeEmptyLabware(lwType));
+        assertEquals(labware, service.markSourcesUsed(labware));
+
+        for (Labware lw : labware) {
+            assertTrue(lw.isUsed());
             verify(mockLwRepo).save(lw);
         }
     }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/store/TestStoreService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/store/TestStoreService.java
@@ -235,11 +235,14 @@ public class TestStoreService {
         destroyedLabware.setDestroyed(true);
         Labware discardedLabware = EntityFactory.makeEmptyLabware(lt);
         discardedLabware.setDiscarded(true);
+        Labware usedLabware = EntityFactory.makeLabware(lt, sample);
+        usedLabware.setUsed(true);
 
         return Stream.of(
                 Arguments.of("Bananas", "No labware found with barcode \"Bananas\""),
 
                 Arguments.of(okLabware, null),
+                Arguments.of(usedLabware, null),
                 Arguments.of(releasedLabware, "Labware %bc cannot be stored because it is released."),
                 Arguments.of(destroyedLabware, "Labware %bc cannot be stored because it is destroyed."),
                 Arguments.of(discardedLabware, "Labware %bc cannot be stored because it is discarded."),
@@ -272,6 +275,9 @@ public class TestStoreService {
         Sample sample = EntityFactory.getSample();
         Labware okLabware = EntityFactory.makeLabware(lt, sample);
         okLabware.setBarcode("STAN-OK");
+        Labware usedLabware = EntityFactory.makeLabware(lt, sample);
+        usedLabware.setBarcode("STAN-USED");
+        usedLabware.setUsed(true);
         Labware emptyLabware = EntityFactory.makeEmptyLabware(lt);
         emptyLabware.setBarcode("STAN-EMPTY");
         Labware releasedLabware = EntityFactory.makeEmptyLabware(lt);
@@ -284,10 +290,12 @@ public class TestStoreService {
         discardedLabware.setBarcode("STAN-DIS");
         discardedLabware.setDiscarded(true);
 
-        UCMap<Labware> labware = UCMap.from(Labware::getBarcode, okLabware, emptyLabware, releasedLabware, destroyedLabware, discardedLabware);
+        UCMap<Labware> labware = UCMap.from(Labware::getBarcode, okLabware, emptyLabware, releasedLabware,
+                destroyedLabware, discardedLabware, usedLabware);
 
         return Arrays.stream(new Object[][] {
                 {okLabware, null},
+                {usedLabware, null},
                 {emptyLabware, "Labware [STAN-EMPTY] cannot be stored because it is [empty]."},
                 {releasedLabware, "Labware [STAN-REL] cannot be stored because it is [released]."},
                 {destroyedLabware, "Labware [STAN-DES] cannot be stored because it is [destroyed]."},


### PR DESCRIPTION
Labware becomes "used" when it is the source for an op with the
"MARK_SOURCE_USED" op type flag.
The Visium cDNA op will have this flag.
Used labware cannot be used in further operations; but it can
be stored, destroyed or released.
