### PR TITLE
x1091 fix: parse strings in excel as dates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>uk.ac.sanger.sccp</groupId>
 	<artifactId>stan</artifactId>
-	<version>2.30.1</version>
+	<version>2.30.2</version>
 	<name>stan</name>
 	<description>Spatial Genomics LIMS</description>
 


### PR DESCRIPTION
In case Excel stubbornly refuses to agree that a value is a date,
if we find a string instead of a date, try and parse it as
day/month/year, which is the format specified in the spreadsheet