### PR TITLE
Dpl- 1070 Multiple search type support in history query 

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -349,6 +349,16 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         };
     }
 
+    public DataFetcher<History> history() {
+        return dfe -> {
+            String workNumber = dfe.getArgument("workNumber");
+            String barcode = dfe.getArgument("barcode");
+            String externalName = dfe.getArgument("externalName");
+            String donorName = dfe.getArgument("donorName");
+            return historyService.getHistory(workNumber, barcode, externalName,donorName);
+        };
+    }
+
     public DataFetcher<History> historyForDonorName() {
         return dfe -> {
             String donorName = dfe.getArgument("donorName");

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -117,6 +117,7 @@ public class GraphQLProvider {
                         .dataFetcher("historyForDonorName", graphQLDataFetchers.historyForDonorName())
                         .dataFetcher("historyForLabwareBarcode", graphQLDataFetchers.historyForLabwareBarcode())
                         .dataFetcher("historyForWorkNumber", graphQLDataFetchers.historyForWorkNumber())
+                        .dataFetcher("history", graphQLDataFetchers.history())
                         .dataFetcher("workProgress", graphQLDataFetchers.workProgress())
 
                         .dataFetcher("location", graphQLStore.getLocation())

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/FindService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/FindService.java
@@ -253,7 +253,7 @@ public class FindService {
         final String externalName = request.getTissueExternalName();
         if (externalName!=null) {
             if (externalName.indexOf('*') >= 0) {
-                final Pattern pattern = makeWildcardPattern(externalName);
+                final Pattern pattern = BasicUtils.makeWildcardPattern(externalName);
                 predicate = andPredicate(predicate,
                         ls -> pattern.matcher(ls.getSample().getTissue().getExternalName()).matches());
             } else {
@@ -276,19 +276,6 @@ public class FindService {
         }
         predicate = andPredicate(predicate, datePredicate(request.getCreatedMin(), request.getCreatedMax()));
         return predicate;
-    }
-
-    /**
-     * Makes a case-insensitive regular expression pattern to match the given string reading <tt>*</tt> as a wildcard.
-     * @param wildcardString a string containing `*` as wildcards
-     * @return the regular expression pattern object
-     */
-    public static Pattern makeWildcardPattern(String wildcardString) {
-        String[] parts = wildcardString.split("\\*+", -1);
-        String regex = Arrays.stream(parts)
-                .map(part -> part.isEmpty() ? part : Pattern.quote(part))
-                .collect(joining(".*"));
-        return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     }
 
     /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
@@ -49,7 +49,7 @@ public interface HistoryService {
      * @param barcode the barcode of the labware (if any) to look up, or null
      * @param externalName the external name of the tissue (if any) to look up, or null
      * @param donorName the name of the donor (if any) to look up, or null
-     * @return
+     * @return the history for the specified identifier(s)
      */
     History getHistory(String workNumber,String barcode, String externalName, String donorName);
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
@@ -43,4 +43,14 @@ public interface HistoryService {
      */
     History getHistoryForWorkNumber(String workNumber);
 
+    /**
+     * Gets the applicable history
+     * @param workNumber the specific work number (if any) to look up, or null
+     * @param barcode the barcode of the labware (if any) to look up, or null
+     * @param externalName the external name of the tissue (if any) to look up, or null
+     * @param donorName the name of the donor (if any) to look up, or null
+     * @return
+     */
+    History getHistory(String workNumber,String barcode, String externalName, String donorName);
+
 }

--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -8,6 +8,8 @@ import java.util.function.*;
 import java.util.regex.Pattern;
 import java.util.stream.*;
 
+import static java.util.stream.Collectors.joining;
+
 /**
  * Much copied from the corresponding class in CGAP lims
  * @author dr6
@@ -419,6 +421,19 @@ public class BasicUtils {
      */
     public static String wildcardToLikeSql(String string) {
         return escapeLikeSql(string).replaceAll("\\*+", "%");
+    }
+
+    /**
+     * Makes a case-insensitive regular expression pattern to match the given string reading <tt>*</tt> as a wildcard.
+     * @param wildcardString a string containing `*` as wildcards
+     * @return the regular expression pattern object
+     */
+    public static Pattern makeWildcardPattern(String wildcardString) {
+        String[] parts = wildcardString.split("\\*+", -1);
+        String regex = Arrays.stream(parts)
+                .map(part -> part.isEmpty() ? part : Pattern.quote(part))
+                .collect(joining(".*"));
+        return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     }
 
     /**

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1806,7 +1806,9 @@ type Query {
     historyForWorkNumber(workNumber: String!): History!
     """Get the history containing a given labware barcode."""
     historyForLabwareBarcode(barcode: String!): History!
-    """Get the work progress (some particular timestamps) associated with a specified work number, and/or
+    """Get the history associated with a specified work number, and/or barcode, external name, donor name."""
+    history(workNumber: String,barcode: String, externalName: String, donorName: String): History!
+   """Get the work progress (some particular timestamps) associated with a specified work number, and/or
     work types, programs, statuses."""
     workProgress(workNumber: String, workTypes: [String!], programs: [String!], statuses: [WorkStatus!], requesters: [String!]): [WorkProgress!]!
     """Get a reagent plate, if it exists. May return null."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestFindService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestFindService.java
@@ -531,18 +531,6 @@ public class TestFindService {
         );
     }
 
-    @ParameterizedTest
-    @CsvSource({
-            "TIS*, \\QTIS\\E.*",
-            "*TI%?\\*, .*\\QTI%?\\\\E.*",
-    })
-    public void testMakeWildcardPattern(String input, String expected) {
-        Pattern p = FindService.makeWildcardPattern(input);
-        assertEquals(expected, p.pattern());
-        assertThat(input).matches(p);
-        assertThat(p.flags() & Pattern.CASE_INSENSITIVE).isNotZero();
-    }
-
     private static FindResult result(int numResults, Object... data) {
         List<FindEntry> entries = new ArrayList<>();
         List<Sample> samples = new ArrayList<>();

--- a/src/test/java/uk/ac/sanger/sccp/utils/TestBasicUtils.java
+++ b/src/test/java/uk/ac/sanger/sccp/utils/TestBasicUtils.java
@@ -4,9 +4,11 @@ package uk.ac.sanger.sccp.utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
+import uk.ac.sanger.sccp.stan.service.FindService;
 
 import java.time.DayOfWeek;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -258,5 +260,18 @@ public class TestBasicUtils {
     public void testContainsDupes() {
         assertTrue(containsDupes(List.of(1,2,3,2)));
         assertFalse(containsDupes(List.of(1,3,5,2)));
+    }
+
+
+    @ParameterizedTest
+    @CsvSource({
+            "TIS*, \\QTIS\\E.*",
+            "*TI%?\\*, .*\\QTI%?\\\\E.*",
+    })
+    public void testMakeWildcardPattern(String input, String expected) {
+        Pattern p = makeWildcardPattern(input);
+        assertEquals(expected, p.pattern());
+        assertThat(input).matches(p);
+        assertThat(p.flags() & Pattern.CASE_INSENSITIVE).isNotZero();
     }
 }


### PR DESCRIPTION
**history** query to get the history associated with a specified work number, and/or  barcode, external name, donor name.

Note :- Related queries (_historyForExternalName, historyForDonorName, historyForWorkNumber, historyForLabwareBarcode_) are not removed just in case it is required in future