### PR TITLE
X896 release file permtimes

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
@@ -30,6 +30,7 @@ public enum ReleaseColumn implements TsvColumn<ReleaseEntry> {
     Tissue_coverage(ReleaseEntry::getCoverage),
     Cq_value(ReleaseEntry::getCq),
     cDNA_analysis_concentration(ReleaseEntry::getCdnaAnalysisConcentration),
+    Permeabilisation_time(ReleaseEntry::getPermTime),
     Dual_index_plate_name(ReleaseEntry::getReagentSource),
     RNAscope_plex(ReleaseEntry::getRnascopePlex),
     IHC_plex(ReleaseEntry::getIhcPlex),

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
@@ -28,6 +28,7 @@ public class ReleaseEntry {
     private Integer rnascopePlex;
     private Integer ihcPlex;
     private LocalDate sectionDate;
+    private Integer permTime;
 
     public ReleaseEntry(Labware labware, Slot slot, Sample sample) {
         this(labware, slot, sample, null);
@@ -164,6 +165,14 @@ public class ReleaseEntry {
         this.sectionDate = sectionDate;
     }
 
+    public Integer getPermTime() {
+        return this.permTime;
+    }
+
+    public void setPermTime(Integer permTime) {
+        this.permTime = permTime;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -182,10 +191,12 @@ public class ReleaseEntry {
                 && Objects.equals(this.coverage, that.coverage)
                 && Objects.equals(this.reagentSource, that.reagentSource)
                 && Objects.equals(this.cq, that.cq)
+                && Objects.equals(this.permTime, that.permTime)
                 && Objects.equals(this.cdnaAnalysisConcentration, that.cdnaAnalysisConcentration)
                 && Objects.equals(this.rnascopePlex, that.rnascopePlex)
                 && Objects.equals(this.ihcPlex, that.ihcPlex)
                 && Objects.equals(this.sectionDate, that.sectionDate)
+
         );
     }
 
@@ -213,6 +224,7 @@ public class ReleaseEntry {
                 .add("rnascopePlex", rnascopePlex)
                 .add("ihcPlex", ihcPlex)
                 .add("sectionDate", sectionDate)
+                .add("permTime",permTime)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
@@ -196,7 +196,6 @@ public class ReleaseEntry {
                 && Objects.equals(this.rnascopePlex, that.rnascopePlex)
                 && Objects.equals(this.ihcPlex, that.ihcPlex)
                 && Objects.equals(this.sectionDate, that.sectionDate)
-
         );
     }
 
@@ -224,7 +223,7 @@ public class ReleaseEntry {
                 .add("rnascopePlex", rnascopePlex)
                 .add("ihcPlex", ihcPlex)
                 .add("sectionDate", sectionDate)
-                .add("permTime",permTime)
+                .add("permTime", permTime)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
@@ -483,8 +483,7 @@ public class ReleaseFileService {
         final String CDNA_CONC = MeasurementType.cDNA_concentration.friendlyName();
         final String CDNA_ANALYSIS = "cDNA analysis";
         final String PERM_TIME= MeasurementType.Permeabilisation_time.friendlyName();
-        final String VISIUM_TO = "Visium TO";
-        final String VISIUM_LP = "Visium LP";
+        final String VISIUM_TO = "Visium TO", VISIUM_LP = "Visium LP", PLATE_96 = "96 well plate";
         Map<Integer, OperationType> opTypeCache = new HashMap<>();
 
         for (Measurement measurement : measurements) {
@@ -543,7 +542,9 @@ public class ReleaseFileService {
                 entry.setCdnaAnalysisConcentration(concMeasurement.getValue());
             }
 
-            if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase(VISIUM_TO) || entry.getLabware().getLabwareType().getName().equalsIgnoreCase(VISIUM_LP)) {
+            String labwareTypeName = entry.getLabware().getLabwareType().getName();
+
+            if (labwareTypeName.equalsIgnoreCase(VISIUM_TO) || labwareTypeName.equalsIgnoreCase(VISIUM_LP)) {
                 //Retrieving measurements only from released labware (not from ancestors)
                 List<Measurement> permMeasurements = slotIdToPermTimes.get(entry.getSlot().getId());
                 if (permMeasurements!=null && !permMeasurements.isEmpty()) {
@@ -559,8 +560,7 @@ public class ReleaseFileService {
                         }
                     }
                 }
-            }
-            if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase("96 Well Plate")) {
+            } else if (labwareTypeName.equalsIgnoreCase(PLATE_96)) {
                 Measurement permMeasurement = selectMeasurement(entry, slotIdToPermTimes, ancestry);
                 if (permMeasurement != null) {
                     try {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
@@ -37,7 +37,6 @@ public class ReleaseFileService {
     private final OperationRepo opRepo;
     private final LabwareNoteRepo lwNoteRepo;
     private final StainTypeRepo stainTypeRepo;
-
     private final ReagentActionDetailService reagentActionDetailService;
 
     @Autowired
@@ -178,7 +177,7 @@ public class ReleaseFileService {
 
     /**
      * Loads and returns a map of snapshot id to shapshot.
-     * Errors if any shapshots cannot be found.
+     * Errors if any snapshots cannot be found.
      * @param releases the releases indicating the snapshots
      * @return a map of snapshots keyed by their id
      * @exception EntityNotFoundException if any snapshots could not be found
@@ -309,6 +308,8 @@ public class ReleaseFileService {
             }
         }
     }
+
+
 
     /**
      * The source for cdna is the first sample found in the ancestry that does not have biostate cDNA.
@@ -475,11 +476,13 @@ public class ReleaseFileService {
         Map<Integer, List<Measurement>> slotIdToCoverage = new HashMap<>();
         Map<Integer, List<Measurement>> slotIdToCq = new HashMap<>();
         Map<Integer, List<Measurement>> slotIdToCDNAConc = new HashMap<>();
+        Map<Integer, List<Measurement>> slotIdToPermTimes = new HashMap<>();
         final String THICKNESS = MeasurementType.Thickness.friendlyName();
         final String COVERAGE = MeasurementType.Tissue_coverage.friendlyName();
         final String CQ = MeasurementType.Cq_value.friendlyName();
         final String CDNA_CONC = MeasurementType.cDNA_concentration.friendlyName();
         final String CDNA_ANALYSIS = "cDNA analysis";
+        final String PERM_TIME= MeasurementType.Permeabilisation_time.friendlyName();
         Map<Integer, OperationType> opTypeCache = new HashMap<>();
         for (Measurement measurement : measurements) {
             if (measurement.getOperationId()==null) {
@@ -506,6 +509,9 @@ public class ReleaseFileService {
                     List<Measurement> slotIdMeasurements = slotIdToCDNAConc.computeIfAbsent(measurement.getSlotId(), k -> new ArrayList<>());
                     slotIdMeasurements.add(measurement);
                 }
+            } else if (measurement.getName().equalsIgnoreCase(PERM_TIME)) {
+                List<Measurement> slotIdMeasurements = slotIdToPermTimes.computeIfAbsent(measurement.getSlotId(), k -> new ArrayList<>());
+                slotIdMeasurements.add(measurement);
             }
         }
         for (ReleaseEntry entry : entries) {
@@ -532,6 +538,33 @@ public class ReleaseFileService {
             Measurement concMeasurement = selectMeasurement(entry, slotIdToCDNAConc, ancestry);
             if (concMeasurement != null) {
                 entry.setCdnaAnalysisConcentration(concMeasurement.getValue());
+            }
+
+            if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium TO") || entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium LP")) {
+                List<Measurement> permMeasurements = slotIdToPermTimes.get(entry.getSlot().getId());
+                if (permMeasurements!=null && !permMeasurements.isEmpty()) {
+                    var optMeasurement = permMeasurements.stream()
+                            .filter(m -> m.getSampleId().equals(entry.getSample().getId()))
+                            .findAny();
+                    if (optMeasurement.isPresent()) {
+                        Measurement permMeasurementResult = optMeasurement.get();
+                        try {
+                            entry.setPermTime(Integer.valueOf(permMeasurementResult.getValue()));
+                        } catch (NumberFormatException e) {
+                            log.error("Permeabilisation time measurement is not an integer: {}", permMeasurementResult.getValue());
+                        }
+                    }
+                }
+            }
+            if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase("96 Well Plate")) {
+                Measurement permMeasurement = selectMeasurement(entry, slotIdToPermTimes, ancestry);
+                if (permMeasurement != null) {
+                    try {
+                        entry.setPermTime(Integer.valueOf(permMeasurement.getValue()));
+                    } catch (NumberFormatException e) {
+                        log.error("Permeabilisation time measurement is not an integer: {}", permMeasurement);
+                    }
+                }
             }
         }
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
@@ -483,6 +483,8 @@ public class ReleaseFileService {
         final String CDNA_CONC = MeasurementType.cDNA_concentration.friendlyName();
         final String CDNA_ANALYSIS = "cDNA analysis";
         final String PERM_TIME= MeasurementType.Permeabilisation_time.friendlyName();
+        final String VISIUM_TO = "Visium TO";
+        final String VISIUM_LP = "Visium LP";
         Map<Integer, OperationType> opTypeCache = new HashMap<>();
         for (Measurement measurement : measurements) {
             if (measurement.getOperationId()==null) {
@@ -540,7 +542,7 @@ public class ReleaseFileService {
                 entry.setCdnaAnalysisConcentration(concMeasurement.getValue());
             }
 
-            if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium TO") || entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium LP")) {
+            if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase(VISIUM_TO) || entry.getLabware().getLabwareType().getName().equalsIgnoreCase(VISIUM_LP)) {
                 //Checking only on releases labware not on ancestors
                 List<Measurement> permMeasurements = slotIdToPermTimes.get(entry.getSlot().getId());
                 if (permMeasurements!=null && !permMeasurements.isEmpty()) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
@@ -541,6 +541,7 @@ public class ReleaseFileService {
             }
 
             if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium TO") || entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium LP")) {
+                //Checking only on releases labware not on ancestrors
                 List<Measurement> permMeasurements = slotIdToPermTimes.get(entry.getSlot().getId());
                 if (permMeasurements!=null && !permMeasurements.isEmpty()) {
                     var optMeasurement = permMeasurements.stream()

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
@@ -541,7 +541,7 @@ public class ReleaseFileService {
             }
 
             if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium TO") || entry.getLabware().getLabwareType().getName().equalsIgnoreCase("Visium LP")) {
-                //Checking only on releases labware not on ancestrors
+                //Checking only on releases labware not on ancestors
                 List<Measurement> permMeasurements = slotIdToPermTimes.get(entry.getSlot().getId());
                 if (permMeasurements!=null && !permMeasurements.isEmpty()) {
                     var optMeasurement = permMeasurements.stream()

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileService.java
@@ -486,6 +486,7 @@ public class ReleaseFileService {
         final String VISIUM_TO = "Visium TO";
         final String VISIUM_LP = "Visium LP";
         Map<Integer, OperationType> opTypeCache = new HashMap<>();
+
         for (Measurement measurement : measurements) {
             if (measurement.getOperationId()==null) {
                 continue;
@@ -543,7 +544,7 @@ public class ReleaseFileService {
             }
 
             if(entry.getLabware().getLabwareType().getName().equalsIgnoreCase(VISIUM_TO) || entry.getLabware().getLabwareType().getName().equalsIgnoreCase(VISIUM_LP)) {
-                //Checking only on releases labware not on ancestors
+                //Retrieving measurements only from released labware (not from ancestors)
                 List<Measurement> permMeasurements = slotIdToPermTimes.get(entry.getSlot().getId());
                 if (permMeasurements!=null && !permMeasurements.isEmpty()) {
                     var optMeasurement = permMeasurements.stream()

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
@@ -125,7 +125,7 @@ public class TestReleaseMutation {
                 "Life stage", "External identifier", "Tissue type", "Spatial location", "Replicate number", "Section number",
                 "Last section number", "Source barcode", "Section thickness", "Released from box location",
                 "Stain type", "Bond barcode", "Tissue coverage", "Cq value", "cDNA analysis concentration",
-                "Dual index plate name", "RNAscope plex", "IHC plex", "Date sectioned");
+                "Dual index plate name", "RNAscope plex", "IHC plex", "Date sectioned", "Permeabilisation time");
         var row0 = tsvMaps.get(0);
         assertEquals(block.getBarcode(), row0.get("Barcode"));
         assertEquals(block.getLabwareType().getName(), row0.get("Labware type"));

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
@@ -47,10 +47,10 @@ public class TestReleaseFileService {
     private User user;
     private ReleaseDestination destination;
     private ReleaseRecipient recipient;
-    private Sample sample, sample1,sample2, sample3;
-    private Labware lw1, lw2,lwTOSlide,lw96WellPlate;
-    private Release release1, release2, release3, release4;
-    private Snapshot snap1, snap2, snap3, snap4;
+    private Sample sample, sample1, sample2, sample3;
+    private Labware lw1, lw2, lwTOSlide,lw96WellPlate;
+    private Release release1, release2;
+    private Snapshot snap1, snap2;
 
 
     @BeforeEach
@@ -106,12 +106,8 @@ public class TestReleaseFileService {
         }
         snap1 = EntityFactory.makeSnapshot(lw1);
         snap2 = EntityFactory.makeSnapshot(lw2);
-        snap3 = EntityFactory.makeSnapshot(lwTOSlide);
-        snap4 = EntityFactory.makeSnapshot(lw96WellPlate);
         release1 = release(1, lw1, snap1);
         release2 = release(2, lw2, snap2);
-        release3 = release(3, lwTOSlide, snap3);
-        release4 = release(4, lw96WellPlate, snap4);
     }
 
     private Map<Integer, Snapshot> snapMap() {

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
@@ -49,8 +49,8 @@ public class TestReleaseFileService {
     private ReleaseRecipient recipient;
     private Sample sample, sample1,sample2, sample3;
     private Labware lw1, lw2,lwTOSlide,lw96WellPlate;
-    private Release release1, release2, release3,release4;
-    private Snapshot snap1, snap2,snap3,snap4;
+    private Release release1, release2, release3, release4;
+    private Snapshot snap1, snap2, snap3, snap4;
 
 
     @BeforeEach
@@ -87,15 +87,16 @@ public class TestReleaseFileService {
         lw1.getSlots().get(1).getSamples().add(sample);
 
         lw2 = EntityFactory.makeLabware(lt, sample);
+
         LabwareType ltTOSlide = new LabwareType(1, "Visium TO", 4, 2, null, false);
         sample2 = new Sample(12, 1, tissue, bioState);
-        lwTOSlide =EntityFactory.makeLabware(ltTOSlide);
+        lwTOSlide = EntityFactory.makeLabware(ltTOSlide);
         lwTOSlide.getFirstSlot().getSamples().add(sample2);
 
         LabwareType lt96WellPlate = new LabwareType(2, "96 well plate", 12, 8, null, false);
         lt96WellPlate.setName("96 Well Plate");
         sample3 = new Sample(13, 1, tissue, bioState);
-        lw96WellPlate =EntityFactory.makeLabware(lt96WellPlate);
+        lw96WellPlate = EntityFactory.makeLabware(lt96WellPlate);
         lw96WellPlate.getFirstSlot().getSamples().add(sample3);
     }
 
@@ -681,10 +682,7 @@ public class TestReleaseFileService {
     public void testLoadMeasurements() {
         setupLabware();
         Labware lw0 = EntityFactory.makeLabware(EntityFactory.getTubeType(), sample);
-
-
         Labware lw96WellPlateSource = EntityFactory.makeLabware(new LabwareType(6, "96 Well Plate", 12, 8, null, false), sample3);
-
 
         // lw0 begat lw1 which begat lw2
         var ancestry = makeAncestry(


### PR DESCRIPTION
Changes proposed in this pull request:
- if the labware being released is an LP or TO slide, then the perm times should be recorded on that same barcode.
- If the labware being released is a 96 well plate, then the perm times should be recorded on the source from which the plate was created.
