### PR TITLE
x951 File store

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
@@ -1,0 +1,71 @@
+package uk.ac.sanger.sccp.stan;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import uk.ac.sanger.sccp.stan.model.StanFile;
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.service.FileStoreService;
+
+/**
+ * Controller for handling download/upload of files
+ * @author dr6
+ */
+@Controller
+public class FileStoreController {
+    private final FileStoreService fileService;
+    private final AuthenticationComponent authComp;
+
+    @Autowired
+    public FileStoreController(FileStoreService fileService, AuthenticationComponent authComp) {
+        this.fileService = fileService;
+        this.authComp = authComp;
+    }
+
+    @GetMapping("/files/{id}")
+    @ResponseBody
+    public ResponseEntity<Resource> serveFile(@PathVariable int id) {
+        StanFile sf = fileService.lookUp(id);
+
+        Resource resource = fileService.loadResource(sf);
+        return ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"" + sf.getName() + "\"").body(resource);
+    }
+
+    @PostMapping("files/{workNumber}")
+    public String receiveFile(@RequestParam("file") MultipartFile file,
+                              @PathVariable String workNumber) {
+        checkUserForUpload();
+        StanFile sf = fileService.save(file, workNumber);
+        return sf.getUrl();
+    }
+
+    protected User getUser() {
+        Authentication auth = authComp.getAuthentication();
+        if (auth != null) {
+            Object principal = auth.getPrincipal();
+            if (principal instanceof User) {
+                return (User) principal;
+            }
+        }
+        return null;
+    }
+
+    protected User checkUserForUpload() {
+        User user = getUser();
+        if (user==null) {
+            throw new AuthenticationCredentialsNotFoundException("Not logged in");
+        }
+        if (!user.hasRole(User.Role.normal)) {
+            throw new InsufficientAuthenticationException("User "+user.getUsername()+" does not have privilege to upload files.");
+        }
+        return user;
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
@@ -43,9 +43,9 @@ public class FileStoreController {
                 "attachment; filename=\"" + sf.getName() + "\"").body(resource);
     }
 
