### PR TITLE
x1052 separate Stain QC from tissue coverage

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ResultService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ResultService.java
@@ -6,7 +6,7 @@ import uk.ac.sanger.sccp.stan.request.ResultRequest;
 
 public interface ResultService {
     /**
-     * Records the given stain QC.
+     * Records the given stain QC/tissue coverage
      * @param user the user responsible for the request
      * @param request the request to record
      * @return an operation result (operations and labware)

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1185,7 +1185,7 @@ input LabwareResult {
     """The barcode of the labware."""
     barcode: String!
     """The individual results."""
-    sampleResults: [SampleResult!]!
+    sampleResults: [SampleResult!]
     """Measurements to record in this labware."""
     slotMeasurements: [SlotMeasurementRequest!]
     """An optional costing for the labware."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestResultService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestResultService.java
@@ -125,7 +125,7 @@ public class TestResultService {
         UCMap<Labware> lwMap = UCMap.from(Labware::getBarcode, lw);
         doReturn(lwMap).when(service).validateLabware(any(), any());
         doNothing().when(service).validateLotNumbers(any(), any());
-        doNothing().when(service).validateLabwareContents(any(), any(), any());
+        doNothing().when(service).validateLabwareContents(any(), any(), any(), anyBoolean());
         Work work = new Work(200, "SGP200", null, null, null, null, null, Work.Status.active);
         doReturn(work).when(mockWorkService).validateUsableWork(any(), any());
         Map<Integer, Integer> lwStainMap = Map.of(100,200);
@@ -173,7 +173,7 @@ public class TestResultService {
         verify(service).loadOpType(anyCollection(), eq(resultOpType.getName()));
         verify(service).loadOpType(anyCollection(), eq(setupOpType.getName()));
         verify(service).validateLabware(anyCollection(), eq(lrs));
-        verify(service).validateLabwareContents(anyCollection(), eq(lwMap), eq(lrs));
+        verify(service).validateLabwareContents(anyCollection(), eq(lwMap), eq(lrs), eq(true));
         verify(service).validateLotNumbers(anyCollection(), same(lrs));
         verify(service).validateComments(anyCollection(), eq(lrs));
         verify(service).validateSampleIdsInSampleComments(anyCollection(), same(lwMap), same(lrs));
@@ -285,7 +285,7 @@ public class TestResultService {
         }).when(service).validateSampleResult(anyCollection(), any(), any(), any());
 
         final List<String> problems = new ArrayList<>();
-        service.validateLabwareContents(problems, lwMap, lrs);
+        service.validateLabwareContents(problems, lwMap, lrs, true);
         assertThat(problems).containsExactlyInAnyOrder(slotSampleProblem, "No results specified for labware "+lw0.getBarcode()+".");
 
         //noinspection unchecked

--- a/src/test/resources/graphql/stainqc.graphql
+++ b/src/test/resources/graphql/stainqc.graphql
@@ -1,5 +1,6 @@
 mutation {
     recordStainResult(request: {
+        operationType: "Stain QC"
         workNumber: "SGP500"
         labwareResults: [
             {
@@ -10,13 +11,6 @@ mutation {
                         result: pass
                         commentId: 1
                         sampleComments: [{ sampleId: 999, commentId: 2 }]
-                    }
-                ]
-                slotMeasurements: [
-                    {
-                        address: "A1"
-                        name: "tissue coverage"
-                        value: "50"
                     }
                 ]
             }

--- a/src/test/resources/graphql/tissuecoverage.graphql
+++ b/src/test/resources/graphql/tissuecoverage.graphql
@@ -1,0 +1,23 @@
+mutation {
+    recordStainResult(request: {
+        operationType: "Tissue coverage"
+        workNumber: "SGP500"
+        labwareResults: [
+            {
+                barcode: "STAN-50"
+                slotMeasurements: [
+                    {
+                        address: "A1"
+                        name: "tissue coverage"
+                        value: "50"
+                    }
+                ]
+            }
+        ]
+    }) {
+        operations {
+            id
+            operationType { name }
+        }
+    }
+}


### PR DESCRIPTION
Now Stain QC will record pass/fail and comments;
Tissue coverage will record tissue coverage measurement. Both are recorded via recordStainQC as results for a stain op.
