### PR TITLE
x949: Allow Stain QC on labware whose ancestor was stained

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Operation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Operation.java
@@ -1,6 +1,7 @@
 package uk.ac.sanger.sccp.stan.model;
 
 import org.hibernate.annotations.*;
+import org.jetbrains.annotations.NotNull;
 import uk.ac.sanger.sccp.utils.BasicUtils;
 
 import javax.persistence.Entity;
@@ -14,7 +15,7 @@ import java.util.Objects;
  */
 @Entity
 @DynamicInsert
-public class Operation {
+public class Operation implements Comparable<Operation> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -139,5 +140,20 @@ public class Operation {
                 .add("operationType", operationType)
                 .addIfNotNull("equipment", equipment)
                 .toString();
+    }
+
+    /**
+     * Compares operations by timestamp and then by id.
+     */
+    @Override
+    public int compareTo(@NotNull Operation other) {
+        if (this==other) {
+            return 0;
+        }
+        int c = this.getPerformed().compareTo(other.getPerformed());
+        if (c==0) {
+            c = this.getId().compareTo(other.getId());
+        }
+        return c;
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ExtractResultServiceImp.java
@@ -7,6 +7,7 @@ import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.ExtractResultRequest;
 import uk.ac.sanger.sccp.stan.request.ExtractResultRequest.ExtractResultLabware;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.operation.OpSearcher;
 import uk.ac.sanger.sccp.stan.service.sanitiser.Sanitiser;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.BasicUtils;
@@ -35,8 +36,8 @@ public class ExtractResultServiceImp extends BaseResultService implements Extrac
                                    CommentValidationService commentValidationService, OperationService opService,
                                    LabwareRepo lwRepo, OperationTypeRepo opTypeRepo, OperationRepo opRepo,
                                    OperationCommentRepo opCommentRepo, MeasurementRepo measurementRepo,
-                                   ResultOpRepo resultOpRepo) {
-        super(labwareValidatorFactory, opTypeRepo, opRepo, lwRepo);
+                                   ResultOpRepo resultOpRepo, OpSearcher opSearcher) {
+        super(labwareValidatorFactory, opTypeRepo, opRepo, lwRepo, opSearcher);
         this.concentrationSanitiser = concentrationSanitiser;
         this.workService = workService;
         this.commentValidationService = commentValidationService;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/analysis/RNAAnalysisServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/analysis/RNAAnalysisServiceImp.java
@@ -7,6 +7,7 @@ import uk.ac.sanger.sccp.stan.request.*;
 import uk.ac.sanger.sccp.stan.request.RNAAnalysisRequest.RNAAnalysisLabware;
 import uk.ac.sanger.sccp.stan.service.*;
 import uk.ac.sanger.sccp.stan.service.analysis.AnalysisMeasurementValidator.AnalysisType;
+import uk.ac.sanger.sccp.stan.service.operation.OpSearcher;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.BasicUtils;
 import uk.ac.sanger.sccp.utils.UCMap;
@@ -38,8 +39,9 @@ public class RNAAnalysisServiceImp extends BaseResultService implements RNAAnaly
                                     WorkService workService, OperationService opService,
                                     CommentValidationService commentValidationService,
                                     OperationTypeRepo opTypeRepo, OperationRepo opRepo, LabwareRepo lwRepo,
-                                    MeasurementRepo measurementRepo, OperationCommentRepo opComRepo) {
-        super(labwareValidatorFactory, opTypeRepo, opRepo, lwRepo);
+                                    MeasurementRepo measurementRepo, OperationCommentRepo opComRepo,
+                                    OpSearcher opSearcher) {
+        super(labwareValidatorFactory, opTypeRepo, opRepo, lwRepo, opSearcher);
         this.measurementValidatorFactory = measurementValidatorFactory;
         this.workService = workService;
         this.opService = opService;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpSearcher.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpSearcher.java
@@ -1,0 +1,16 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import uk.ac.sanger.sccp.stan.model.*;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface OpSearcher {
+    /**
+     * Finds the latest generational op of the given type for each given labware.
+     * @param opType the type of operation to find
+     * @param labware the labware to find operations for
+     * @return a map of labware id to operation
+     */
+    Map<Integer, Operation> findLabwareOps(OperationType opType, Collection<Labware> labware);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpSearcherImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpSearcherImp.java
@@ -1,0 +1,115 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.Ancestry;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.SlotSample;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * Service for finding the last op on given labware or its ancestors.
+ * @author dr6
+ */
+@Service
+public class OpSearcherImp implements OpSearcher {
+    private final Ancestoriser ancestoriser;
+    private final OperationRepo opRepo;
+
+    @Autowired
+    public OpSearcherImp(Ancestoriser ancestoriser, OperationRepo opRepo) {
+        this.ancestoriser = ancestoriser;
+        this.opRepo = opRepo;
+    }
+
+    @Override
+    public Map<Integer, Operation> findLabwareOps(OperationType opType, Collection<Labware> labware) {
+        List<SlotSample> slotSamples = labware.stream()
+                .flatMap(SlotSample::stream)
+                .collect(toList());
+        Ancestry ancestry = ancestoriser.findAncestry(slotSamples);
+        return findLabwareOps(opType, labware, ancestry);
+    }
+
+    /**
+     * Finds the op of the given type for each given labware with the given ancestry.
+     * @param opType the type of operation to find
+     * @param labware the labware to find operations for
+     * @param ancestry the ancestry of the labware
+     * @return a map of labware id to operation
+     */
+    public Map<Integer, Operation> findLabwareOps(OperationType opType, Collection<Labware> labware, Ancestry ancestry) {
+        Set<Integer> slotIds = ancestry.keySet().stream()
+                .map(ss -> ss.getSlot().getId())
+                .collect(toSet());
+        List<Operation> ops = opRepo.findAllByOperationTypeAndDestinationSlotIdIn(opType, slotIds);
+        if (ops.isEmpty()) {
+            return Map.of();
+        }
+        Map<Integer, Operation> destSlotOp = ops.stream()
+                .flatMap(op -> op.getActions().stream()
+                        .map(ac -> Map.entry(ac.getDestination().getId(), op))
+                ).collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<Integer, Operation> lwOp = new HashMap<>(labware.size());
+        for (Labware lw : labware) {
+            Operation op = selectOp(lw, ancestry, destSlotOp);
+            if (op!=null) {
+                lwOp.put(lw.getId(), op);
+            }
+        }
+        return lwOp;
+    }
+
+    /**
+     * Gets the greater of two comparable objects.
+     * Objects are compared using their {@link Comparable#compareTo} method, with the
+     * greater being selected.
+     * If either is null, the other will be returned.
+     * @param opA one of the objects
+     * @param opB the other of the objects
+     * @return the greater of the new objects
+     */
+    public <T extends Comparable<T>> T selectGreater(T opA, T opB) {
+        if (opA==null) {
+            return opB;
+        }
+        if (opB==null) {
+            return opA;
+        }
+        return (opA.compareTo(opB) > 0 ? opA : opB);
+    }
+
+    /**
+     * Selects latest generational op for the given labware and its ancestry.
+     * @param lw the labware to find the operation for
+     * @param ancestry the ancestry of the labware
+     * @param destOp a map of destination slot id to operation
+     * @return a latest generational op for the given labware and its ancestry, if any is found; otherwise null
+     */
+    public Operation selectOp(Labware lw, Ancestry ancestry, Map<Integer, Operation> destOp) {
+        Collection<SlotSample> sss = SlotSample.stream(lw).collect(toList());
+        final Set<SlotSample> seenSlotSamples = new HashSet<>();
+        while (!sss.isEmpty()) {
+            seenSlotSamples.addAll(sss);
+            Operation foundOp = null;
+            for (SlotSample ss : sss) {
+                Operation op = destOp.get(ss.getSlot().getId());
+                foundOp = selectGreater(op, foundOp);
+
+            }
+            if (foundOp!=null) {
+                return foundOp;
+            }
+            sss = sss.stream()
+                    .flatMap(ss -> ancestry.ancestors(ss).stream())
+                    .filter(ss -> !seenSlotSamples.contains(ss))
+                    .collect(toSet());
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/Ancestoriser.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/Ancestoriser.java
@@ -7,6 +7,7 @@ import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.ActionRepo;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -209,6 +210,15 @@ public class Ancestoriser {
                 return n;
             }
             return Integer.compare(this.sample.getId(), that.sample.getId());
+        }
+
+        public static Stream<SlotSample> stream(Stream<Slot> slots) {
+            return slots.flatMap(slot -> slot.getSamples().stream()
+                    .map(sam -> new SlotSample(slot, sam)));
+        }
+
+        public static Stream<SlotSample> stream(Labware lw) {
+            return stream(lw.getSlots().stream());
         }
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestExtractResultService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestExtractResultService.java
@@ -12,6 +12,7 @@ import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.ExtractResultRequest;
 import uk.ac.sanger.sccp.stan.request.ExtractResultRequest.ExtractResultLabware;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.operation.OpSearcher;
 import uk.ac.sanger.sccp.stan.service.sanitiser.Sanitiser;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.UCMap;
@@ -55,10 +56,11 @@ public class TestExtractResultService {
         mockOpCommentRepo = mock(OperationCommentRepo.class);
         mockMeasurementRepo = mock(MeasurementRepo.class);
         mockResultOpRepo = mock(ResultOpRepo.class);
+        OpSearcher mockOpSearcher = mock(OpSearcher.class);
 
         service = spy(new ExtractResultServiceImp(mockLabwareValidatorFactory, mockConcentrationSanitiser,
                 mockWorkService, mockCommentValidationService, mockOpService, mockLwRepo, mockOpTypeRepo,
-                mockOpRepo, mockOpCommentRepo, mockMeasurementRepo, mockResultOpRepo));
+                mockOpRepo, mockOpCommentRepo, mockMeasurementRepo, mockResultOpRepo, mockOpSearcher));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/analysis/TestRnaAnalysisService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/analysis/TestRnaAnalysisService.java
@@ -12,6 +12,7 @@ import uk.ac.sanger.sccp.stan.request.*;
 import uk.ac.sanger.sccp.stan.request.RNAAnalysisRequest.RNAAnalysisLabware;
 import uk.ac.sanger.sccp.stan.service.*;
 import uk.ac.sanger.sccp.stan.service.analysis.AnalysisMeasurementValidator.AnalysisType;
+import uk.ac.sanger.sccp.stan.service.operation.OpSearcher;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.UCMap;
 
@@ -56,10 +57,11 @@ public class TestRnaAnalysisService {
         mockOpTypeRepo = mock(OperationTypeRepo.class);
         OperationRepo mockOpRepo = mock(OperationRepo.class);
         mockLwRepo = mock(LabwareRepo.class);
+        OpSearcher mockOpSearcher = mock(OpSearcher.class);
 
         service = spy(new RNAAnalysisServiceImp(mockLabwareValidatorFactory, mockMeasurementValidatorFactory,
                 mockWorkService, mockOpService, mockCommentValidationService, mockOpTypeRepo, mockOpRepo,
-                mockLwRepo, mockMeasurementRepo, mockOpComRepo));
+                mockLwRepo, mockMeasurementRepo, mockOpComRepo, mockOpSearcher));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestOpSearcher.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestOpSearcher.java
@@ -1,0 +1,188 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.Ancestry;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.SlotSample;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link OpSearcherImp}
+ * @author dr6
+ */
+public class TestOpSearcher {
+    private Ancestoriser mockAncestoriser;
+    private OperationRepo mockOpRepo;
+
+    private OpSearcherImp searcher;
+
+    @BeforeEach
+    void setup() {
+        mockAncestoriser = mock(Ancestoriser.class);
+        mockOpRepo = mock(OperationRepo.class);
+        searcher = spy(new OpSearcherImp(mockAncestoriser, mockOpRepo));
+    }
+
+    @Test
+    public void testFindLabwareOps() {
+        OperationType opType = EntityFactory.makeOperationType("Paint", null);
+        LabwareType lt = EntityFactory.makeLabwareType(2,3);
+        Sample sam1 = new Sample(51, null, null, null);
+        Sample sam2 = new Sample(52, null, null, null);
+        Address B2 = new Address(2,2);
+        List<Labware> labware = IntStream.rangeClosed(1,2).mapToObj(i -> {
+            Labware lw = EntityFactory.makeEmptyLabware(lt);
+            lw.setBarcode("STAN-A"+i);
+            lw.setId(i);
+            lw.getFirstSlot().addSample(sam1);
+            lw.getFirstSlot().addSample(sam2);
+            lw.getSlot(B2).addSample(i==1 ? sam1 : sam2);
+            for (int j = 0; j < lw.getSlots().size(); ++j) {
+                lw.getSlots().get(j).setId(10*i+j+1);
+            }
+            return lw;
+        }).collect(toList());
+        Ancestry ancestry = new Ancestry();
+        when(mockAncestoriser.findAncestry(any())).thenReturn(ancestry);
+        List<SlotSample> sss = List.of(
+                new SlotSample(labware.get(0).getFirstSlot(), sam1),
+                new SlotSample(labware.get(0).getFirstSlot(), sam2),
+                new SlotSample(labware.get(0).getSlot(B2), sam1),
+                new SlotSample(labware.get(1).getFirstSlot(), sam1),
+                new SlotSample(labware.get(1).getFirstSlot(), sam2),
+                new SlotSample(labware.get(1).getSlot(B2), sam2)
+        );
+        Map<Integer, Operation> opMap = Map.of(17, new Operation());
+        doReturn(opMap).when(searcher).findLabwareOps(any(), any(), any());
+
+        assertSame(opMap, searcher.findLabwareOps(opType, labware));
+        verify(mockAncestoriser).findAncestry(sss);
+        verify(searcher).findLabwareOps(opType, labware, ancestry);
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testFindLabwareOps_ancestry(boolean anyOps) {
+        OperationType opType = EntityFactory.makeOperationType("Spoon", null);
+        LabwareType lt = EntityFactory.getTubeType();
+        Sample sam = EntityFactory.getSample();
+        Labware[] labware = IntStream.rangeClosed(1,3).mapToObj(i -> {
+            Labware lw = EntityFactory.makeLabware(lt, sam);
+            lw.setBarcode("STAN-A"+i);
+            lw.setId(i);
+            lw.getFirstSlot().setId(50+i);
+            return lw;
+        }).toArray(Labware[]::new);
+        Ancestry ancestry = new Ancestry();
+        Slot[] slots = Arrays.stream(labware).map(Labware::getFirstSlot).toArray(Slot[]::new);
+        ancestry.put(new SlotSample(slots[0], sam), Set.of(new SlotSample(slots[1], sam)));
+        ancestry.put(new SlotSample(slots[1], sam), Set.of(new SlotSample(slots[2], sam)));
+
+        Set<Integer> slotIds = Set.of(51, 52);
+
+        if (!anyOps) {
+            doReturn(List.of()).when(mockOpRepo).findAllByOperationTypeAndDestinationSlotIdIn(any(), any());
+            assertThat(searcher.findLabwareOps(opType, Arrays.asList(labware), ancestry)).isEmpty();
+            verify(searcher, never()).selectOp(any(), any(), any());
+            verify(mockOpRepo).findAllByOperationTypeAndDestinationSlotIdIn(opType, slotIds);
+            return;
+        }
+        Operation[] ops = IntStream.range(0,2).mapToObj(i -> {
+            int id = i+101;
+            Operation op = new Operation();
+            op.setId(id);
+            Action a = new Action();
+            a.setOperationId(id);
+            a.setDestination(slots[i]);
+            op.setActions(List.of(a));
+            return op;
+        }).toArray(Operation[]::new);
+        doReturn(Arrays.asList(ops)).when(mockOpRepo).findAllByOperationTypeAndDestinationSlotIdIn(any(), any());
+
+        doReturn(ops[0]).when(searcher).selectOp(same(labware[0]), any(), any());
+        doReturn(ops[1]).when(searcher).selectOp(same(labware[1]), any(), any());
+        doReturn(null).when(searcher).selectOp(same(labware[2]), any(), any());
+        Map<Integer, Operation> expectedSlotIdMap = Map.of(slots[0].getId(), ops[0], slots[1].getId(), ops[1]);
+
+        Map<Integer, Operation> expectedResult = Map.of(labware[0].getId(), ops[0], labware[1].getId(), ops[1]);
+
+        assertEquals(expectedResult, searcher.findLabwareOps(opType, Arrays.asList(labware), ancestry));
+
+        verify(mockOpRepo).findAllByOperationTypeAndDestinationSlotIdIn(opType, slotIds);
+        verify(searcher).selectOp(labware[0], ancestry, expectedSlotIdMap);
+        verify(searcher).selectOp(labware[1], ancestry, expectedSlotIdMap);
+        verify(searcher).selectOp(labware[2], ancestry, expectedSlotIdMap);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1,1,1", "1,2,2", "2,1,2", "1,,1", "2,,2", ",,"})
+    public void testSelectGreater(Integer a, Integer b, Integer expected) {
+        assertEquals(expected, searcher.selectGreater(a, b));
+    }
+
+    @ParameterizedTest
+    @MethodSource("selectOpArgs")
+    public void testSelectOp(Labware lw, Ancestry ancestry, Map<Integer, Operation> lwOp, Operation expected) {
+        assertSame(expected, searcher.selectOp(lw, ancestry, lwOp));
+    }
+
+    static Stream<Arguments> selectOpArgs() {
+        LabwareType lt = EntityFactory.makeLabwareType(1,3);
+        final Address A2 = new Address(1,2);
+        Sample sam = EntityFactory.getSample();
+        Labware lw1 = EntityFactory.makeLabware(lt, sam, sam); // Slots 11,12,13
+        Labware lw2 = EntityFactory.makeLabware(EntityFactory.getTubeType(), sam); // Slot 21
+        Labware lw3 = EntityFactory.makeLabware(EntityFactory.getTubeType(), sam); // Slot 31
+        Labware lw4 = EntityFactory.makeLabware(EntityFactory.getTubeType(), sam); // Slot 41
+        Labware lw5 = EntityFactory.makeLabware(EntityFactory.getTubeType(), sam); // Slot 51
+        final List<Labware> labware = List.of(lw1, lw2, lw3, lw4, lw5);
+        for (int i = 0; i < labware.size(); ++i) {
+            int id = i+1;
+            Labware lw = labware.get(i);
+            lw.setId(id);
+            for (int j = 0; j < lw.getSlots().size(); ++j) {
+                lw.getSlots().get(j).setId(10*id + j + 1);
+            }
+        }
+
+
+        final IntFunction<SlotSample> ssFn = i -> new SlotSample(labware.get(i).getFirstSlot(), sam);
+
+        Ancestry anc = new Ancestry();
+        anc.put(ssFn.apply(0), Set.of(ssFn.apply(1)));
+        anc.put(ssFn.apply(1), Set.of(ssFn.apply(2), ssFn.apply(3)));
+        anc.put(new SlotSample(lw1.getSlot(A2), sam), Set.of(ssFn.apply(4)));
+
+        Operation op1 = new Operation();
+        op1.setId(101);
+        op1.setPerformed(LocalDateTime.now());
+        Operation op2 = new Operation();
+        op2.setId(102);
+        op2.setPerformed(LocalDateTime.now());
+
+        return Arrays.stream(new Object[][] {
+                {lw1, anc, Map.of(51, op1), op1},
+                {lw1, anc, Map.of(41, op1), op1},
+                {lw1, anc, Map.of(41,op1, 21,op2), op2},
+                {lw2, anc, Map.of(51, op1), null},
+        }).map(Arguments::of);
+    }
+}


### PR DESCRIPTION
Includes OpSearcher class, which looks for ops of a certain type in
labware's ancestry.