-    @PostMapping("/files/{workNumber}")
+    @PostMapping("/files")
     public ResponseEntity<String> receiveFile(@RequestParam("file") MultipartFile file,
-                              @PathVariable String workNumber) {
+                                              @RequestParam("workNumber") String workNumber) {
         User user = checkUserForUpload();
         StanFile sf = fileService.save(user, file, workNumber);
         log.info("Saved file "+sf);

--- a/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
@@ -15,6 +15,9 @@ import uk.ac.sanger.sccp.stan.model.StanFile;
 import uk.ac.sanger.sccp.stan.model.User;
 import uk.ac.sanger.sccp.stan.service.FileStoreService;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * Controller for handling download/upload of files
  * @author dr6
@@ -44,12 +47,12 @@ public class FileStoreController {
     }
 
     @PostMapping("/files")
-    public ResponseEntity<String> receiveFile(@RequestParam("file") MultipartFile file,
-                                              @RequestParam("workNumber") String workNumber) {
+    public ResponseEntity<?> receiveFile(@RequestParam("file") MultipartFile file,
+                                         @RequestParam("workNumber") String workNumber) throws URISyntaxException {
         User user = checkUserForUpload();
         StanFile sf = fileService.save(user, file, workNumber);
         log.info("Saved file "+sf);
-        return ResponseEntity.ok("Uploaded.");
+        return ResponseEntity.created(new URI(sf.getUrl())).build();
     }
 
     protected User getUser() {

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -66,6 +66,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final NextReplicateService nextReplicateService;
     final WorkSummaryService workSummaryService;
     final LabwareService labwareService;
+    final FileStoreService fileStoreService;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, UserRepo userRepo,
@@ -84,7 +85,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                PassFailQueryService passFailQueryService,
                                WorkService workService, VisiumPermDataService visiumPermDataService,
                                NextReplicateService nextReplicateService, WorkSummaryService workSummaryService,
-                               LabwareService labwareService) {
+                               LabwareService labwareService, FileStoreService fileStoreService) {
         super(objectMapper, authComp, userRepo);
         this.sessionConfig = sessionConfig;
         this.tissueTypeRepo = tissueTypeRepo;
@@ -118,6 +119,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.nextReplicateService = nextReplicateService;
         this.workSummaryService = workSummaryService;
         this.labwareService = labwareService;
+        this.fileStoreService = fileStoreService;
     }
 
     public DataFetcher<User> getUser() {
@@ -228,6 +230,13 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         return dfe -> {
             Collection<Work.Status> statuses = arg(dfe, "status", new TypeReference<List<Work.Status>>() {});
             return workService.getWorksWithComments(statuses);
+        };
+    }
+
+    public DataFetcher<List<StanFile>> listStanFiles() {
+        return dfe -> {
+            String workNumber = dfe.getArgument("workNumber");
+            return fileStoreService.list(workNumber);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -89,6 +89,7 @@ public class GraphQLProvider {
                         .dataFetcher("work", graphQLDataFetchers.getWork())
                         .dataFetcher("worksWithComments", graphQLDataFetchers.getWorksWithComments())
                         .dataFetcher("worksSummary", graphQLDataFetchers.worksSummary())
+                        .dataFetcher("listFiles", graphQLDataFetchers.listStanFiles())
                         .dataFetcher("stainTypes", graphQLDataFetchers.getEnabledStainTypes())
                         .dataFetcher("visiumPermData", graphQLDataFetchers.getVisiumPermData())
                         .dataFetcher("extractResult", graphQLDataFetchers.getExtractResult())

--- a/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
@@ -8,6 +8,7 @@ import uk.ac.sanger.sccp.stan.service.Validator;
 import uk.ac.sanger.sccp.stan.service.sanitiser.*;
 
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -233,5 +234,10 @@ public class FieldValidation {
         Pattern pattern = Pattern.compile("[A-Z]\\d{2}[A-Z]\\d{2}-\\d{7}-\\d{2}-\\d{2}", Pattern.CASE_INSENSITIVE);
         return new StringValidator("Visium LP CytAssist barcode", 20, 20,
                 charTypes, false, pattern);
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/config/StanFileConfig.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/StanFileConfig.java
@@ -1,0 +1,24 @@
+package uk.ac.sanger.sccp.stan.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Config related to storing files on a network volume
+ * @author dr6
+ */
+@Configuration
+public class StanFileConfig {
+    @Value("${stan.store.root}")
+    String root;
+    @Value("${stan.store.directory}")
+    String dir;
+
+    public String getRoot() {
+        return this.root;
+    }
+
+    public String getDir() {
+        return this.dir;
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/config/WebSecurityConfig.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/WebSecurityConfig.java
@@ -26,7 +26,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/graphiql").permitAll()
             .and()
                 .csrf()
-                .ignoringAntMatchers("/files/*")
+                .ignoringRequestMatchers(r -> "/files".equalsIgnoreCase(r.getRequestURI()))
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/config/WebSecurityConfig.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/WebSecurityConfig.java
@@ -26,6 +26,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/graphiql").permitAll()
             .and()
                 .csrf()
+                .ignoringAntMatchers("/files/*")
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/StanFile.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/StanFile.java
@@ -116,7 +116,7 @@ public class StanFile {
 
     /** The url where this file may be downloaded */
     public String getUrl() {
-        return "files/"+this.getId();
+        return "/files/"+this.getId();
     }
 
     @Override

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/StanFile.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/StanFile.java
@@ -1,0 +1,138 @@
+package uk.ac.sanger.sccp.stan.model;
+
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * A stored file
+ * @author dr6
+ */
+@Entity
+public class StanFile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    @Generated(GenerationTime.INSERT)
+    private LocalDateTime created;
+    @ManyToOne
+    private Work work;
+
+    private String name;
+    private String path;
+    private LocalDateTime deprecated;
+
+
+    public StanFile() {}
+
+    public StanFile(Integer id, LocalDateTime created, Work work, String name, String path, LocalDateTime deprecated) {
+        this.id = id;
+        this.created = created;
+        this.work = work;
+        this.name = name;
+        this.path = path;
+        this.deprecated = deprecated;
+    }
+
+    public StanFile(Work work, String name, String path) {
+        this(null, null, work, name, path, null);
+    }
+
+    /** The primary key of this entry in the database */
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    /** The timestamp that this entry was created */
+    public LocalDateTime getCreated() {
+        return this.created;
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = created;
+    }
+
+    /** The timestamp (if any) that this file was replaced or deprecated */
+    public LocalDateTime getDeprecated() {
+        return this.deprecated;
+    }
+
+    public void setDeprecated(LocalDateTime deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    /** The user-facing name of this file */
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /** The path where this file is stored inside the volume */
+    public String getPath() {
+        return this.path;
+    }
+
+    public void setPath(String filePath) {
+        this.path = filePath;
+    }
+
+    /** Is this file active? (Not deprecated) */
+    public boolean isActive() {
+        return (this.deprecated==null);
+    }
+
+    /** The work this file is associated with */
+    public Work getWork() {
+        return this.work;
+    }
+
+    public void setWork(Work work) {
+        this.work = work;
+    }
+
+    /** The url where this file may be downloaded */
+    public String getUrl() {
+        return "files/"+this.getId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StanFile that = (StanFile) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.created, that.created)
+                && Objects.equals(this.deprecated, that.deprecated)
+                && Objects.equals(this.name, that.name)
+                && Objects.equals(this.path, that.path)
+                && Objects.equals(this.work, that.work));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, created, deprecated, name, path, work);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe(this)
+                .add("id", id)
+                .add("created", created)
+                .add("work", work)
+                .addRepr("name", name)
+                .addRepr("path", path)
+                .addIfNotNull("deprecated", deprecated)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/StanFile.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/StanFile.java
@@ -21,6 +21,8 @@ public class StanFile {
     private LocalDateTime created;
     @ManyToOne
     private Work work;
+    @ManyToOne
+    private User user;
 
     private String name;
     private String path;
@@ -29,17 +31,19 @@ public class StanFile {
 
     public StanFile() {}
 
-    public StanFile(Integer id, LocalDateTime created, Work work, String name, String path, LocalDateTime deprecated) {
+    public StanFile(Integer id, LocalDateTime created, Work work, User user,
+                    String name, String path, LocalDateTime deprecated) {
         this.id = id;
         this.created = created;
+        this.user = user;
         this.work = work;
         this.name = name;
         this.path = path;
         this.deprecated = deprecated;
     }
 
-    public StanFile(Work work, String name, String path) {
-        this(null, null, work, name, path, null);
+    public StanFile(Work work, User user, String name, String path) {
+        this(null, null, work, user, name, path, null);
     }
 
     /** The primary key of this entry in the database */
@@ -101,6 +105,15 @@ public class StanFile {
         this.work = work;
     }
 
+    /** The user who uploaded the file */
+    public User getUser() {
+        return this.user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
     /** The url where this file may be downloaded */
     public String getUrl() {
         return "files/"+this.getId();
@@ -116,12 +129,13 @@ public class StanFile {
                 && Objects.equals(this.deprecated, that.deprecated)
                 && Objects.equals(this.name, that.name)
                 && Objects.equals(this.path, that.path)
-                && Objects.equals(this.work, that.work));
+                && Objects.equals(this.work, that.work)
+                && Objects.equals(this.user, that.user));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, created, deprecated, name, path, work);
+        return Objects.hash(id, created, deprecated, name, path, work, user);
     }
 
     @Override
@@ -130,6 +144,7 @@ public class StanFile {
                 .add("id", id)
                 .add("created", created)
                 .add("work", work)
+                .addRepr("user", user==null ? null: user.getUsername())
                 .addRepr("name", name)
                 .addRepr("path", path)
                 .addIfNotNull("deprecated", deprecated)

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/StanFileRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/StanFileRepo.java
@@ -14,7 +14,7 @@ public interface StanFileRepo extends CrudRepository<StanFile, Integer> {
     List<StanFile> findAllActiveByWorkId(Integer workId);
 
     /** Finds all active stan files with the given name, associated with the given work id. */
-    @Query("select f from StanFile f where f.work.id=?1 and f.name=?2")
+    @Query("select f from StanFile f where f.work.id=?1 and f.name=?2 and f.deprecated is null")
     List<StanFile> findAllActiveByWorkIdAndName(Integer workId, String name);
 
     /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/StanFileRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/StanFileRepo.java
@@ -1,0 +1,29 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.StanFile;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+
+/** Repo for {@link StanFile} */
+public interface StanFileRepo extends CrudRepository<StanFile, Integer> {
+    /** Finds all active stan files associated with the given work id. */
+    @Query("select f from StanFile f where f.work.id=?1 and f.deprecated is null")
+    List<StanFile> findAllActiveByWorkId(Integer workId);
+
+    /** Finds all active stan files with the given name, associated with the given work id. */
+    @Query("select f from StanFile f where f.work.id=?1 and f.name=?2")
+    List<StanFile> findAllActiveByWorkIdAndName(Integer workId, String name);
+
+    /**
+     * Gets the stan file with the given id
+     * @param id the id of the stan file
+     * @return the found stan file
+     * @exception EntityNotFoundException if there is no stan file with the given id
+     */
+    default StanFile getById(Integer id) throws EntityNotFoundException {
+        return findById(id).orElseThrow(() -> new EntityNotFoundException("No stan file found with id "+id+"."));
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreService.java
@@ -9,15 +9,39 @@ import java.util.List;
 
 /** Service for helping to deal with stored files. */
 public interface FileStoreService {
-    /** Saves a file, creating a new entry in the files table. */
+    /**
+     * Saves a file, creating a new entry in the files table (with an internal transaction).
+     * @param user user uploading the file
+     * @param multipartFile the file data
+     * @param workNumber the work number to save the file in association with
+     * @return a new stanfile from the database
+     * @exception java.io.UncheckedIOException if saving the file causes an IOException
+     * @exception javax.persistence.EntityNotFoundException if referenced entities do not exist
+     */
     StanFile save(User user, MultipartFile multipartFile, String workNumber);
 
-    /** Loads the data for the given stan file */
+    /**
+     * Loads the data for the given stan file
+     * @param stanFile an existing StanFile object
+     * @return the resource of the indicated file
+     * @exception IllegalStateException if the indicated is deprecated (i.e. replaced by a newer version)
+     * @exception java.io.UncheckedIOException if opening the file causes an IOException
+     */
     Resource loadResource(StanFile stanFile);
 
-    /** Looks up the stan file record with the given id */
+    /**
+     * Looks up the stan file record with the given id
+     * @param id the id of a stan file
+     * @return the stan file with the given id
+     * @exception javax.persistence.EntityNotFoundException if the indicated stan file is not found
+     */
     StanFile lookUp(Integer id);
 
-    /** Lists the active files linked to a particular work. */
+    /**
+     * Lists the active files linked to a particular work.
+     * @param workNumber the work number of an existing work
+     * @return the stan file objects associated with the given work number
+     * @exception javax.persistence.EntityNotFoundException if the indicated work cannot be found
+     */
     List<StanFile> list(String workNumber);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreService.java
@@ -1,0 +1,22 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+import uk.ac.sanger.sccp.stan.model.StanFile;
+
+import java.util.List;
+
+/** Service for helping to deal with stored files. */
+public interface FileStoreService {
+    /** Saves a file, creating a new entry in the files table. */
+    StanFile save(MultipartFile multipartFile, String workNumber);
+
+    /** Loads the data for the given stan file */
+    Resource loadResource(StanFile stanFile);
+
+    /** Looks up the stan file record with the given id */
+    StanFile lookUp(Integer id);
+
+    /** Lists the active files linked to a particular work. */
+    List<StanFile> list(String workNumber);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreService.java
@@ -3,13 +3,14 @@ package uk.ac.sanger.sccp.stan.service;
 import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 import uk.ac.sanger.sccp.stan.model.StanFile;
+import uk.ac.sanger.sccp.stan.model.User;
 
 import java.util.List;
 
 /** Service for helping to deal with stored files. */
 public interface FileStoreService {
     /** Saves a file, creating a new entry in the files table. */
-    StanFile save(MultipartFile multipartFile, String workNumber);
+    StanFile save(User user, MultipartFile multipartFile, String workNumber);
 
     /** Loads the data for the given stan file */
     Resource loadResource(StanFile stanFile);

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreServiceImp.java
@@ -6,8 +6,7 @@ import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import uk.ac.sanger.sccp.stan.config.StanFileConfig;
-import uk.ac.sanger.sccp.stan.model.StanFile;
-import uk.ac.sanger.sccp.stan.model.Work;
+import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.StanFileRepo;
 import uk.ac.sanger.sccp.stan.repo.WorkRepo;
 
@@ -38,7 +37,7 @@ public class FileStoreServiceImp implements FileStoreService {
     }
 
     @Override
-    public StanFile save(MultipartFile fileData, String workNumber) {
+    public StanFile save(User user, MultipartFile fileData, String workNumber) {
         Work work = workRepo.getByWorkNumber(workNumber);
 
         String filename = getFilename(fileData);
@@ -60,7 +59,7 @@ public class FileStoreServiceImp implements FileStoreService {
 
         deprecateOldFiles(filename, work.getId(), now);
 
-        return fileRepo.save(new StanFile(work, filename, path.toString()));
+        return fileRepo.save(new StanFile(work, user, filename, path.toString()));
     }
 
     private String getFilename(MultipartFile file) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/FileStoreServiceImp.java
@@ -1,0 +1,106 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import uk.ac.sanger.sccp.stan.config.StanFileConfig;
+import uk.ac.sanger.sccp.stan.model.StanFile;
+import uk.ac.sanger.sccp.stan.model.Work;
+import uk.ac.sanger.sccp.stan.repo.StanFileRepo;
+import uk.ac.sanger.sccp.stan.repo.WorkRepo;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.*;
+import java.util.List;
+
+/**
+ * @author dr6
+ */
+@Service
+public class FileStoreServiceImp implements FileStoreService {
+    private final StanFileConfig config;
+    private final Clock clock;
+    private final StanFileRepo fileRepo;
+    private final WorkRepo workRepo;
+
+    @Autowired
+    public FileStoreServiceImp(StanFileConfig config, Clock clock, StanFileRepo fileRepo, WorkRepo workRepo) {
+        this.config = config;
+        this.clock = clock;
+        this.fileRepo = fileRepo;
+        this.workRepo = workRepo;
+    }
+
+    @Override
+    public StanFile save(MultipartFile fileData, String workNumber) {
+        Work work = workRepo.getByWorkNumber(workNumber);
+
+        String filename = fileData.getOriginalFilename();
+        String san;
+        if (filename==null || filename.isEmpty()) {
+            filename = "unnamed";
+            san = filename;
+        } else {
+            san = filename.replaceAll("[^a-zA-Z0-9_-]","");
+            if (san.isEmpty()) {
+                san = "unnamed";
+            }
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        final String savedFilename = now + ":" + san;
+        Path path = Paths.get(config.getDir(), savedFilename);
+
+        try {
+            fileData.transferTo(Paths.get(config.getRoot(), config.getDir(), savedFilename));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        deprecateOldFiles(filename, work.getId(), now);
+
+        return fileRepo.save(new StanFile(work, filename, path.toString()));
+    }
+
+    @Override
+    public Resource loadResource(StanFile stanFile) {
+        if (!stanFile.isActive()) {
+            throw new IllegalArgumentException("File is inactive: "+stanFile.getPath());
+        }
+        Path path = Paths.get(config.getRoot(), stanFile.getPath());
+        try {
+            return new UrlResource(path.toUri());
+        } catch (MalformedURLException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public StanFile lookUp(Integer id) {
+        return fileRepo.getById(id);
+    }
+
+    public void deprecateOldFiles(String name, Integer workId, LocalDateTime timestamp) {
+        List<StanFile> oldFiles = fileRepo.findAllActiveByWorkIdAndName(workId, name);
+        if (oldFiles.isEmpty()) {
+            return;
+        }
+        for (StanFile f : oldFiles) {
+            f.setDeprecated(timestamp);
+        }
+        fileRepo.saveAll(oldFiles);
+    }
+
+    @Override
+    public List<StanFile> list(String workNumber) {
+        Work work = workRepo.getByWorkNumber(workNumber);
+        return fileRepo.findAllActiveByWorkId(work.getId());
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -21,3 +21,5 @@ stan.mail.sender=Stan dev<no-reply@sanger.ac.uk>
 stan.mail.alert_recipients=
 stan.mail.service_description=Stan dev
 uk.ac.sanger.sccp.stan.apikeys=${STAN_APIKEYS:{'devapikey':'patch'}}
+stan.store.root=${HOME}/stan_files
+stan.store.directory=local

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -20,3 +20,5 @@ stan.mail.sender=Stan test<no-reply@sanger.ac.uk>
 stan.mail.alert_recipients=
 stan.mail.service_description=Stan test
 uk.ac.sanger.sccp.stan.apikeys=${STAN_APIKEYS:{'devapikey':'patch'}}
+stan.store.root=${HOME}/stan_files
+stan.store.directory=test

--- a/src/main/resources/db/changelog/changelog-2.15.xml
+++ b/src/main/resources/db/changelog/changelog-2.15.xml
@@ -11,6 +11,9 @@
             <column name="work_id" type="INT">
                 <constraints nullable="false" foreignKeyName="fk_stan_file_work" referencedTableName="work" referencedColumnNames="id"/>
             </column>
+            <column name="user_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_stan_file_user" referencedTableName="user" referencedColumnNames="id"/>
+            </column>
             <column name="name" type="VARCHAR(64)">
                 <constraints nullable="false"/>
             </column>

--- a/src/main/resources/db/changelog/changelog-2.15.xml
+++ b/src/main/resources/db/changelog/changelog-2.15.xml
@@ -1,0 +1,42 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="2.15.0" author="dr6">
+        <createTable tableName="stan_file">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="work_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_stan_file_work" referencedTableName="work" referencedColumnNames="id"/>
+            </column>
+            <column name="name" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="path" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deprecated" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="stan_file" indexName="ix_stan_file_name" unique="false">
+            <column name="name"/>
+        </createIndex>
+        <createIndex tableName="stan_file" indexName="uk_stan_file_path" unique="true">
+            <column name="path"/>
+        </createIndex>
+        <rollback>
+            <dropAllForeignKeyConstraints baseTableName="stan_file"/>
+            <dropTable tableName="stan_file"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -16,4 +16,5 @@
     <include relativeToChangelogFile="true" file="changelog-2.7.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.9.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.13.xml"/>
+    <include relativeToChangelogFile="true" file="changelog-2.15.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1304,6 +1304,18 @@ type WorkSummaryData {
     workTypes: [WorkType!]!
 }
 
+"""A file uploaded to Stan."""
+type StanFile {
+    """When this stanfile was uploaded."""
+    created: Timestamp!
+    """The work with which this file is associated."""
+    work: Work!
+    """The name of the file."""
+    name: String!
+    """The url to download the file."""
+    url: String!
+}
+
 """A specification that a particular reagent slot should be transferred to an address."""
 input ReagentTransfer {
     """The barcode of a reagent plate."""
@@ -1486,6 +1498,8 @@ type Query {
     extractResult(barcode: String!): ExtractResult!
     """Get an operation and the pass/fail result recorded on it, for a given labware barcode and operation type name."""
     passFails(barcode: String!, operationType: String!): [OpPassFail!]!
+    """List files linked to a work number."""
+    listFiles(workNumber: String!): [StanFile!]!
 
     """Get the history containing a given sample id."""
     historyForSampleId(sampleId: Int!): History!

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1310,6 +1310,8 @@ type StanFile {
     created: Timestamp!
     """The work with which this file is associated."""
     work: Work!
+    """The user who uploaded the file."""
+    user: User!
     """The name of the file."""
     name: String!
     """The url to download the file."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestFileStore.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestFileStore.java
@@ -1,0 +1,145 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.config.StanFileConfig;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+
+/**
+ * Tests storing files.
+ * @see StanFile
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestFileStore {
+    @Autowired
+    private StanFileConfig stanFileConfig;
+    @Autowired
+    private GraphQLTester tester;
+    @Autowired
+    private EntityCreator entityCreator;
+
+    @Test
+    @Transactional
+    public void testFileStore() throws Exception {
+        Path directory = Paths.get(stanFileConfig.getRoot(), stanFileConfig.getDir());
+        if (!Files.isDirectory(directory)) {
+            Files.createDirectories(directory);
+        }
+        Path local = Files.createTempFile("stanfile", ".txt");
+        Files.write(local, List.of("Alpha", "Beta"));
+        Work work = entityCreator.createWork(null, null, null, null);
+        String workNumber = work.getWorkNumber();
+        assertThat(listFiles(workNumber)).isEmpty();
+        String username = "user1";
+        User user = entityCreator.createUser(username);
+        tester.setUser(user);
+
+        final String filename = "stanfile.txt";
+        final String fileContent = "Hello\nworld";
+        String downloadUrl = upload(workNumber, filename, fileContent);
+
+        assertEquals(fileContent, download(downloadUrl, filename));
+
+        var filesData = listFiles(workNumber);
+        assertThat(filesData).hasSize(1);
+        assertFileData(filesData.get(0), filename, downloadUrl, username, workNumber);
+
+        String fileContent2 = "Alabama\nAlaska";
+        final String filename2 = "stanfile2.txt";
+        String url2 = upload(workNumber, filename2, fileContent2);
+
+        assertEquals(fileContent2, download(url2, filename2));
+
+        filesData = listFiles(workNumber);
+        assertThat(filesData).hasSize(2);
+        if (filesData.get(0).get("name").equals(filename2)) {
+            filesData = List.of(filesData.get(1), filesData.get(0));
+        }
+
+        assertFileData(filesData.get(0), filename, downloadUrl, username, workNumber);
+        assertFileData(filesData.get(1), filename2, url2, username, workNumber);
+
+        String fileContentB = "Goodbye\nWorld";
+        downloadUrl = upload(workNumber, filename, fileContentB);
+
+        assertEquals(fileContentB, download(downloadUrl, filename));
+        filesData = listFiles(workNumber);
+        assertThat(filesData).hasSize(2);
+        if (filesData.get(0).get("name").equals(filename2)) {
+            filesData = List.of(filesData.get(1), filesData.get(0));
+        }
+
+        assertFileData(filesData.get(0), filename, downloadUrl, username, workNumber);
+        assertFileData(filesData.get(1), filename2, url2, username, workNumber);
+
+        deleteTestFiles(directory);
+    }
+
+    private List<Map<String, ?>> listFiles(String workNumber) throws Exception {
+        String query = tester.readGraphQL("listfiles.graphql").replace("SGP1", workNumber);
+        Object result = tester.post(query);
+        return chainGet(result, "data", "listFiles");
+    }
+
+    private String upload(String workNumber, String filename, String content) throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", filename, MediaType.TEXT_PLAIN_VALUE, content.getBytes()
+        );
+        return tester.getMockMvc().perform(
+                multipart("/files").file(file).queryParam("workNumber", workNumber)
+        ).andExpect(status().isCreated()).andReturn().getResponse().getHeader("location");
+    }
+
+    private String download(String downloadUrl, String filename) throws Exception {
+        var r = tester.getMockMvc().perform(MockMvcRequestBuilders.get(downloadUrl)).andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
+        assertThat(r.getHeader("Content-Disposition")).contains(filename);
+        return r.getContentAsString();
+    }
+
+    private void assertFileData(Map<String, ?> data, String filename, String url, String username, String workNumber) {
+        assertNotNull(data.get("created"));
+        assertEquals(filename, data.get("name"));
+        assertEquals(url, data.get("url"));
+        assertEquals(username, chainGet(data, "user", "username"));
+        assertEquals(workNumber, chainGet(data, "work", "workNumber"));
+    }
+
+    private void deleteTestFiles(Path directory) throws IOException {
+        try (Stream<Path> files = Files.list(directory)) {
+            Iterable<Path> pathIter = files::iterator;
+            for (Path path : pathIter) {
+                Files.delete(path);
+            }
+        }
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestStanFileRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestStanFileRepo.java
@@ -1,0 +1,86 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test {@link StanFileRepo}
+ * @author dr6
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@Import(EntityCreator.class)
+public class TestStanFileRepo {
+    @Autowired
+    StanFileRepo fileRepo;
+    @Autowired
+    EntityCreator entityCreator;
+
+    private WorkType workType;
+    private Project project;
+    private CostCode costCode;
+
+    private Work makeWork() {
+        if (workType==null) {
+            workType = entityCreator.createWorkType("Drywalling");
+        }
+        if (project==null) {
+            project = entityCreator.createProject("Stargate");
+        }
+        if (costCode==null) {
+            costCode = entityCreator.createCostCode("S400");
+        }
+        return entityCreator.createWork(workType, project, costCode, null);
+    }
+
+    @Test
+    @Transactional
+    public void testFindAllActiveByWorkId() {
+        Work work1 = makeWork();
+        Work work2 = makeWork();
+        assertThat(fileRepo.findAllActiveByWorkId(work1.getId())).isEmpty();
+        StanFile sf1 = fileRepo.save(new StanFile(work1, "Alpha", "Beta"));
+        StanFile sf2 = fileRepo.save(new StanFile(work1, "Gamma", "Delta"));
+        StanFile sf3 = fileRepo.save(new StanFile(work2, "Epsilon", "Zeta"));
+        fileRepo.save(new StanFile(null, null, work2, "Epsilon", "Eta", LocalDateTime.now()));
+        assertThat(fileRepo.findAllActiveByWorkId(work1.getId())).containsExactlyInAnyOrder(sf1, sf2);
+        assertThat(fileRepo.findAllActiveByWorkId(work2.getId())).containsExactly(sf3);
+    }
+
+    @Test
+    @Transactional
+    public void testFindAllActiveByWorkIdAndName() {
+        Work work1 = makeWork();
+        Work work2 = makeWork();
+        StanFile sf1 = fileRepo.save(new StanFile(work1, "Alpha", "Beta"));
+        fileRepo.save(new StanFile(work1, "Gamma", "Delta"));
+        fileRepo.save(new StanFile(work2, "Alpha", "Epsilon"));
+        fileRepo.save(new StanFile(null, null, work1, "Alpha", "Eta", LocalDateTime.now()));
+        assertThat(fileRepo.findAllActiveByWorkIdAndName(work1.getId(), "Alpha")).containsExactly(sf1);
+        assertThat(fileRepo.findAllActiveByWorkIdAndName(work2.getId(), "Gamma")).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    public void testGetById() {
+        Work work = makeWork();
+        StanFile sf1 = fileRepo.save(new StanFile(work, "Alpha", "Beta"));
+        StanFile sf2 = fileRepo.save(new StanFile(work, "Gamma", "Delta"));
+        assertEquals(sf1, fileRepo.getById(sf1.getId()));
+        assertEquals(sf2, fileRepo.getById(sf2.getId()));
+        assertThrows(EntityNotFoundException.class, () -> fileRepo.getById(sf2.getId()+1));
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestStanFileRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestStanFileRepo.java
@@ -51,11 +51,12 @@ public class TestStanFileRepo {
     public void testFindAllActiveByWorkId() {
         Work work1 = makeWork();
         Work work2 = makeWork();
+        User user = entityCreator.createUser("user1");
         assertThat(fileRepo.findAllActiveByWorkId(work1.getId())).isEmpty();
-        StanFile sf1 = fileRepo.save(new StanFile(work1, "Alpha", "Beta"));
-        StanFile sf2 = fileRepo.save(new StanFile(work1, "Gamma", "Delta"));
-        StanFile sf3 = fileRepo.save(new StanFile(work2, "Epsilon", "Zeta"));
-        fileRepo.save(new StanFile(null, null, work2, "Epsilon", "Eta", LocalDateTime.now()));
+        StanFile sf1 = fileRepo.save(new StanFile(work1, user, "Alpha", "Beta"));
+        StanFile sf2 = fileRepo.save(new StanFile(work1, user, "Gamma", "Delta"));
+        StanFile sf3 = fileRepo.save(new StanFile(work2, user, "Epsilon", "Zeta"));
+        fileRepo.save(new StanFile(null, null, work2, user, "Epsilon", "Eta", LocalDateTime.now()));
         assertThat(fileRepo.findAllActiveByWorkId(work1.getId())).containsExactlyInAnyOrder(sf1, sf2);
         assertThat(fileRepo.findAllActiveByWorkId(work2.getId())).containsExactly(sf3);
     }
@@ -65,10 +66,11 @@ public class TestStanFileRepo {
     public void testFindAllActiveByWorkIdAndName() {
         Work work1 = makeWork();
         Work work2 = makeWork();
-        StanFile sf1 = fileRepo.save(new StanFile(work1, "Alpha", "Beta"));
-        fileRepo.save(new StanFile(work1, "Gamma", "Delta"));
-        fileRepo.save(new StanFile(work2, "Alpha", "Epsilon"));
-        fileRepo.save(new StanFile(null, null, work1, "Alpha", "Eta", LocalDateTime.now()));
+        User user = entityCreator.createUser("user1");
+        StanFile sf1 = fileRepo.save(new StanFile(work1, user, "Alpha", "Beta"));
+        fileRepo.save(new StanFile(work1, user, "Gamma", "Delta"));
+        fileRepo.save(new StanFile(work2, user, "Alpha", "Epsilon"));
+        fileRepo.save(new StanFile(null, null, work1, user, "Alpha", "Eta", LocalDateTime.now()));
         assertThat(fileRepo.findAllActiveByWorkIdAndName(work1.getId(), "Alpha")).containsExactly(sf1);
         assertThat(fileRepo.findAllActiveByWorkIdAndName(work2.getId(), "Gamma")).isEmpty();
     }
@@ -77,8 +79,9 @@ public class TestStanFileRepo {
     @Transactional
     public void testGetById() {
         Work work = makeWork();
-        StanFile sf1 = fileRepo.save(new StanFile(work, "Alpha", "Beta"));
-        StanFile sf2 = fileRepo.save(new StanFile(work, "Gamma", "Delta"));
+        User user = entityCreator.createUser("user1");
+        StanFile sf1 = fileRepo.save(new StanFile(work, user, "Alpha", "Beta"));
+        StanFile sf2 = fileRepo.save(new StanFile(work, user, "Gamma", "Delta"));
         assertEquals(sf1, fileRepo.getById(sf1.getId()));
         assertEquals(sf2, fileRepo.getById(sf2.getId()));
         assertThrows(EntityNotFoundException.class, () -> fileRepo.getById(sf2.getId()+1));

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestFileStoreService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestFileStoreService.java
@@ -1,0 +1,146 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.web.multipart.MultipartFile;
+import uk.ac.sanger.sccp.stan.config.StanFileConfig;
+import uk.ac.sanger.sccp.stan.model.StanFile;
+import uk.ac.sanger.sccp.stan.model.Work;
+import uk.ac.sanger.sccp.stan.repo.StanFileRepo;
+import uk.ac.sanger.sccp.stan.repo.WorkRepo;
+
+import java.io.*;
+import java.nio.file.*;
+import java.time.*;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test {@link FileStoreServiceImp}
+ * @author dr6
+ */
+public class TestFileStoreService {
+    private StanFileConfig mockConfig;
+    private Clock clock;
+    private StanFileRepo mockFileRepo;
+    private WorkRepo mockWorkRepo;
+
+    private FileStoreServiceImp service;
+
+    @BeforeEach
+    void setup() {
+        mockConfig = mock(StanFileConfig.class);
+        when(mockConfig.getRoot()).thenReturn("/ROOT");
+        when(mockConfig.getDir()).thenReturn("DIR");
+        clock = Clock.fixed(LocalDateTime.of(2022,11,4,14,0).toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+        mockFileRepo = mock(StanFileRepo.class);
+        mockWorkRepo = mock(WorkRepo.class);
+
+        service = spy(new FileStoreServiceImp(mockConfig, clock, mockFileRepo, mockWorkRepo));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"folder/alpha,alpha,alpha", "/Robot/SW/R2D2 *&^%,R2D2 *&^%,R2D2", "Alpha/^%^&*,^%^&*, unnamed", ",unnamed,unnamed"})
+    public void testSave(String name, String expectedName, String expectedPathFragment) throws IOException {
+        Work work = new Work(500, "SGP500", null, null, null, null, Work.Status.active);
+        MultipartFile data = mock(MultipartFile.class);
+        LocalDateTime time = LocalDateTime.now(clock);
+        when(data.getOriginalFilename()).thenReturn(name);
+
+        when(mockFileRepo.save(any())).then(invocation -> {
+            StanFile sf = invocation.getArgument(0);
+            sf.setId(300);
+            sf.setCreated(time);
+            return sf;
+        });
+        when(mockWorkRepo.getByWorkNumber(work.getWorkNumber())).thenReturn(work);
+        StanFile sf = service.save(data, work.getWorkNumber());
+        String expectedPath = "DIR/"+time+"_"+expectedPathFragment;
+        assertEquals(expectedPath, sf.getPath());
+        assertEquals(expectedName, sf.getName());
+        assertEquals(300, sf.getId());
+
+        verify(data).transferTo(Paths.get("/ROOT/"+expectedPath));
+    }
+
+    @Test
+    public void testLoadResource() throws IOException {
+        String root = System.getProperty("user.home");
+        doReturn(root).when(mockConfig).getRoot();
+        mkdir(Paths.get(root, "stan_files"));
+        mkdir(Paths.get(root, "stan_files", "test"));
+        Path filePath = Paths.get(root, "stan_files", "test", "testfile.txt");
+        List<String> fileLines = List.of("Alpha", "Beta");
+        Files.write(filePath, fileLines);
+        StanFile sf = new StanFile(200, null, null, "filename",
+                "stan_files/test/testfile.txt", null);
+        var resource = service.loadResource(sf);
+        try (var in = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+            assertThat(in.lines()).containsExactlyElementsOf(fileLines);
+        }
+    }
+
+    @Test
+    public void testLoadResource_inactive() {
+        StanFile sf = new StanFile(200, null, null, "filename",
+                "stan_files/test/testfile.txt", LocalDateTime.now());
+        assertThrows(IllegalStateException.class, () -> service.loadResource(sf));
+    }
+
+    private static Path mkdir(Path path) throws IOException {
+        if (!Files.isDirectory(path)) {
+            Files.createDirectory(path);
+        }
+        return path;
+    }
+
+    @Test
+    public void testLookUp() {
+        StanFile sf = new StanFile(200, null, null, "filename", "path", null);
+        when(mockFileRepo.getById(sf.getId())).thenReturn(sf);
+        assertSame(sf, service.lookUp(sf.getId()));
+    }
+
+    @Test
+    public void testDeprecateOldFiles_none() {
+        when(mockFileRepo.findAllActiveByWorkIdAndName(any(), any())).thenReturn(List.of());
+        service.deprecateOldFiles("name", 24, LocalDateTime.now());
+        verify(mockFileRepo, never()).save(any());
+        verify(mockFileRepo, never()).saveAll(any());
+    }
+
+
+    @Test
+    public void testDeprecateOldFiles() {
+        List<StanFile> sfs = List.of(
+                new StanFile(10, null, null, null, null, null),
+                new StanFile(11, null, null, null, null, null)
+        );
+        sfs.forEach(sf -> assertNull(sf.getDeprecated()));
+        sfs.forEach(sf -> assertTrue(sf.isActive()));
+
+        when(mockFileRepo.findAllActiveByWorkIdAndName(24, "name")).thenReturn(sfs);
+        final LocalDateTime time = LocalDateTime.now();
+        service.deprecateOldFiles("name", 24, time);
+        verify(mockFileRepo).saveAll(sfs);
+        sfs.forEach(sf -> assertEquals(time, sf.getDeprecated()));
+        sfs.forEach(sf -> assertFalse(sf.isActive()));
+    }
+
+    @Test
+    public void testList() {
+        List<StanFile> sfs = List.of(
+                new StanFile(10, null, null, null, null, null),
+                new StanFile(11, null, null, null, null, null)
+        );
+        Work work = new Work(500, "SGP500", null, null, null, null, Work.Status.active);
+        when(mockWorkRepo.getByWorkNumber(work.getWorkNumber())).thenReturn(work);
+        when(mockFileRepo.findAllActiveByWorkId(work.getId())).thenReturn(sfs);
+        assertEquals(sfs, service.list(work.getWorkNumber()));
+    }
+}

--- a/src/test/resources/graphql/listfiles.graphql
+++ b/src/test/resources/graphql/listfiles.graphql
@@ -1,0 +1,9 @@
+query {
+    listFiles(workNumber: "SGP1") {
+        created
+        name
+        url
+        user { username }
+        work { workNumber }
+    }
+}


### PR DESCRIPTION
Closes #141 

Support upload and download of files linked to a work number.
Files are stored in a mounted network drive.
When a new file is uploaded with the same name and work number, the old one
is deprecated in the db (but the file is not deleted from storage).
UAT can load files in the production area, but will only create files in its dedicated
uat area.
