### PR TITLE
x873 Add external ID to sample

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -30,6 +30,7 @@ import uk.ac.sanger.sccp.stan.service.operation.plan.PlanService;
 import uk.ac.sanger.sccp.stan.service.register.*;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.stan.service.work.WorkTypeService;
+import uk.ac.sanger.sccp.stan.service.SampleProcessingService;
 
 import java.util.*;
 import java.util.function.BiFunction;
@@ -84,6 +85,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
     final OriginalSampleRegisterService originalSampleRegisterService;
     final BlockProcessingService blockProcessingService;
     final PotProcessingService potProcessingService;
+    final SampleProcessingService sampleProcessingService;
     final UserAdminService userAdminService;
 
     @Autowired
@@ -107,7 +109,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
                            ComplexStainService complexStainService, AliquotService aliquotService,
                            ReagentTransferService reagentTransferService, OriginalSampleRegisterService originalSampleRegisterService,
                            BlockProcessingService blockProcessingService, PotProcessingService potProcessingService,
-                           UserAdminService userAdminService) {
+                           SampleProcessingService sampleProcessingService, UserAdminService userAdminService) {
         super(objectMapper, authComp, userRepo);
         this.ldapService = ldapService;
         this.sessionConfig = sessionConfig;
@@ -149,6 +151,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         this.originalSampleRegisterService = originalSampleRegisterService;
         this.blockProcessingService = blockProcessingService;
         this.potProcessingService = potProcessingService;
+        this.sampleProcessingService = sampleProcessingService;
         this.userAdminService = userAdminService;
     }
 
