### PR TITLE
x925 Allow original samples with the same fields

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -374,4 +374,13 @@ public class BasicUtils {
     public static boolean nullOrEmpty(String string) {
         return (string==null || string.isEmpty());
     }
+
+    /**
+     * If the string is empty, return null. Otherwise, return the string.
+     * @param string the string that may be empty
+     * @return the nonempty string, or null
+     */
+    public static String emptyToNull(String string) {
+        return (string==null || string.isEmpty() ? null : string);
+    }
 }


### PR DESCRIPTION
Previously we blocked original samples duplicating another's donor, tissue type and spatial location. Now we allow it.

Closes #120 