### PR TITLE
x1093: Remove "medium" field from TissueBlockRequest

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/request/TissueBlockRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/TissueBlockRequest.java
@@ -93,20 +93,18 @@ public class TissueBlockRequest {
         private String preBarcode;
         private Integer commentId;
         private String replicate;
-        private String medium;
 
         public TissueBlockLabware() {}
 
-        public TissueBlockLabware(String sourceBarcode, String labwareType, String replicate, String medium) {
-            this(sourceBarcode, labwareType, replicate, medium, null, null);
+        public TissueBlockLabware(String sourceBarcode, String labwareType, String replicate) {
+            this(sourceBarcode, labwareType, replicate, null, null);
         }
 
-        public TissueBlockLabware(String sourceBarcode, String labwareType, String replicate, String medium,
+        public TissueBlockLabware(String sourceBarcode, String labwareType, String replicate,
                                   String preBarcode, Integer commentId) {
             this.sourceBarcode = sourceBarcode;
             this.labwareType = labwareType;
             this.replicate = replicate;
-            this.medium = medium;
             this.preBarcode = preBarcode;
             this.commentId = commentId;
         }
@@ -166,17 +164,6 @@ public class TissueBlockRequest {
             this.replicate = replicate;
         }
 
-        /**
-         * The medium for the new block.
-         */
-        public String getMedium() {
-            return this.medium;
-        }
-
-        public void setMedium(String medium) {
-            this.medium = medium;
-        }
-
         @Override
         public String toString() {
             return BasicUtils.describe("TissueBlockLabware")
@@ -185,7 +172,6 @@ public class TissueBlockRequest {
                     .add("preBarcode", preBarcode)
                     .add("commentId", commentId)
                     .add("replicate", replicate)
-                    .add("medium", medium)
                     .reprStringValues()
                     .omitNullValues()
                     .toString();
@@ -201,7 +187,7 @@ public class TissueBlockRequest {
                     && Objects.equals(this.preBarcode, that.preBarcode)
                     && Objects.equals(this.commentId, that.commentId)
                     && Objects.equals(this.replicate, that.replicate)
-                    && Objects.equals(this.medium, that.medium));
+            );
         }
 
         @Override

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1544,8 +1544,6 @@ input TissueBlockLabware {
     commentId: Int
     """The replicate number for the new block."""
     replicate: String!
-    """The medium for the new block."""
-    medium: String!
 }
 
 """A request to transfer original sample into pots."""

--- a/src/test/resources/graphql/tissueblock.graphql
+++ b/src/test/resources/graphql/tissueblock.graphql
@@ -4,7 +4,6 @@ mutation {
         workNumber: "WORKNUMBER"
         labware: [{
             sourceBarcode: "BARCODE"
-            medium: "None"
             labwareType: "Tube"
             replicate: "5c"
         }]


### PR DESCRIPTION
New processed blocks now inherit the medium from the original sample rather than having the medium specified in the request.

For #282