### PR TITLE
x1037 Look up perm data for ancestral slots

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/SlotIdSampleId.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/SlotIdSampleId.java
@@ -13,6 +13,10 @@ public class SlotIdSampleId implements Serializable {
 
     public SlotIdSampleId() {}
 
+    public SlotIdSampleId(Slot slot, Sample sample) {
+        this(slot.getId(), sample.getId());
+    }
+
     public SlotIdSampleId(Integer slotId, Integer sampleId) {
         this.slotId = slotId;
         this.sampleId = sampleId;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/VisiumPermDataService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/VisiumPermDataService.java
@@ -1,5 +1,6 @@
 package uk.ac.sanger.sccp.stan.service;
 
+import org.apache.logging.log4j.util.TriConsumer;
 import org.springframework.stereotype.Service;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.LabwareRepo;
@@ -7,11 +8,15 @@ import uk.ac.sanger.sccp.stan.repo.MeasurementRepo;
 import uk.ac.sanger.sccp.stan.request.ControlType;
 import uk.ac.sanger.sccp.stan.request.VisiumPermData;
 import uk.ac.sanger.sccp.stan.request.VisiumPermData.AddressPermData;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.Ancestry;
 
 import java.util.*;
 
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+import static uk.ac.sanger.sccp.utils.BasicUtils.reverseIter;
 
 /**
  * Service to look up perm times for a labware barcode
@@ -25,10 +30,12 @@ public class VisiumPermDataService {
 
     private final LabwareRepo lwRepo;
     private final MeasurementRepo measurementRepo;
+    private final Ancestoriser ancestoriser;
 
-    public VisiumPermDataService(LabwareRepo lwRepo, MeasurementRepo measurementRepo) {
+    public VisiumPermDataService(LabwareRepo lwRepo, MeasurementRepo measurementRepo, Ancestoriser ancestoriser) {
         this.lwRepo = lwRepo;
         this.measurementRepo = measurementRepo;
+        this.ancestoriser = ancestoriser;
     }
 
     /**
@@ -38,40 +45,87 @@ public class VisiumPermDataService {
      */
     public VisiumPermData load(String barcode) {
         Labware lw = lwRepo.getByBarcode(barcode);
-        List<Integer> slotIds = lw.getSlots().stream().map(Slot::getId).collect(toList());
+        var ancestry = ancestoriser.findAncestry(Ancestoriser.SlotSample.stream(lw).collect(toList()));
+
+        var ssToAddress = makeSlotSampleIdAddressMap(lw, ancestry);
+        Set<Integer> slotIds = ancestry.keySet().stream()
+                .map(ss -> ss.getSlot().getId())
+                .collect(toSet());
         List<Measurement> measurements = measurementRepo.findAllBySlotIdIn(slotIds);
-        List<AddressPermData> pds = compilePermData(lw, measurements);
+        List<AddressPermData> pds = compilePermData(measurements, ssToAddress);
         return new VisiumPermData(lw, pds);
     }
 
     /**
-     * Converts measurements to perm data
-     * @param lw the labware the measurements are recorded on
-     * @param measurements the measurements to convert
-     * @return perm data of the given measurements
+     * Makes a map of ancestral slot and sample id to ultimate address in the given labware
+     * @param lw the labware
+     * @param ancestry the ancestry of this labware
+     * @return a map of ancestral slot and sample id to address in the given labware
      */
-    public List<AddressPermData> compilePermData(Labware lw, Collection<Measurement> measurements) {
-        Map<Integer, Address> slotIdToAddress = lw.getSlots().stream()
-                .collect(toMap(Slot::getId, Slot::getAddress));
-        Measurement selected = null;
-        final LinkedHashSet<AddressPermData> pds = new LinkedHashSet<>(measurements.size());
-        Iterable<Measurement> sortedMeas = () -> measurements.stream()
-                .sorted(Comparator.comparing(Measurement::getId))
-                .iterator();
-        for (Measurement meas : sortedMeas) {
-            if (meas.getName().equalsIgnoreCase(SELECTED_TIME)) {
-                selected = meas;
-            } else if (meas.getName().equalsIgnoreCase(PERM_TIME)) {
-                pds.add(new AddressPermData(slotIdToAddress.get(meas.getSlotId()), Integer.valueOf(meas.getValue())));
-            } else if (meas.getName().equalsIgnoreCase(CONTROL)) {
-                pds.add(new AddressPermData(slotIdToAddress.get(meas.getSlotId()), ControlType.valueOf(meas.getValue().toLowerCase())));
+    public Map<SlotIdSampleId, Set<Address>> makeSlotSampleIdAddressMap(Labware lw, Ancestry ancestry) {
+        final Map<SlotIdSampleId, Set<Address>> ssToAddress = new HashMap<>();
+        final TriConsumer<Slot, Sample, Address> addToMap = (slot, sample, address) -> {
+            ssToAddress.computeIfAbsent(new SlotIdSampleId(slot, sample), k -> new HashSet<>()).add(address);
+        };
+
+        for (Slot slot : lw.getSlots()) {
+            for (Sample sam : slot.getSamples()) {
+                addToMap.accept(slot, sam, slot.getAddress());
             }
         }
-        if (selected!=null) {
-            Address address = slotIdToAddress.get(selected.getSlotId());
-            for (AddressPermData pd : pds) {
-                if (pd.getAddress().equals(address) && pd.getSeconds()!=null && pd.getSeconds().toString().equals(selected.getValue())) {
-                    pd.setSelected(true);
+
+        Ancestoriser.SlotSample.stream(lw).forEach(targetSs -> {
+            Address targetAddress = targetSs.getSlot().getAddress();
+            for (Ancestoriser.SlotSample ancesterSs : ancestry.ancestors(targetSs)) {
+                addToMap.accept(ancesterSs.getSlot(), ancesterSs.getSample(), targetAddress);
+            }
+        });
+        return ssToAddress;
+    }
+
+    /**
+     * Converts measurements to perm data
+     * @param measurements the measurements to convert
+     * @param ssToAddress a map of slot and sample ids to address to indicate in the data
+     * @return perm data of the given measurements
+     */
+    public List<AddressPermData> compilePermData(Collection<Measurement> measurements,
+                                                 Map<SlotIdSampleId, Set<Address>> ssToAddress) {
+        final LinkedHashSet<AddressPermData> pds = new LinkedHashSet<>(measurements.size());
+        List<Measurement> sortedMeasurements = measurements.stream()
+                .sorted(Comparator.comparing(Measurement::getId))
+                .collect(toList());
+
+        Measurement selectedMeasurement = null;
+        for (Measurement meas : reverseIter(sortedMeasurements)) {
+            if (meas.getName().equalsIgnoreCase(SELECTED_TIME)) {
+                selectedMeasurement = meas;
+                break;
+            }
+        }
+
+        for (Measurement meas : sortedMeasurements) {
+            if (meas.getName().equalsIgnoreCase(PERM_TIME)) {
+                SlotIdSampleId key = new SlotIdSampleId(meas.getSlotId(), meas.getSampleId());
+                Set<Address> targetAddresses = ssToAddress.get(key);
+                if (!nullOrEmpty(targetAddresses)) {
+                    boolean selected = (selectedMeasurement!=null
+                            && selectedMeasurement.getSlotId().equals(meas.getSlotId())
+                            && selectedMeasurement.getSampleId().equals(meas.getSampleId())
+                            && selectedMeasurement.getValue().equals(meas.getValue()));
+                    Integer permValue = Integer.valueOf(meas.getValue());
+                    for (Address address : targetAddresses) {
+                        pds.add(new AddressPermData(address, permValue, null, selected));
+                    }
+                }
+            } else if (meas.getName().equalsIgnoreCase(CONTROL)) {
+                SlotIdSampleId key = new SlotIdSampleId(meas.getSlotId(), meas.getSampleId());
+                Set<Address> targetAddresses = ssToAddress.get(key);
+                if (!nullOrEmpty(targetAddresses)) {
+                    ControlType controlType = ControlType.valueOf(meas.getValue().toLowerCase());
+                    for (Address address : targetAddresses) {
+                        pds.add(new AddressPermData(address, controlType));
+                    }
                 }
             }
         }

--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -381,6 +381,16 @@ public class BasicUtils {
     }
 
     /**
+     * Makes an {@link Iterable} to iterate through a list from end to start.
+     * @param list the list to reverse-iterate
+     * @return an {@code Iterable<T>}
+     */
+    public static <T> Iterable<T> reverseIter(List<T> list) {
+        return () -> new ReverseIterator<>(list.listIterator(list.size()));
+    }
+
+
+    /**
      * Does the given string start with the given substring, ignoring its case?
      * @param string the containing string
      * @param sub the substring

--- a/src/main/java/uk/ac/sanger/sccp/utils/ReverseIterator.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/ReverseIterator.java
@@ -1,0 +1,29 @@
+package uk.ac.sanger.sccp.utils;
+
+import java.util.Iterator;
+import java.util.ListIterator;
+
+
+/** An iterator to traverse a list iterator backwards */
+class ReverseIterator<T> implements Iterator<T> {
+    private final ListIterator<T> iter;
+
+    public ReverseIterator(ListIterator<T> iter) {
+        this.iter = iter;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iter.hasPrevious();
+    }
+
+    @Override
+    public T next() {
+        return iter.previous();
+    }
+
+    @Override
+    public void remove() {
+        iter.remove();
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/utils/TestBasicUtils.java
+++ b/src/test/java/uk/ac/sanger/sccp/utils/TestBasicUtils.java
@@ -245,4 +245,14 @@ public class TestBasicUtils {
         assertFalse(startsWithIgnoreCase("Alph", "Alpha"));
         assertFalse(startsWithIgnoreCase("Alpha", "Balpha"));
     }
+
+    @Test
+    public void testReverseIter() {
+        List<Integer> list = List.of(1,2,3,4);
+        Iterator<Integer> expected = List.of(4,3,2,1).iterator();
+        for (Integer value : reverseIter(list)) {
+            assertEquals(value, expected.next());
+        }
+        assertFalse(expected.hasNext());
+    }
 }


### PR DESCRIPTION
For #213 

When looking up perm data, look up measurements on ancesters of
the specified labware's slots.