### PR TITLE
x1000 support multiple release recipients

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/ReleaseRecipientRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/ReleaseRecipientRepo.java
@@ -4,8 +4,7 @@ import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.ReleaseRecipient;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
 
@@ -14,5 +13,12 @@ public interface ReleaseRecipientRepo extends CrudRepository<ReleaseRecipient, I
     Optional<ReleaseRecipient> findByUsername(String username);
     default ReleaseRecipient getByUsername(String username) throws EntityNotFoundException {
         return findByUsername(username).orElseThrow(() -> new EntityNotFoundException("No release recipient found with username "+repr(username)));
+    }
+
+    List<ReleaseRecipient> findAllByUsernameIn(Collection<String> names);
+
+    default List<ReleaseRecipient> getAllByUsernameIn(Collection<String> names) throws EntityNotFoundException {
+        return RepoUtils.getAllByField(this::findAllByUsernameIn, names, ReleaseRecipient::getUsername,
+                "Unknown recipient{s}: ", String::toLowerCase);
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/ReleaseRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/ReleaseRequest.java
@@ -1,12 +1,9 @@
 package uk.ac.sanger.sccp.stan.request;
 
-import com.google.common.base.MoreObjects;
-import uk.ac.sanger.sccp.utils.BasicUtils;
+import java.util.List;
+import java.util.Objects;
 
-import java.util.*;
-
-import static uk.ac.sanger.sccp.utils.BasicUtils.coalesce;
-import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+import static uk.ac.sanger.sccp.utils.BasicUtils.*;
 
 /**
  * @author dr6
@@ -77,18 +74,23 @@ public class ReleaseRequest {
         }
     }
 
-    private List<ReleaseLabware> releaseLabware;
+    private List<ReleaseLabware> releaseLabware = List.of();
     private String destination;
     private String recipient;
+    private List<String> otherRecipients = List.of();
 
-    public ReleaseRequest() {
-        setReleaseLabware(null);
-    }
+    public ReleaseRequest() {}
 
-    public ReleaseRequest(List<ReleaseLabware> releaseLabware, String destination, String recipient) {
+    public ReleaseRequest(List<ReleaseLabware> releaseLabware, String destination, String recipient,
+                          List<String> otherRecipients) {
         setReleaseLabware(releaseLabware);
         setDestination(destination);
         setRecipient(recipient);
+        setOtherRecipients(otherRecipients);
+    }
+
+    public ReleaseRequest(List<ReleaseLabware> releaseLabware, String destination, String recipient) {
+        this(releaseLabware, destination, recipient, null);
     }
 
     public List<ReleaseLabware> getReleaseLabware() {
@@ -96,7 +98,7 @@ public class ReleaseRequest {
     }
 
     public void setReleaseLabware(List<ReleaseLabware> releaseLabware) {
-        this.releaseLabware = coalesce(releaseLabware, List.of());
+        this.releaseLabware = nullToEmpty(releaseLabware);
     }
 
     public String getDestination() {
@@ -115,6 +117,14 @@ public class ReleaseRequest {
         this.recipient = recipient;
     }
 
+    public List<String> getOtherRecipients() {
+        return this.otherRecipients;
+    }
+
+    public void setOtherRecipients(List<String> otherRecipients) {
+        this.otherRecipients = nullToEmpty(otherRecipients);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -122,7 +132,8 @@ public class ReleaseRequest {
         ReleaseRequest that = (ReleaseRequest) o;
         return (Objects.equals(this.releaseLabware, that.releaseLabware)
                 && Objects.equals(this.destination, that.destination)
-                && Objects.equals(this.recipient, that.recipient));
+                && Objects.equals(this.recipient, that.recipient)
+                && this.otherRecipients.equals(that.otherRecipients));
     }
 
     @Override
@@ -132,10 +143,11 @@ public class ReleaseRequest {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
+        return describe(this)
                 .add("releaseLabware", releaseLabware)
                 .add("destination", repr(destination))
                 .add("recipient", repr(recipient))
+                .addIfNotEmpty("otherRecipients", otherRecipients)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -426,6 +426,15 @@ public class BasicUtils {
     }
 
     /**
+     * If the collection is empty, return null. Otherwise, return the collection.
+     * @param items the collection that may be empty
+     * @return the nonempty collection, or null
+     */
+    public static <C extends Collection<?>> C emptyToNull(C items) {
+        return (items==null || items.isEmpty() ? null : items);
+    }
+
+    /**
      * If the given list is non-null, it is returned. Otherwise, returns the immutable empty list.
      * @param list list or null
      * @return a non-null list

--- a/src/main/resources/db/changelog/changelog-2.21.xml
+++ b/src/main/resources/db/changelog/changelog-2.21.xml
@@ -1,0 +1,22 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="2.21.0" author="dr6">
+        <createTable tableName="release_other_recipient">
+            <column name="release_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_release_other_recipient_release" referencedTableName="labware_release" referencedColumnNames="id"/>
+            </column>
+            <column name="recipient_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_release_other_recipient_recipient" referencedTableName="release_recipient" referencedColumnNames="id"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="release_other_recipient" columnNames="release_id,recipient_id"/>
+        <rollback>
+            <dropAllForeignKeyConstraints baseTableName="release_other_recipient"/>
+            <dropTable tableName="release_other_recipient"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -21,4 +21,5 @@
     <include relativeToChangelogFile="true" file="changelog-2.17.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.19.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.20.xml"/>
+    <include relativeToChangelogFile="true" file="changelog-2.21.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -700,6 +700,8 @@ input ReleaseRequest {
     destination: String!
     """The name of the release recipient."""
     recipient: String!
+    """Additional recipients."""
+    otherRecipients: [String!]
 }
 
 """A request to record an extract operation."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
@@ -136,7 +136,8 @@ public class TestReleaseMutation {
         assertThat(message.getTo()).containsExactly(recipient.getUsername()+"@sanger.ac.uk");
         assertThat(message.getCc()).containsExactly("beagledev@sanger.ac.uk");
         String releaseUrl = "stantestroot/release?id=" + releaseIds.stream().map(Object::toString).collect(joining(","));
-        assertEquals("The details of the release are available at "+releaseUrl, message.getText());
+        assertEquals("Release to "+recipient.getUsername()+"@sanger.ac.uk.\n" +
+                "The details of the release are available at "+releaseUrl, message.getText());
 
         String tsvString = getReleaseFile(releaseIds);
         var tsvMaps = tsvToMap(tsvString);

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestReleaseRecipientRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestReleaseRecipientRepo.java
@@ -1,0 +1,81 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.model.ReleaseRecipient;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.asList;
+
+/**
+ * Tests {@link ReleaseRecipientRepo}
+ * @author dr6
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+public class TestReleaseRecipientRepo {
+    @Autowired
+    ReleaseRecipientRepo recRepo;
+
+    @Test
+    @Transactional
+    public void testFindAllByEnabled() {
+        List<ReleaseRecipient> newRecs = IntStream.range(0,6)
+                .mapToObj(i -> new ReleaseRecipient(null, "rec"+i))
+                .collect(toList());
+        for (int i = 0; i < 6; ++i) {
+            newRecs.get(i).setEnabled(i < 3);
+        }
+        List<ReleaseRecipient> savedRecs = asList(recRepo.saveAll(newRecs));
+        final List<ReleaseRecipient> savedEnabled = savedRecs.subList(0, 3);
+        final List<ReleaseRecipient> savedDisabled = savedRecs.subList(3, 6);
+        final List<ReleaseRecipient> enabledRecs = recRepo.findAllByEnabled(true);
+        assertThat(enabledRecs).containsAll(savedEnabled);
+        assertThat(enabledRecs).doesNotContainAnyElementsOf(savedDisabled);
+        final List<ReleaseRecipient> disabledRecs = recRepo.findAllByEnabled(false);
+        assertThat(disabledRecs).containsAll(savedDisabled);
+        assertThat(disabledRecs).doesNotContainAnyElementsOf(savedEnabled);
+    }
+
+    @Test
+    @Transactional
+    public void testGetByUsername() {
+        ReleaseRecipient rec = recRepo.getByUsername("ET2");
+        assertEquals("et2", rec.getUsername());
+        assertEquals(1, rec.getId());
+        assertTrue(rec.isEnabled());
+    }
+
+    @Test
+    @Transactional
+    public void testGetByUsernameNotFound() {
+        assertThat(assertThrows(EntityNotFoundException.class, () -> recRepo.getByUsername("BANANAS!")))
+                .hasMessage("No release recipient found with username \"BANANAS!\"");
+    }
+
+    @Test
+    @Transactional
+    public void testGetAllByUsernameIn() {
+        List<ReleaseRecipient> recs = recRepo.getAllByUsernameIn(List.of("ET2", "Cm18"));
+        assertEquals(1, recs.get(0).getId());
+        assertEquals(2, recs.get(1).getId());
+        assertEquals("et2", recs.get(0).getUsername());
+        assertEquals("cm18", recs.get(1).getUsername());
+    }
+
+    @Test
+    @Transactional
+    public void testGetAllByUsernameInNotFound() {
+        assertThat(assertThrows(EntityNotFoundException.class, () -> recRepo.getAllByUsernameIn(List.of("et2", "Banana!", "Banana!", "Custard"))))
+                .hasMessage("Unknown recipients: [Banana!, Custard]");
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/releasefile/TestReleaseFileService.java
@@ -189,7 +189,7 @@ public class TestReleaseFileService {
         Iterator<Address> addressIter = addresses.iterator();
         Labware lw = EntityFactory.getTube();
         List<Release> releases = locationBarcodes.stream()
-                .map(bc -> new Release(100, lw, user, destination, recipient, 120, null, bc, addressIter.next()))
+                .map(bc -> new Release(100, lw, user, destination, recipient, 120, null, bc, addressIter.next(), null))
                 .collect(toList());
         assertEquals(expected, service.shouldIncludeStorageAddress(releases));
     }


### PR DESCRIPTION
In addition to the main recipient there may now be "other recipients" who will be cc'd in the release email. The relationship between releases and other recipients is stored in the database but not exposed in Stan.

For #195 