### PR TITLE
x937 Give back solution names from original samples mutation

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/request/register/LabwareSolutionName.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/register/LabwareSolutionName.java
@@ -1,0 +1,53 @@
+package uk.ac.sanger.sccp.stan.request.register;
+
+import java.util.Objects;
+
+/**
+ * An association between a labware barcode and a solution
+ */
+public class LabwareSolutionName {
+    private String barcode;
+    private String solutionName;
+
+    public LabwareSolutionName() {}
+
+    public LabwareSolutionName(String barcode, String solutionName) {
+        this.barcode = barcode;
+        this.solutionName = solutionName;
+    }
+
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    public String getSolutionName() {
+        return this.solutionName;
+    }
+
+    public void setSolutionName(String solutionName) {
+        this.solutionName = solutionName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LabwareSolutionName that = (LabwareSolutionName) o;
+        return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.solutionName, that.solutionName));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(barcode, solutionName);
+    }
+
+    @Override
+    public String toString() {
+        return barcode + ": " + solutionName;
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/register/RegisterResult.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/register/RegisterResult.java
@@ -12,11 +12,17 @@ import java.util.Objects;
 public class RegisterResult {
     private List<Labware> labware = List.of();
     private List<RegisterClash> clashes = List.of();
+    private List<LabwareSolutionName> labwareSolutions = List.of();
 
     public RegisterResult() {}
 
     public RegisterResult(List<Labware> labware) {
         this.labware = labware;
+    }
+
+    public RegisterResult(List<Labware> labware, List<LabwareSolutionName> labwareSolutions) {
+        this.labware = labware;
+        this.labwareSolutions = labwareSolutions;
     }
 
     public List<Labware> getLabware() {
@@ -33,6 +39,14 @@ public class RegisterResult {
 
     public void setClashes(List<RegisterClash> clashes) {
         this.clashes = clashes;
+    }
+
+    public List<LabwareSolutionName> getLabwareSolutions() {
+        return this.labwareSolutions;
+    }
+
+    public void setLabwareSolutions(List<LabwareSolutionName> labwareSolutions) {
+        this.labwareSolutions = labwareSolutions;
     }
 
     public static RegisterResult clashes(List<RegisterClash> clashes) {
@@ -60,7 +74,9 @@ public class RegisterResult {
         return MoreObjects.toStringHelper(this)
                 .add("labware", labware)
                 .add("clashes", clashes)
+                .add("labwareSolutions", labwareSolutions)
                 .omitNullValues()
                 .toString();
     }
+
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -338,12 +338,22 @@ type RegisterClash {
     labware: [Labware!]!
 }
 
+"""A labware barcode and name of a solution."""
+type LabwareSolutionName {
+    """The barcode of an item of labware."""
+    barcode: String!
+    """The name of a solution."""
+    solutionName: String!
+}
+
 """The result of a register request. It is expected to contain either labware or clashes."""
 type RegisterResult {
     """The labware created."""
     labware: [Labware!]!
     """The clashes that prevented registration."""
     clashes: [RegisterClash!]!
+    """The names of solutions used for labware barcodes, if any."""
+    labwareSolutions: [LabwareSolutionName]!
 }
 
 """A description of a source slot in a plan request."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterOriginalSamplesMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterOriginalSamplesMutation.java
@@ -65,7 +65,10 @@ public class TestRegisterOriginalSamplesMutation {
         Map<String, ?> result = tester.post(mutation);
         assertThat((List<?>) result.get("errors")).isNullOrEmpty();
         assertThat((List<?>) result.get("clashes")).isNullOrEmpty();
-        List<Map<String, ?>> labwareData = chainGet(result, "data", "registerOriginalSamples", "labware");
+        Map<String, ?> regData = chainGet(result, "data", "registerOriginalSamples");
+        assertThat((List<?>) regData.get("clashes")).isNullOrEmpty();
+        List<Map<String, ?>> labwareData = chainGet(regData, "labware");
+        List<Map<String, String>> lwSolData = chainGet(regData, "labwareSolutions");
         assertThat(labwareData).hasSize(1);
         Map<String, ?> lwData = labwareData.get(0);
 
@@ -97,6 +100,11 @@ public class TestRegisterOriginalSamplesMutation {
         assertEquals(externalName, tissue.getExternalName());
         assertNull(tissue.getReplicate());
         assertEquals(Labware.State.active, lw.getState());
+
+        assertThat(lwSolData).hasSize(1);
+        Map<String, String> lwSol = lwSolData.get(0);
+        assertEquals(lw.getBarcode(), lwSol.get("barcode"));
+        assertEquals(solution.getName(), lwSol.get("solutionName"));
 
         Work work = entityCreator.createWork(null, null, null, null);
         Labware block = testBlockProcessing(barcode, work);

--- a/src/test/resources/graphql/registeroriginal.graphql
+++ b/src/test/resources/graphql/registeroriginal.graphql
@@ -41,5 +41,6 @@ mutation {
             tissue { externalName }
             labware { barcode }
         }
+        labwareSolutions { barcode solutionName }
     }
 }


### PR DESCRIPTION
Include in the register result a list of labware barcode/solution-name entries.

Also added a check in the service that none of the sample data are identical, because it would fail weirdly if it was.
