### PR TITLE
x1069: Filter history by event type

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -358,7 +358,8 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
             String barcode = dfe.getArgument("barcode");
             String externalName = dfe.getArgument("externalName");
             String donorName = dfe.getArgument("donorName");
-            return historyService.getHistory(workNumber, barcode, externalName,donorName);
+            String eventType = dfe.getArgument("eventType");
+            return historyService.getHistory(workNumber, barcode, externalName, donorName, eventType);
         };
     }
 
@@ -381,6 +382,10 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
             String barcode = dfe.getArgument("barcode");
             return historyService.getHistoryForLabwareBarcode(barcode);
         };
+    }
+
+    public DataFetcher<List<String>> eventTypes() {
+        return dfe -> historyService.getEventTypes();
     }
 
     public DataFetcher<List<WorkProgress>> workProgress() {

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -119,6 +119,7 @@ public class GraphQLProvider {
                         .dataFetcher("historyForLabwareBarcode", graphQLDataFetchers.historyForLabwareBarcode())
                         .dataFetcher("historyForWorkNumber", graphQLDataFetchers.historyForWorkNumber())
                         .dataFetcher("history", graphQLDataFetchers.history())
+                        .dataFetcher("eventTypes", graphQLDataFetchers.eventTypes())
                         .dataFetcher("workProgress", graphQLDataFetchers.workProgress())
 
                         .dataFetcher("location", graphQLStore.getLocation())

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareRepo.java
@@ -56,4 +56,7 @@ public interface LabwareRepo extends CrudRepository<Labware, Integer> {
                 "No labware found with barcode{s}: ");
     }
 
+    @Query(value = "SELECT DISTINCT slot.labware_id FROM slot_sample ss JOIN slot ON (ss.slot_id=slot.id) " +
+            "WHERE ss.sample_id IN (?1)", nativeQuery = true)
+    Set<Integer> findAllLabwareIdsContainingSampleIds(Collection<Integer> sampleIds);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationRepo.java
@@ -24,4 +24,6 @@ public interface OperationRepo extends CrudRepository<Operation, Integer> {
     @Query("select distinct op from Operation op join Action a on (a.operationId=op.id) " +
             "where op.operationType=?1 and a.destination.id in (?2)")
     List<Operation> findAllByOperationTypeAndDestinationSlotIdIn(OperationType opType, Collection<Integer> slotIds);
+
+    List<Operation> findAllByOperationType(OperationType opType);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/History.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/History.java
@@ -7,6 +7,8 @@ import uk.ac.sanger.sccp.utils.BasicUtils;
 import java.util.List;
 import java.util.Objects;
 
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullToEmpty;
+
 /**
  * @author dr6
  */
@@ -14,20 +16,23 @@ public class History {
     private List<HistoryEntry> entries;
     private List<Sample> samples;
     private List<Labware> labware;
+
     public History(List<HistoryEntry> entries, List<Sample> samples, List<Labware> labware) {
         setEntries(entries);
         setSamples(samples);
         setLabware(labware);
     }
 
-    public History() {}
+    public History() {
+        this(null, null, null);
+    }
 
     public List<HistoryEntry> getEntries() {
         return this.entries;
     }
 
     public void setEntries(List<HistoryEntry> entries) {
-        this.entries = entries;
+        this.entries = nullToEmpty(entries);
     }
 
     public List<Sample> getSamples() {
@@ -35,7 +40,7 @@ public class History {
     }
 
     public void setSamples(List<Sample> samples) {
-        this.samples = samples;
+        this.samples = nullToEmpty(samples);
     }
 
     public List<Labware> getLabware() {
@@ -43,7 +48,7 @@ public class History {
     }
 
     public void setLabware(List<Labware> labware) {
-        this.labware = labware;
+        this.labware = nullToEmpty(labware);
     }
 
     @Override

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryService.java
@@ -2,6 +2,8 @@ package uk.ac.sanger.sccp.stan.service.history;
 
 import uk.ac.sanger.sccp.stan.request.History;
 
+import java.util.List;
+
 /**
  * Service for getting the history from some kind of identifier.
  * The history typically includes all related samples.
@@ -49,8 +51,14 @@ public interface HistoryService {
      * @param barcode the barcode of the labware (if any) to look up, or null
      * @param externalName the external name of the tissue (if any) to look up, or null
      * @param donorName the name of the donor (if any) to look up, or null
+     * @param eventType the name of the event type (if any) you are interested in
      * @return the history for the specified identifier(s)
      */
-    History getHistory(String workNumber,String barcode, String externalName, String donorName);
+    History getHistory(String workNumber, String barcode, String externalName, String donorName, String eventType);
 
+    /**
+     * Gets a list of the different event types used in history
+     * @return the different event types
+     */
+    List<String> getEventTypes();
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1800,6 +1800,8 @@ type Query {
     planData(barcode: String!): PlanData!
     """Get the available stain types."""
     stainTypes: [StainType!]!
+    """Event types."""
+    eventTypes: [String!]!
     """Get an item of labware and the visium permeabilisation data recorded on it, if any."""
     visiumPermData(barcode: String!): VisiumPermData!
     """Get a previously recorded extract result for a given labware barcode."""
@@ -1824,7 +1826,7 @@ type Query {
     """Get the history containing a given labware barcode."""
     historyForLabwareBarcode(barcode: String!): History!
     """Get the history associated with a specified work number, and/or barcode, external name, donor name."""
-    history(workNumber: String,barcode: String, externalName: String, donorName: String): History!
+    history(workNumber: String, barcode: String, externalName: String, donorName: String, eventType: String): History!
    """Get the work progress (some particular timestamps) associated with a specified work number, and/or
     work types, programs, statuses."""
     workProgress(workNumber: String, workTypes: [String!], programs: [String!], statuses: [WorkStatus!], requesters: [String!]): [WorkProgress!]!


### PR DESCRIPTION
For https://github.com/sanger/stan-client/issues/421

Let the user specify an event type (operation type or a couple of other things)
as all or part of a history request.