@@ -625,6 +628,15 @@ public class GraphQLMutation extends BaseGraphQLResource {
             PotProcessingRequest request = arg(dfe, "request", PotProcessingRequest.class);
             logRequest("Perform pot processing", user, request);
             return potProcessingService.perform(user, request);
+        };
+    }
+
+    public DataFetcher<OperationResult> addExternalID() {
+        return dfe -> {
+            User user = checkUser(dfe, User.Role.normal);
+            AddExternalIDRequest request = arg(dfe, "request", AddExternalIDRequest.class);
+            logRequest("Perform add external ID", user, request);
+            return sampleProcessingService.addExternalID(user, request);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -169,6 +169,7 @@ public class GraphQLProvider {
                         .dataFetcher("registerOriginalSamples", transact(graphQLMutation.registerOriginalSamples()))
                         .dataFetcher("performTissueBlock", transact(graphQLMutation.performTissueBlock()))
                         .dataFetcher("performPotProcessing", transact(graphQLMutation.performPotProcessing()))
+                        .dataFetcher("addExternalID", transact(graphQLMutation.addExternalID()))
 
                         .dataFetcher("addUser", transact(graphQLMutation.addUser()))
                         .dataFetcher("setUserRole", transact(graphQLMutation.setUserRole()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/AddExternalIDRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/AddExternalIDRequest.java
@@ -1,0 +1,52 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import java.util.Objects;
+
+public class AddExternalIDRequest {
+    private String labwareBarcode;
+    private String externalName;
+
+    public AddExternalIDRequest() {}
+
+    public AddExternalIDRequest(String labwareBarcode, String externalName) {
+        setLabwareBarcode(labwareBarcode);
+        setExternalName(externalName);
+    }
+
+    public String getLabwareBarcode() {
+        return labwareBarcode;
+    }
+
+    public void setLabwareBarcode(String labwareBarcode) {
+        this.labwareBarcode = labwareBarcode;
+    }
+
+    public String getExternalName() {
+        return externalName;
+    }
+
+    public void setExternalName(String externalName) {
+        this.externalName = externalName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddExternalIDRequest that = (AddExternalIDRequest) o;
+        return Objects.equals(labwareBarcode, that.labwareBarcode) && Objects.equals(externalName, that.externalName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labwareBarcode, externalName);
+    }
+
+    @Override
+    public String toString() {
+        return "AddExternalIDRequest{" +
+                "labwareBarcode='" + labwareBarcode + '\'' +
+                ", externalName='" + externalName + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingService.java
@@ -4,6 +4,16 @@ import uk.ac.sanger.sccp.stan.model.User;
 import uk.ac.sanger.sccp.stan.request.AddExternalIDRequest;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
 
+/**
+ * A service to deal with sample processing
+ * @author bt8
+ */
 public interface SampleProcessingService {
-    public OperationResult addExternalID(User user, AddExternalIDRequest request) throws ValidationException;
+    /**
+     * Adds an external id to a samples tissue
+     * @param user the user responsible for the request
+     * @param request the request to record add external id
+     * @return the operations and labware
+     */
+    OperationResult addExternalID(User user, AddExternalIDRequest request) throws ValidationException;
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingService.java
@@ -1,0 +1,9 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.request.AddExternalIDRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+
+public interface SampleProcessingService {
+    public OperationResult addExternalID(User user, AddExternalIDRequest request) throws ValidationException;
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingServiceImp.java
@@ -4,10 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.ac.sanger.sccp.stan.model.*;
-import uk.ac.sanger.sccp.stan.repo.LabwareRepo;
-import uk.ac.sanger.sccp.stan.repo.OperationTypeRepo;
-import uk.ac.sanger.sccp.stan.repo.SampleRepo;
-import uk.ac.sanger.sccp.stan.repo.TissueRepo;
+import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.AddExternalIDRequest;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
 
@@ -18,7 +15,6 @@ import static java.util.stream.Collectors.toSet;
 
 @Service
 public class SampleProcessingServiceImp implements SampleProcessingService {
-    private final SampleRepo sampleRepo;
     private final TissueRepo tissueRepo;
     private final OperationTypeRepo opTypeRepo;
     private final LabwareRepo labwareRepo;
@@ -26,13 +22,11 @@ public class SampleProcessingServiceImp implements SampleProcessingService {
     private final Validator<String> externalNameValidator;
 
     @Autowired
-    public SampleProcessingServiceImp(SampleRepo sampleRepo,
-                                      TissueRepo tissueRepo,
+    public SampleProcessingServiceImp(TissueRepo tissueRepo,
                                       OperationTypeRepo opTypeRepo,
                                       LabwareRepo labwareRepo,
                                       OperationService opService,
                                       @Qualifier("externalNameValidator") Validator<String> externalNameValidator) {
-        this.sampleRepo = sampleRepo;
         this.tissueRepo = tissueRepo;
         this.opTypeRepo = opTypeRepo;
         this.labwareRepo = labwareRepo;
@@ -66,6 +60,13 @@ public class SampleProcessingServiceImp implements SampleProcessingService {
         return new OperationResult(List.of(op), List.of(lw));
     }
 
+    /**
+     * Checks for problems with the samples in the labware.
+     * There should be one sample in the labware, and the tissue for that sample
+     * should have a replicate number and no external name.
+     * @param problems receptacle for problems
+     * @param samples the samples in the labware
+     */
     public void validateSamples(Collection<String> problems, Set<Sample> samples) {
         if (samples.isEmpty()) {
             problems.add("Could not find a sample associated with this labware");
@@ -84,6 +85,11 @@ public class SampleProcessingServiceImp implements SampleProcessingService {
         }
     }
 
+    /**
+     * Checks for problems with the given external name.
+     * @param problems receptacle for problems
+     * @param externalName the given external name.
+     */
     public void validateExternalName(Collection<String> problems, String externalName) {
         if (externalName==null || externalName.isEmpty()) {
             problems.add("No external identifier provided");

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SampleProcessingServiceImp.java
@@ -1,0 +1,100 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareRepo;
+import uk.ac.sanger.sccp.stan.repo.OperationTypeRepo;
+import uk.ac.sanger.sccp.stan.repo.SampleRepo;
+import uk.ac.sanger.sccp.stan.repo.TissueRepo;
+import uk.ac.sanger.sccp.stan.request.AddExternalIDRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+
+import java.util.*;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class SampleProcessingServiceImp implements SampleProcessingService {
+    private final SampleRepo sampleRepo;
+    private final TissueRepo tissueRepo;
+    private final OperationTypeRepo opTypeRepo;
+    private final LabwareRepo labwareRepo;
+    private final OperationService opService;
+    private final Validator<String> externalNameValidator;
+
+    @Autowired
+    public SampleProcessingServiceImp(SampleRepo sampleRepo,
+                                      TissueRepo tissueRepo,
+                                      OperationTypeRepo opTypeRepo,
+                                      LabwareRepo labwareRepo,
+                                      OperationService opService,
+                                      @Qualifier("externalNameValidator") Validator<String> externalNameValidator) {
+        this.sampleRepo = sampleRepo;
+        this.tissueRepo = tissueRepo;
+        this.opTypeRepo = opTypeRepo;
+        this.labwareRepo = labwareRepo;
+        this.opService = opService;
+        this.externalNameValidator = externalNameValidator;
+    }
+
+    @Override
+    public OperationResult addExternalID(User user, AddExternalIDRequest request) {
+        requireNonNull(user, "User is null.");
+        requireNonNull(request, "Request is null.");
+        Collection<String> problems = new LinkedHashSet<>();
+
+        Labware lw = labwareRepo.getByBarcode(request.getLabwareBarcode());
+        String externalName = request.getExternalName();
+        List<Sample> samples = new ArrayList<>();
+        lw.getSlots().forEach((slot) -> {
+            if (slot.getSamples() != null) {
+                samples.addAll(slot.getSamples());
+            }
+        });
+
+        validateSamples(problems, samples);
+        validateExternalName(problems, externalName);
+
+        if (!problems.isEmpty()) {
+            throw new ValidationException("The request could not be validated.", problems);
+        }
+
+        Tissue tissue = samples.get(0).getTissue();
+        tissue.setExternalName(externalName);
+        OperationType opType = opTypeRepo.getByName("Add external ID");
+        Operation op = opService.createOperationInPlace(opType, user, lw, null, null);
+        return new OperationResult(List.of(op), List.of(lw));
+    }
+
+    public void validateSamples(Collection<String> problems, List<Sample> samples) {
+        if (samples.isEmpty()) {
+            problems.add("Could not find a sample associated with this labware");
+            return;
+        }
+        if (samples.size() > 1) {
+            problems.add("There are too many samples associated with this labware");
+            return;
+        }
+        Tissue tissue = samples.get(0).getTissue();
+        if (!tissue.getExternalName().isEmpty() || tissue.getExternalName() == null) {
+            problems.add("The associated tissue already has an external identifier: " + tissue.getExternalName());
+        }
+        if (tissue.getReplicate().isEmpty() || tissue.getReplicate() == null) {
+            problems.add("The associated tissue does not have a replicate number");
+        }
+    }
+
+    public void validateExternalName(Collection<String> problems, String externalName) {
+        if (externalName==null || externalName.isEmpty()) {
+            problems.add("No external identifier provided");
+            return;
+        }
+        if (tissueRepo.findAllByExternalName(externalName).size() > 0) {
+            problems.add("External identifier is already associated with another a sample: " + externalName);
+        }
+        externalNameValidator.validate(externalName, problems::add);
+    }
+
+}

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -960,7 +960,7 @@ enum StainPanel {
 
 """The details for a particular labware in a complex stain request."""
 input ComplexStainLabware {
-    """The barcode of the lawbare."""
+    """The barcode of the labware."""
     barcode: String!
     """The bond barcode for the stain."""
     bondBarcode: String!
@@ -1283,6 +1283,13 @@ input PotProcessingDestination {
     commentId: Int
 }
 
+input AddExternalIDRequest {
+    """The external identifier used to identify the tissue."""
+    externalName: String!
+    """The existing labware containing the tissue"""
+    labwareBarcode: String!
+}
+
 """
 Get information from the application.
 These typically require no user privilege.
@@ -1490,6 +1497,9 @@ type Mutation {
     performTissueBlock(request: TissueBlockRequest!): OperationResult!
     """Process an original sample into pots."""
     performPotProcessing(request: PotProcessingRequest!): OperationResult!
+    """Record an operation adding a external ID to a sample."""
+    addExternalID(request: AddExternalIDRequest!): OperationResult!
+
 
     """Create a new user for the application."""
     addUser(username: String!): User!

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestAddExternalIDMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestAddExternalIDMutation.java
@@ -1,0 +1,56 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareRepo;
+
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestAddExternalIDMutation {
+    @Autowired
+    private GraphQLTester tester;
+    @Autowired
+    private EntityCreator entityCreator;
+
+    @Autowired
+    private LabwareRepo lwRepo;
+
+    @Test
+    @Transactional
+    public void testAddExternalID() throws Exception {
+        tester.setUser(entityCreator.createUser("user1"));
+
+        // Create the intial labware with sample
+        entityCreator.createOpType("Add external ID", null,OperationTypeFlag.IN_PLACE);
+        Donor donor = entityCreator.createDonor("Donor1");
+        Tissue tissue = entityCreator.createTissue(donor, "", "1");
+        Sample sample = entityCreator.createSample(tissue, 1, null);
+        LabwareType lt = entityCreator.createLabwareType("LT",1, 1);
+        Labware lw = entityCreator.createLabware("Barcode1", lt, sample);
+
+        System.out.println(lw);
+        String mutation = tester.readGraphQL("addexternalid.graphql");
+        Object result = tester.post(mutation);
+
+        Integer opId = chainGet(result, "data", "addExternalID", "operations", 0, "id");
+        assertNotNull(opId);
+        assertEquals("ExternalName", tissue.getExternalName());
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestSampleProcessingService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestSampleProcessingService.java
@@ -26,8 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author bt8
  **/
 public class TestSampleProcessingService {
-
-    private SampleRepo mockSampleRepo;
     private TissueRepo mockTissueRepo;
     private OperationTypeRepo mockOpTypeRepo;
     private LabwareRepo mockLabwareRepo;
@@ -37,14 +35,14 @@ public class TestSampleProcessingService {
 
     @BeforeEach
     void setup() {
-        mockSampleRepo = mock(SampleRepo.class);
         mockTissueRepo = mock(TissueRepo.class);
         mockOpTypeRepo = mock(OperationTypeRepo.class);
         mockLabwareRepo = mock(LabwareRepo.class);
         mockOpService = mock(OperationService.class);
+        //noinspection unchecked
         mockExternalNameValidator = mock(Validator.class);
 
-        sampleProcessingService = spy(new SampleProcessingServiceImp(mockSampleRepo, mockTissueRepo, mockOpTypeRepo, mockLabwareRepo, mockOpService, mockExternalNameValidator));
+        sampleProcessingService = spy(new SampleProcessingServiceImp(mockTissueRepo, mockOpTypeRepo, mockLabwareRepo, mockOpService, mockExternalNameValidator));
     }
 
     @Test
@@ -88,7 +86,7 @@ public class TestSampleProcessingService {
         // Use an existing tissue with external name
         AddExternalIDRequest request = new AddExternalIDRequest(lw.getBarcode(), tissue.getExternalName());
         assertValidationException(() -> sampleProcessingService.addExternalID(user, request), "The request could not be validated.",
-                String.format("The associated tissue already has an external identifier: %s", tissue.getExternalName())
+                "The associated tissue already has an external identifier: " + tissue.getExternalName()
         );
 
         verify(mockLabwareRepo).getByBarcode(eq(lw.getBarcode()));
@@ -108,7 +106,7 @@ public class TestSampleProcessingService {
         when(mockTissueRepo.findAllByExternalName(any())).thenReturn(List.of(tissue));
 
         sampleProcessingService.validateExternalName(problems, tissue.getExternalName());
-        assertThat(problems).contains(String.format("External identifier is already associated with another sample: %s", tissue.getExternalName()));
+        assertThat(problems).contains("External identifier is already associated with another sample: "+tissue.getExternalName());
         verify(mockTissueRepo).findAllByExternalName(eq(tissue.getExternalName()));
         verify(mockExternalNameValidator).validate(eq(tissue.getExternalName()), any());
     }
@@ -142,7 +140,7 @@ public class TestSampleProcessingService {
         Sample sample1 = new Sample(1, 100, tissue, null);
 
         sampleProcessingService.validateSamples(problems, Set.of(sample1));
-        assertThat(problems).contains(String.format("The associated tissue already has an external identifier: %s", tissue.getExternalName()));
+        assertThat(problems).contains("The associated tissue already has an external identifier: "+tissue.getExternalName());
     }
 
     @Test
@@ -156,6 +154,6 @@ public class TestSampleProcessingService {
         Sample sample1 = new Sample(1, 100, tissue, null);
 
         sampleProcessingService.validateSamples(problems, Set.of(sample1));
-        assertThat(problems).contains(String.format("The associated tissue does not have a replicate number"));
+        assertThat(problems).contains("The associated tissue does not have a replicate number");
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestSampleProcessingService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestSampleProcessingService.java
@@ -13,12 +13,18 @@ import uk.ac.sanger.sccp.stan.request.OperationResult;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static uk.ac.sanger.sccp.stan.Matchers.assertValidationException;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests {@link SampleProcessingServiceImp}
+ * @author bt8
+ **/
 public class TestSampleProcessingService {
 
     private SampleRepo mockSampleRepo;
@@ -62,7 +68,7 @@ public class TestSampleProcessingService {
         Assertions.assertEquals(opRes, sampleProcessingService.addExternalID(user, request));
 
         verify(mockLabwareRepo).getByBarcode(eq(lw.getBarcode()));
-        verify(sampleProcessingService).validateSamples(any(), eq(List.of(sample)));
+        verify(sampleProcessingService).validateSamples(any(), eq(Set.of(sample)));
         verify(sampleProcessingService).validateExternalName(any(), eq("ExternalName"));
         verify(mockTissueRepo).findAllByExternalName(eq("ExternalName"));
     }
@@ -86,7 +92,7 @@ public class TestSampleProcessingService {
         );
 
         verify(mockLabwareRepo).getByBarcode(eq(lw.getBarcode()));
-        verify(sampleProcessingService).validateSamples(any(), eq(List.of(sample)));
+        verify(sampleProcessingService).validateSamples(any(), eq(Set.of(sample)));
         verify(sampleProcessingService).validateExternalName(any(), eq(tissue.getExternalName()));
         verify(mockTissueRepo).findAllByExternalName(eq(tissue.getExternalName()));
         verifyNoInteractions(mockOpTypeRepo);
@@ -102,7 +108,7 @@ public class TestSampleProcessingService {
         when(mockTissueRepo.findAllByExternalName(any())).thenReturn(List.of(tissue));
 
         sampleProcessingService.validateExternalName(problems, tissue.getExternalName());
-        assertThat(problems).contains(String.format("External identifier is already associated with another a sample: %s", tissue.getExternalName()));
+        assertThat(problems).contains(String.format("External identifier is already associated with another sample: %s", tissue.getExternalName()));
         verify(mockTissueRepo).findAllByExternalName(eq(tissue.getExternalName()));
         verify(mockExternalNameValidator).validate(eq(tissue.getExternalName()), any());
     }
@@ -110,7 +116,7 @@ public class TestSampleProcessingService {
     @Test
     public void testNoSamplesValidation() {
         Collection<String> problems = new LinkedHashSet<>();
-        sampleProcessingService.validateSamples(problems, List.of());
+        sampleProcessingService.validateSamples(problems, Set.of());
         assertThat(problems).contains("Could not find a sample associated with this labware");
     }
 
@@ -123,7 +129,7 @@ public class TestSampleProcessingService {
         Sample sample1 = new Sample(1, 100, tissue, null);
         Sample sample2 = new Sample(2, 100, tissue, null);
 
-        sampleProcessingService.validateSamples(problems, List.of(sample1, sample2));
+        sampleProcessingService.validateSamples(problems, Set.of(sample1, sample2));
         assertThat(problems).contains("There are too many samples associated with this labware");
     }
 
@@ -135,7 +141,7 @@ public class TestSampleProcessingService {
         Tissue tissue = EntityFactory.makeTissue(donor, sl);
         Sample sample1 = new Sample(1, 100, tissue, null);
 
-        sampleProcessingService.validateSamples(problems, List.of(sample1));
+        sampleProcessingService.validateSamples(problems, Set.of(sample1));
         assertThat(problems).contains(String.format("The associated tissue already has an external identifier: %s", tissue.getExternalName()));
     }
 
@@ -149,7 +155,7 @@ public class TestSampleProcessingService {
         tissue.setExternalName("");
         Sample sample1 = new Sample(1, 100, tissue, null);
 
-        sampleProcessingService.validateSamples(problems, List.of(sample1));
+        sampleProcessingService.validateSamples(problems, Set.of(sample1));
         assertThat(problems).contains(String.format("The associated tissue does not have a replicate number"));
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestSampleProcessingService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestSampleProcessingService.java
@@ -1,0 +1,155 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.AddExternalIDRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.assertValidationException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSampleProcessingService {
+
+    private SampleRepo mockSampleRepo;
+    private TissueRepo mockTissueRepo;
+    private OperationTypeRepo mockOpTypeRepo;
+    private LabwareRepo mockLabwareRepo;
+    private OperationService mockOpService;
+    private SampleProcessingServiceImp sampleProcessingService;
+    private Validator<String> mockExternalNameValidator;
+
+    @BeforeEach
+    void setup() {
+        mockSampleRepo = mock(SampleRepo.class);
+        mockTissueRepo = mock(TissueRepo.class);
+        mockOpTypeRepo = mock(OperationTypeRepo.class);
+        mockLabwareRepo = mock(LabwareRepo.class);
+        mockOpService = mock(OperationService.class);
+        mockExternalNameValidator = mock(Validator.class);
+
+        sampleProcessingService = spy(new SampleProcessingServiceImp(mockSampleRepo, mockTissueRepo, mockOpTypeRepo, mockLabwareRepo, mockOpService, mockExternalNameValidator));
+    }
+
+    @Test
+    public void testValidAddExternalId() {
+        User user = EntityFactory.getUser();
+        Donor donor = EntityFactory.getDonor();
+        SpatialLocation sl = EntityFactory.getSpatialLocation();
+        Tissue tissue = EntityFactory.makeTissue(donor, sl);
+        tissue.setExternalName("");
+        Sample sample = new Sample(1, 100, tissue, null);
+        LabwareType lt = EntityFactory.makeLabwareType(1,1, "LT1");
+        Labware lw = EntityFactory.makeLabware(lt, sample);
+        OperationType opType = EntityFactory.makeOperationType("Add External ID", null);
+        Operation op = new Operation(200, opType, null, null, user);
+
+        when(mockLabwareRepo.getByBarcode(any())).thenReturn(lw);
+        when(mockOpService.createOperationInPlace(any(), any(), any(), any(), any())).thenReturn(op);
+
+        AddExternalIDRequest request = new AddExternalIDRequest(lw.getBarcode(), "ExternalName");
+        OperationResult opRes = new OperationResult(List.of(op), List.of(lw));
+        Assertions.assertEquals(opRes, sampleProcessingService.addExternalID(user, request));
+
+        verify(mockLabwareRepo).getByBarcode(eq(lw.getBarcode()));
+        verify(sampleProcessingService).validateSamples(any(), eq(List.of(sample)));
+        verify(sampleProcessingService).validateExternalName(any(), eq("ExternalName"));
+        verify(mockTissueRepo).findAllByExternalName(eq("ExternalName"));
+    }
+
+    @Test
+    public void testInvalidAddExternalId() {
+        User user = EntityFactory.getUser();
+        Donor donor = EntityFactory.getDonor();
+        SpatialLocation sl = EntityFactory.getSpatialLocation();
+        Tissue tissue = EntityFactory.makeTissue(donor, sl);
+        Sample sample = new Sample(1, 100, tissue, null);
+        LabwareType lt = EntityFactory.makeLabwareType(1,1, "LT1");
+        Labware lw = EntityFactory.makeLabware(lt, sample);
+
+        when(mockLabwareRepo.getByBarcode(any())).thenReturn(lw);
+
+        // Use an existing tissue with external name
+        AddExternalIDRequest request = new AddExternalIDRequest(lw.getBarcode(), tissue.getExternalName());
+        assertValidationException(() -> sampleProcessingService.addExternalID(user, request), "The request could not be validated.",
+                String.format("The associated tissue already has an external identifier: %s", tissue.getExternalName())
+        );
+
+        verify(mockLabwareRepo).getByBarcode(eq(lw.getBarcode()));
+        verify(sampleProcessingService).validateSamples(any(), eq(List.of(sample)));
+        verify(sampleProcessingService).validateExternalName(any(), eq(tissue.getExternalName()));
+        verify(mockTissueRepo).findAllByExternalName(eq(tissue.getExternalName()));
+        verifyNoInteractions(mockOpTypeRepo);
+    }
+
+    @Test
+    public void testExternalNameValidation() {
+        Collection<String> problems = new LinkedHashSet<>();
+        Donor donor = EntityFactory.getDonor();
+        SpatialLocation sl = EntityFactory.getSpatialLocation();
+        Tissue tissue = EntityFactory.makeTissue(donor, sl);
+
+        when(mockTissueRepo.findAllByExternalName(any())).thenReturn(List.of(tissue));
+
+        sampleProcessingService.validateExternalName(problems, tissue.getExternalName());
+        assertThat(problems).contains(String.format("External identifier is already associated with another a sample: %s", tissue.getExternalName()));
+        verify(mockTissueRepo).findAllByExternalName(eq(tissue.getExternalName()));
+        verify(mockExternalNameValidator).validate(eq(tissue.getExternalName()), any());
+    }
+
+    @Test
+    public void testNoSamplesValidation() {
+        Collection<String> problems = new LinkedHashSet<>();
+        sampleProcessingService.validateSamples(problems, List.of());
+        assertThat(problems).contains("Could not find a sample associated with this labware");
+    }
+
+    @Test
+    public void testTooManySamplesValidation() {
+        Collection<String> problems = new LinkedHashSet<>();
+        Donor donor = EntityFactory.getDonor();
+        SpatialLocation sl = EntityFactory.getSpatialLocation();
+        Tissue tissue = EntityFactory.makeTissue(donor, sl);
+        Sample sample1 = new Sample(1, 100, tissue, null);
+        Sample sample2 = new Sample(2, 100, tissue, null);
+
+        sampleProcessingService.validateSamples(problems, List.of(sample1, sample2));
+        assertThat(problems).contains("There are too many samples associated with this labware");
+    }
+
+    @Test
+    public void testExistingExternalIdSamplesValidation() {
+        Collection<String> problems = new LinkedHashSet<>();
+        Donor donor = EntityFactory.getDonor();
+        SpatialLocation sl = EntityFactory.getSpatialLocation();
+        Tissue tissue = EntityFactory.makeTissue(donor, sl);
+        Sample sample1 = new Sample(1, 100, tissue, null);
+
+        sampleProcessingService.validateSamples(problems, List.of(sample1));
+        assertThat(problems).contains(String.format("The associated tissue already has an external identifier: %s", tissue.getExternalName()));
+    }
+
+    @Test
+    public void testNoReplicateSamplesValidation() {
+        Collection<String> problems = new LinkedHashSet<>();
+        Donor donor = EntityFactory.getDonor();
+        SpatialLocation sl = EntityFactory.getSpatialLocation();
+        Tissue tissue = EntityFactory.makeTissue(donor, sl);
+        tissue.setReplicate("");
+        tissue.setExternalName("");
+        Sample sample1 = new Sample(1, 100, tissue, null);
+
+        sampleProcessingService.validateSamples(problems, List.of(sample1));
+        assertThat(problems).contains(String.format("The associated tissue does not have a replicate number"));
+    }
+}

--- a/src/test/resources/graphql/addexternalid.graphql
+++ b/src/test/resources/graphql/addexternalid.graphql
@@ -1,0 +1,11 @@
+mutation {
+    addExternalID(request: {
+        labwareBarcode: "Barcode1"
+        externalName: "ExternalName"
+    }) {
+        operations {
+            operationType { name }
+            id
+        }
+    }
+}


### PR DESCRIPTION
Added SampleProcessingServices and ability to add an external ID to a single sample/tissue within a labware
Relies on new (in place) operation type "Add external ID" within stan-sql
