### PR TITLE
x1079 Labware flags

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -2,7 +2,6 @@ package uk.ac.sanger.sccp.stan;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -435,7 +434,10 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     }
   
     public DataFetcher<PlanData> getPlanData() {
-        return dfe -> planService.getPlanData(dfe.getArgument("barcode"));
+        return dfe -> {
+            boolean requestsFlags = requestsField(dfe, "**/flagged");
+            return planService.getPlanData(dfe.getArgument("barcode"), requestsFlags);
+        };
     }
 
     public DataFetcher<List<StainType>> getEnabledStainTypes() {
@@ -498,9 +500,8 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         };
     }
 
-    private boolean requestsField(DataFetchingEnvironment dfe, String childName) {
-        return dfe.getField().getSelectionSet().getChildren().stream()
-                .anyMatch(f -> ((Field) f).getName().equals(childName));
+    private boolean requestsField(DataFetchingEnvironment dfe, String glob) {
+       return dfe.getSelectionSet().contains(glob);
     }
 
     @FunctionalInterface

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -449,7 +449,10 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     }
 
     public DataFetcher<ExtractResult> getExtractResult() {
-        return dfe -> extractResultQueryService.getExtractResult(dfe.getArgument("barcode"));
+        return dfe -> {
+            boolean loadFlags = requestsField(dfe, "**/flagged");
+            return extractResultQueryService.getExtractResult(dfe.getArgument("barcode"), loadFlags);
+        };
     }
 
     public DataFetcher<List<OpPassFail>> getPassFails() {

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -21,6 +21,7 @@ import uk.ac.sanger.sccp.stan.request.stain.StainRequest;
 import uk.ac.sanger.sccp.stan.service.*;
 import uk.ac.sanger.sccp.stan.service.analysis.RNAAnalysisService;
 import uk.ac.sanger.sccp.stan.service.extract.ExtractService;
+import uk.ac.sanger.sccp.stan.service.flag.FlagLabwareService;
 import uk.ac.sanger.sccp.stan.service.label.print.LabelPrintService;
 import uk.ac.sanger.sccp.stan.service.operation.*;
 import uk.ac.sanger.sccp.stan.service.operation.confirm.ConfirmOperationService;
@@ -95,6 +96,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
     final ProbeService probeService;
     final CompletionService completionService;
     final AnalyserService analyserService;
+    final FlagLabwareService flagLabwareService;
     final QCLabwareService qcLabwareService;
     final SSStudyService ssStudyService;
     final UserAdminService userAdminService;
@@ -127,7 +129,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
                            SampleProcessingService sampleProcessingService, SolutionTransferService solutionTransferService,
                            ParaffinProcessingService paraffinProcessingService, OpWithSlotCommentsService opWithSlotCommentsService,
                            ProbeService probeService, CompletionService completionService, AnalyserService analyserService,
-                           QCLabwareService qcLabwareService, SSStudyService ssStudyService,
+                           FlagLabwareService flagLabwareService, QCLabwareService qcLabwareService, SSStudyService ssStudyService,
                            UserAdminService userAdminService) {
         super(objectMapper, authComp, userRepo);
         this.ldapService = ldapService;
@@ -182,6 +184,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         this.probeService = probeService;
         this.completionService = completionService;
         this.analyserService = analyserService;
+        this.flagLabwareService = flagLabwareService;
         this.qcLabwareService = qcLabwareService;
         this.ssStudyService = ssStudyService;
         this.userAdminService = userAdminService;
@@ -836,6 +839,14 @@ public class GraphQLMutation extends BaseGraphQLResource {
             AnalyserRequest request = arg(dfe, "request", AnalyserRequest.class);
             logRequest("Record analyser", user, request);
             return analyserService.perform(user, request);
+        };
+    }
+
+    public DataFetcher<OperationResult> flagLabware() {
+        return dfe -> {
+            User user = checkUser(dfe, User.Role.normal);
+            FlagLabwareRequest request = arg(dfe, "request", FlagLabwareRequest.class);
+            return flagLabwareService.record(user, request);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -74,6 +74,7 @@ public class GraphQLProvider {
                         .dataFetcher("fixatives", graphQLDataFetchers.getFixatives())
                         .dataFetcher("species", graphQLDataFetchers.getSpecies())
                         .dataFetcher("labware", graphQLDataFetchers.findLabwareByBarcode())
+                        .dataFetcher("labwareFlagged", graphQLDataFetchers.findLabwareFlagged())
                         .dataFetcher("printers", graphQLDataFetchers.findPrinters())
                         .dataFetcher("comments", graphQLDataFetchers.getComments())
                         .dataFetcher("equipments", graphQLDataFetchers.getEquipments())

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -110,6 +110,7 @@ public class GraphQLProvider {
                         .dataFetcher("suggestedWorkForLabware", graphQLDataFetchers.getSuggestedWorkForLabwareBarcodes())
                         .dataFetcher("suggestedLabwareForWork", graphQLDataFetchers.getSuggestedLabwareForWork())
                         .dataFetcher("findLatestOp", graphQLDataFetchers.findLatestOperation())
+                        .dataFetcher("labwareFlagDetails", graphQLDataFetchers.getFlagDetails())
 
                         .dataFetcher("users", graphQLDataFetchers.getUsers())
                         .dataFetcher("planData", graphQLDataFetchers.getPlanData())
@@ -210,6 +211,7 @@ public class GraphQLProvider {
                         .dataFetcher("recordProbeOperation", transact(graphQLMutation.recordProbeOperation()))
                         .dataFetcher("recordCompletion", transact(graphQLMutation.recordCompletion()))
                         .dataFetcher("recordAnalyser", transact(graphQLMutation.recordAnalyser()))
+                        .dataFetcher("flagLabware", transact(graphQLMutation.flagLabware()))
                         .dataFetcher("recordQCLabware", transact(graphQLMutation.recordQcLabware()))
 
                         .dataFetcher("addUser", transact(graphQLMutation.addUser()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/LabwareFlag.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/LabwareFlag.java
@@ -1,0 +1,102 @@
+package uk.ac.sanger.sccp.stan.model;
+
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+/**
+ * @author dr6
+ */
+@Entity
+public class LabwareFlag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    private Labware labware;
+
+    private String description;
+    @ManyToOne
+    private User user;
+    private Integer operationId;
+
+    public LabwareFlag(Integer id, Labware labware, String description, User user, Integer operationId) {
+        this.id = id;
+        this.labware = labware;
+        this.description = description;
+        this.user = user;
+        this.operationId = operationId;
+    }
+
+    public LabwareFlag() {}
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Labware getLabware() {
+        return this.labware;
+    }
+
+    public void setLabware(Labware labware) {
+        this.labware = labware;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public User getUser() {
+        return this.user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Integer getOperationId() {
+        return this.operationId;
+    }
+
+    public void setOperationId(Integer operationId) {
+        this.operationId = operationId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LabwareFlag that = (LabwareFlag) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.labware, that.labware)
+                && Objects.equals(this.description, that.description)
+                && Objects.equals(this.user, that.user)
+                && Objects.equals(this.operationId, that.operationId));
+    }
+
+    @Override
+    public int hashCode() {
+        return (id!=null ? id.hashCode() : Objects.hash(labware, description));
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe(this)
+                .add("id", id)
+                .add("labware", labware==null ? null : labware.getBarcode())
+                .addRepr("description", description)
+                .add("user", user==null ? null : user.getUsername())
+                .add("operationId", operationId)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareFlagRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareFlagRepo.java
@@ -1,0 +1,15 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.LabwareFlag;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface LabwareFlagRepo extends CrudRepository<LabwareFlag, Integer> {
+    @Query("select lf from LabwareFlag lf where lf.labware.id in (?1)")
+    List<LabwareFlag> findAllByLabwareIdIn(Collection<Integer> labwareIds);
+
+    List<LabwareFlag> findAllByOperationIdIn(Collection<Integer> opIds);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/ExtractResult.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/ExtractResult.java
@@ -1,6 +1,5 @@
 package uk.ac.sanger.sccp.stan.request;
 
-import uk.ac.sanger.sccp.stan.model.Labware;
 import uk.ac.sanger.sccp.stan.model.PassFail;
 import uk.ac.sanger.sccp.utils.BasicUtils;
 
@@ -11,23 +10,23 @@ import java.util.Objects;
  * @author dr6
  */
 public class ExtractResult {
-    private Labware labware;
+    private LabwareFlagged labware;
     private PassFail result;
     private String concentration;
 
     public ExtractResult() {}
 
-    public ExtractResult(Labware labware, PassFail result, String concentration) {
+    public ExtractResult(LabwareFlagged labware, PassFail result, String concentration) {
         this.labware = labware;
         this.result = result;
         this.concentration = concentration;
     }
 
-    public Labware getLabware() {
+    public LabwareFlagged getLabware() {
         return this.labware;
     }
 
-    public void setLabware(Labware labware) {
+    public void setLabware(LabwareFlagged labware) {
         this.labware = labware;
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/FlagDetail.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/FlagDetail.java
@@ -1,0 +1,119 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import java.util.List;
+import java.util.Objects;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.*;
+
+/**
+ * Information about flags related to some labware.
+ * @author dr6
+ */
+public class FlagDetail {
+    /**
+     * Summary of a particular labware flag.
+     * @author dr6
+     */
+    public static class FlagSummary {
+        private String barcode;
+        private String description;
+
+        public FlagSummary(String barcode, String description) {
+            this.barcode = barcode;
+            this.description = description;
+        }
+
+        /**
+         * The labware barcode that was flagged.
+         */
+        public String getBarcode() {
+            return this.barcode;
+        }
+
+        public void setBarcode(String barcode) {
+            this.barcode = barcode;
+        }
+
+        /**
+         * The description of the flag.
+         */
+        public String getDescription() {
+            return this.description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FlagSummary that = (FlagSummary) o;
+            return (Objects.equals(this.barcode, that.barcode)
+                    && Objects.equals(this.description, that.description));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(barcode, description);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[%s: %s]", barcode, repr(description));
+        }
+    }
+
+    private String barcode;
+    private List<FlagSummary> flags;
+
+    public FlagDetail(String barcode, List<FlagSummary> flags) {
+        this.barcode = barcode;
+        setFlags(flags);
+    }
+
+    /**
+     * The barcode of the labware whose flags have been looked up.
+     */
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    /**
+     * Summaries of the flags applicable to the specified labware.
+     */
+    public List<FlagSummary> getFlags() {
+        return this.flags;
+    }
+
+    public void setFlags(List<FlagSummary> flags) {
+        this.flags = nullToEmpty(flags);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FlagDetail that = (FlagDetail) o;
+        return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.flags, that.flags));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(barcode, flags);
+    }
+
+    @Override
+    public String toString() {
+        return describe("FlagDetail")
+                .add("barcode", barcode)
+                .add("flags", flags)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/FlagLabwareRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/FlagLabwareRequest.java
@@ -1,0 +1,67 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.util.Objects;
+
+/**
+ * Raise a flag on a piece of labware.
+ * @author dr6
+ */
+public class FlagLabwareRequest {
+    private String barcode;
+    private String description;
+
+    public FlagLabwareRequest(String barcode, String description) {
+        this.barcode = barcode;
+        this.description = description;
+    }
+
+    // required for framework
+    public FlagLabwareRequest() {}
+
+    /**
+     * The barcode of the flagged labware.
+     */
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    /**
+     * The description of the flag.
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FlagLabwareRequest that = (FlagLabwareRequest) o;
+        return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.description, that.description));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(barcode, description);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe("FlagLabwareRequest")
+                .add("barcode", barcode)
+                .add("description", description)
+                .reprStringValues()
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/LabwareFlagged.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/LabwareFlagged.java
@@ -1,0 +1,132 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import org.jetbrains.annotations.NotNull;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Labware with an additional field specifying whether it is flagged.
+ * @author dr6
+ */
+public class LabwareFlagged {
+    @NotNull
+    private final Labware labware;
+    private final boolean flagged;
+
+    public LabwareFlagged(Labware labware, boolean flagged) {
+        this.labware = requireNonNull(labware, "labware is null");
+        this.flagged = flagged;
+    }
+
+    /**
+     * The unique id of this labware.
+     */
+    public Integer getId() {
+        return this.labware.getId();
+    }
+
+    /**
+     * The unique barcode of this labware.
+     */
+    public String getBarcode() {
+        return this.labware.getBarcode();
+    }
+
+    /**
+     * The external barcode of this labware, as input by the user.
+     */
+    public String getExternalBarcode() {
+        return this.labware.getExternalBarcode();
+    }
+
+    /**
+     * The type of labware.
+     */
+    public LabwareType getLabwareType() {
+        return this.labware.getLabwareType();
+    }
+
+    /**
+     * The slots in this labware. The number of slots and their addresses are determined by the labware type.
+     */
+    public List<Slot> getSlots() {
+        return this.labware.getSlots();
+    }
+
+    /**
+     * Has this labware been released?
+     */
+    public boolean isReleased() {
+        return this.labware.isReleased();
+    }
+
+    /**
+     * Has this labware been destroyed?
+     */
+    public boolean isDestroyed() {
+        return this.labware.isDestroyed();
+    }
+
+    /**
+     * Has this labware been discarded?
+     */
+    public boolean isDiscarded() {
+        return this.labware.isDiscarded();
+    }
+
+    /**
+     * Has this labware been marked as used?
+     */
+    public boolean isUsed() {
+        return this.labware.isUsed();
+    }
+
+    /**
+     * The state, derived from the contents and other fields on the labware.
+     */
+    public Labware.State getState() {
+        return this.labware.getState();
+    }
+
+    /**
+     * The time when this labware was created in the application.
+     */
+    public LocalDateTime getCreated() {
+        return this.labware.getCreated();
+    }
+
+    @NotNull
+    public Labware getLabware() {
+        return this.labware;
+    }
+
+    /**
+     * Is there a labware flag applicable to this labware?
+     */
+    public boolean isFlagged() {
+        return this.flagged;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LabwareFlagged that = (LabwareFlagged) o;
+        return (this.flagged == that.flagged
+                && this.labware.equals(that.labware));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.labware.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("LabwareFlagged(%s, %s)", labware.getBarcode(), flagged);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/PlanData.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/PlanData.java
@@ -1,6 +1,5 @@
 package uk.ac.sanger.sccp.stan.request;
 
-import uk.ac.sanger.sccp.stan.model.Labware;
 import uk.ac.sanger.sccp.stan.model.PlanOperation;
 import uk.ac.sanger.sccp.utils.BasicUtils;
 
@@ -15,10 +14,10 @@ import static uk.ac.sanger.sccp.utils.BasicUtils.newArrayList;
  */
 public class PlanData {
     private PlanOperation plan;
-    private List<Labware> sources;
-    private Labware destination;
+    private List<LabwareFlagged> sources;
+    private LabwareFlagged destination;
 
-    public PlanData(PlanOperation plan, Iterable<Labware> sources, Labware destination) {
+    public PlanData(PlanOperation plan, Iterable<LabwareFlagged> sources, LabwareFlagged destination) {
         setPlan(plan);
         setSources(sources);
         setDestination(destination);
@@ -36,19 +35,19 @@ public class PlanData {
         this.plan = plan;
     }
 
-    public List<Labware> getSources() {
+    public List<LabwareFlagged> getSources() {
         return this.sources;
     }
 
-    public void setSources(Iterable<Labware> sources) {
+    public void setSources(Iterable<LabwareFlagged> sources) {
         this.sources = newArrayList(sources);
     }
 
-    public Labware getDestination() {
+    public LabwareFlagged getDestination() {
         return this.destination;
     }
 
-    public void setDestination(Labware destination) {
+    public void setDestination(LabwareFlagged destination) {
         this.destination = destination;
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLabwareService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLabwareService.java
@@ -1,0 +1,21 @@
+package uk.ac.sanger.sccp.stan.service.flag;
+
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.request.FlagLabwareRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.ValidationException;
+
+/**
+ * Service for performing {@link FlagLabwareRequest}
+ * @author dr6
+ */
+public interface FlagLabwareService {
+    /**
+     * Checks and records the given labware flag.
+     * @param user the user recording the flag
+     * @param request the request to record
+     * @return the labware and op recorded
+     * @exception ValidationException validation fails
+     */
+    OperationResult record(User user, FlagLabwareRequest request) throws ValidationException;
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLabwareServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLabwareServiceImp.java
@@ -1,0 +1,130 @@
+package uk.ac.sanger.sccp.stan.service.flag;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.FlagLabwareRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.OperationService;
+import uk.ac.sanger.sccp.stan.service.ValidationException;
+
+import java.util.*;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * @author dr6
+ */
+@Service
+public class FlagLabwareServiceImp implements FlagLabwareService {
+    static final int MAX_DESCRIPTION_LEN = 512;
+
+    private final OperationService opService;
+
+    private final LabwareFlagRepo flagRepo;
+    private final LabwareRepo lwRepo;
+    private final OperationTypeRepo opTypeRepo;
+
+    @Autowired
+    public FlagLabwareServiceImp(OperationService opService,
+                                 LabwareFlagRepo flagRepo, LabwareRepo lwRepo, OperationTypeRepo opTypeRepo) {
+        this.opService = opService;
+        this.flagRepo = flagRepo;
+        this.lwRepo = lwRepo;
+        this.opTypeRepo = opTypeRepo;
+    }
+
+    @Override
+    public OperationResult record(User user, FlagLabwareRequest request) throws ValidationException {
+        final Collection<String> problems = new LinkedHashSet<>();
+        if (user==null) {
+            problems.add("No user specified.");
+        }
+        if (request==null) {
+            problems.add("No request supplied.");
+            throw new ValidationException(problems);
+        }
+
+        Labware lw = loadLabware(problems, request.getBarcode());
+        String description = checkDescription(problems, request.getDescription());
+        OperationType opType = loadOpType(problems);
+
+        if (!problems.isEmpty()) {
+            throw new ValidationException(problems);
+        }
+
+        return create(user, opType, lw, description);
+    }
+
+    /**
+     * Loads the labware indicated. The labware does not need to be active to be flagged.
+     * @param problems receptacle for problems
+     * @param barcode the barcode of the labware to load
+     * @return the labware found, or null
+     */
+    Labware loadLabware(Collection<String> problems, String barcode) {
+        if (nullOrEmpty(barcode)) {
+            problems.add("No labware barcode supplied.");
+            return null;
+        }
+        var opt = lwRepo.findByBarcode(barcode);
+        if (opt.isEmpty()) {
+            problems.add("Unknown labware barcode: "+repr(barcode));
+            return null;
+        }
+        return opt.get();
+    }
+
+    /**
+     * Sanitises and validates the flag description.
+     * Sanitisation involves removing superfluous whitespace.
+     * Validation involves checking the description is non-null and a suitable length.
+     * @param problems receptacle for problems found
+     * @param description the description to validate
+     * @return the sanitised description, if any description was supplied
+     */
+    String checkDescription(Collection<String> problems, String description) {
+        if (description!=null) {
+            description = description.trim().replaceAll("\\s+", " ");
+            if (!description.isEmpty()) {
+                if (description.length() > MAX_DESCRIPTION_LEN) {
+                    problems.add("Description too long.");
+                }
+                return description;
+            }
+        }
+        problems.add("Missing flag description.");
+        return null;
+    }
+
+    /**
+     * Loads the appropriate op type
+     * @param problems receptacle for problems
+     * @return the operation type, if found
+     */
+    OperationType loadOpType(Collection<String> problems) {
+        var opt = opTypeRepo.findByName("Flag labware");
+        if (opt.isEmpty()) {
+            problems.add("Flag labware operation type is missing.");
+            return null;
+        }
+        return opt.get();
+    }
+
+    /**
+     * Records a flag labware operation and records the specified flag
+     * @param user the user responsible
+     * @param opType the operation type to record
+     * @param lw the labware being flagged
+     * @param description the flag description
+     * @return the labware and operation
+     */
+    OperationResult create(User user, OperationType opType, Labware lw, String description) {
+        Operation op = opService.createOperationInPlace(opType, user, lw, null, null);
+        LabwareFlag flag = new LabwareFlag(null, lw, description, user, op.getId());
+        flagRepo.save(flag);
+        return new OperationResult(List.of(op), List.of(lw));
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupService.java
@@ -44,4 +44,12 @@ public interface FlagLookupService {
      * @return an object specifying a labware and whether or not there are any applicable flags
      */
     LabwareFlagged getLabwareFlagged(Labware lw);
+
+    /**
+     * Looks up which labware are flagged and returns {@code LabwareFlagged} objects.
+     * Labware are returned in the same order as the labware passed in.
+     * @param labware the labware to check
+     * @return objects specifying the labware and whether there are any applicable flags
+     */
+    List<LabwareFlagged> getLabwareFlagged(Collection<Labware> labware);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupService.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import uk.ac.sanger.sccp.stan.model.Labware;
 import uk.ac.sanger.sccp.stan.model.LabwareFlag;
 import uk.ac.sanger.sccp.stan.request.FlagDetail;
+import uk.ac.sanger.sccp.stan.request.LabwareFlagged;
 import uk.ac.sanger.sccp.utils.UCMap;
 
 import java.util.Collection;
@@ -36,4 +37,11 @@ public interface FlagLookupService {
     default List<FlagDetail> lookUpDetails(Collection<Labware> labware) {
         return toDetails(lookUp(labware));
     }
+
+    /**
+     * Checks if the labware is flagged and returns a {@code LabwareFlagged} object.
+     * @param lw the labware to check
+     * @return an object specifying a labware and whether or not there are any applicable flags
+     */
+    LabwareFlagged getLabwareFlagged(Labware lw);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupService.java
@@ -1,0 +1,39 @@
+package uk.ac.sanger.sccp.stan.service.flag;
+
+import org.jetbrains.annotations.NotNull;
+import uk.ac.sanger.sccp.stan.model.Labware;
+import uk.ac.sanger.sccp.stan.model.LabwareFlag;
+import uk.ac.sanger.sccp.stan.request.FlagDetail;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Service for looking up {@link LabwareFlag flags} on labware
+ */
+public interface FlagLookupService {
+    /**
+     * Looks up flags on the given labware and its ancestors
+     * @param labware the labware to look up flags on
+     * @return a map from labware barcodes to the found flags
+     */
+    @NotNull
+    UCMap<List<LabwareFlag>> lookUp(Collection<Labware> labware);
+
+    /**
+     * Converts a map of flags to details for serialisation
+     * @param flagMap a map of labware barcode to applicable flags
+     * @return a list of flag details
+     */
+    List<FlagDetail> toDetails(UCMap<List<LabwareFlag>> flagMap);
+
+    /**
+     * Looks up flags and converts them to details
+     * @param labware the labware to get flag details for
+     * @return the flag details applicable to the given labware
+     */
+    default List<FlagDetail> lookUpDetails(Collection<Labware> labware) {
+        return toDetails(lookUp(labware));
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupServiceImp.java
@@ -187,41 +187,6 @@ public class FlagLookupServiceImp implements FlagLookupService {
         return new FlagDetail(barcode, summaries);
     }
 
-    // TODO replace this with a record after Java upgrade
     /** A hash key comprising an op id and a labware id */
-    static class OpIdLwId {
-        final Integer opId;
-        final Integer lwId;
-
-        public OpIdLwId(Integer opId, Integer lwId) {
-            this.opId = opId;
-            this.lwId = lwId;
-        }
-
-        public int opId() {
-            return this.opId;
-        }
-        public int lwId() {
-            return this.lwId;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            OpIdLwId that = (OpIdLwId) o;
-            return (Objects.equals(this.opId(), that.opId())
-                    && Objects.equals(this.lwId(), that.lwId()));
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(opId(), lwId());
-        }
-
-        @Override
-        public String toString() {
-            return String.format("[opId=%s, lwId=%s]", opId(), lwId());
-        }
-    }
+    record OpIdLwId(Integer opid, Integer lwId) {}
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupServiceImp.java
@@ -79,7 +79,7 @@ public class FlagLookupServiceImp implements FlagLookupService {
      */
     @NotNull
     Map<SlotSample, List<LabwareFlag>> loadDirectFlags(Collection<SlotSample> slotSamples) {
-        Set<Integer> labwareIds = slotSamples.stream().map(ss -> ss.getSlot().getLabwareId()).collect(toSet());
+        Set<Integer> labwareIds = slotSamples.stream().map(ss -> ss.slot().getLabwareId()).collect(toSet());
         List<LabwareFlag> flags = flagRepo.findAllByLabwareIdIn(labwareIds);
         if (flags.isEmpty()) {
             return Map.of();
@@ -157,7 +157,7 @@ public class FlagLookupServiceImp implements FlagLookupService {
         Set<SlotSample> slotSamples = SlotSample.stream(lw).collect(toSet());
         Ancestry ancestry = ancestoriser.findAncestry(slotSamples);
         Set<SlotSample> ancestorSS = ancestry.keySet();
-        Set<Integer> labwareIds = ancestorSS.stream().map(ss -> ss.getSlot().getLabwareId()).collect(toSet());
+        Set<Integer> labwareIds = ancestorSS.stream().map(ss -> ss.slot().getLabwareId()).collect(toSet());
         List<LabwareFlag> flags = flagRepo.findAllByLabwareIdIn(labwareIds);
         if (flags.isEmpty()) {
             return false;
@@ -180,7 +180,7 @@ public class FlagLookupServiceImp implements FlagLookupService {
                 .collect(toSet());
         Ancestry ancestry = ancestoriser.findAncestry(slotSamples);
         Set<SlotSample> ancestorSs = ancestry.keySet();
-        Set<Integer> labwareIds = ancestorSs.stream().map(ss -> ss.getSlot().getLabwareId()).collect(toSet());
+        Set<Integer> labwareIds = ancestorSs.stream().map(ss -> ss.slot().getLabwareId()).collect(toSet());
         List<LabwareFlag> flags = flagRepo.findAllByLabwareIdIn(labwareIds);
         if (flags.isEmpty()) {
             return labware.stream().map(lw -> new LabwareFlagged(lw, false)).toList();

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/flag/FlagLookupServiceImp.java
@@ -1,0 +1,202 @@
+package uk.ac.sanger.sccp.stan.service.flag;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareFlagRepo;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+import uk.ac.sanger.sccp.stan.request.FlagDetail;
+import uk.ac.sanger.sccp.stan.request.FlagDetail.FlagSummary;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.Ancestry;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.SlotSample;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+
+/**
+ * @author dr6
+ */
+@Service
+public class FlagLookupServiceImp implements FlagLookupService {
+    private final Ancestoriser ancestoriser;
+    private final LabwareFlagRepo flagRepo;
+    private final OperationRepo opRepo;
+
+    @Autowired
+    public FlagLookupServiceImp(Ancestoriser ancestoriser, LabwareFlagRepo flagRepo, OperationRepo opRepo) {
+        this.ancestoriser = ancestoriser;
+        this.flagRepo = flagRepo;
+        this.opRepo = opRepo;
+    }
+
+    @Override
+    @NotNull
+    public UCMap<List<LabwareFlag>> lookUp(Collection<Labware> labware) {
+        if (labware.isEmpty()) {
+            return new UCMap<>(0);
+        }
+
+        Ancestry ancestry = loadAncestry(labware);
+        Map<SlotSample, List<LabwareFlag>> ssFlags = loadDirectFlags(ancestry.keySet());
+        if (ssFlags.isEmpty()) {
+            return new UCMap<>(0);
+        }
+
+        UCMap<List<LabwareFlag>> lwFlags = new UCMap<>(labware.size());
+        for (Labware lw : labware) {
+            List<LabwareFlag> flags = flagsForLabware(ancestry, lw, ssFlags);
+            lwFlags.put(lw.getBarcode(), flags);
+        }
+        return lwFlags;
+    }
+
+    /**
+     * Loads the ancestry for the given labware
+     * @param labware the labware to look up ancestry for
+     * @return the ancestry of the given labware
+     */
+    @NotNull
+    Ancestry loadAncestry(Collection<Labware> labware) {
+        List<SlotSample> slotSamples = labware.stream()
+                .flatMap(SlotSample::stream)
+                .collect(toList());
+        return ancestoriser.findAncestry(slotSamples);
+    }
+
+    /**
+     * Looks up flags directly recorded on the given slotsamples.
+     * @param slotSamples the slots and samples to look up flags for
+     * @return a map of slot samples to applicable flags
+     */
+    @NotNull
+    Map<SlotSample, List<LabwareFlag>> loadDirectFlags(Collection<SlotSample> slotSamples) {
+        Set<Integer> labwareIds = slotSamples.stream().map(ss -> ss.getSlot().getLabwareId()).collect(toSet());
+        List<LabwareFlag> flags = flagRepo.findAllByLabwareIdIn(labwareIds);
+        if (flags.isEmpty()) {
+            return Map.of();
+        }
+        Set<Integer> opIds = new HashSet<>();
+        Map<OpIdLwId, List<LabwareFlag>> opLwFlagMap = new HashMap<>();
+        for (LabwareFlag flag : flags) {
+            opIds.add(flag.getOperationId());
+            opLwFlagMap.computeIfAbsent(new OpIdLwId(flag.getOperationId(), flag.getLabware().getId()), k -> new ArrayList<>())
+                    .add(flag);
+        }
+        return makeSsFlagMap(opIds, opLwFlagMap);
+    }
+
+    /**
+     * Loads the ops for the indicated flags and compiles a map from slot samples to their direct flags
+     * @param opIds all the op ids in the {@code opLwFlagMap}
+     * @param opLwFlagMap map of op id and labware id to the flags directly on that labware recorded in that op
+     * @return a map from slot sample to the flags directly on that slot sample
+     */
+    @NotNull
+    Map<SlotSample, List<LabwareFlag>> makeSsFlagMap(Set<Integer> opIds, Map<OpIdLwId, List<LabwareFlag>> opLwFlagMap) {
+        Map<SlotSample, List<LabwareFlag>> ssFlags = new HashMap<>();
+        for (Operation op : opRepo.findAllById(opIds)) {
+            for (Action ac : op.getActions()) {
+                List<LabwareFlag> lwFlags = opLwFlagMap.get(new OpIdLwId(op.getId(), ac.getDestination().getLabwareId()));
+                if (nullOrEmpty(lwFlags)) {
+                    continue;
+                }
+                SlotSample ss = new SlotSample(ac.getDestination(), ac.getSample());
+                var flagsForSs = ssFlags.get(ss);
+                if (flagsForSs==null) {
+                    ssFlags.put(ss, new ArrayList<>(lwFlags));
+                } else {
+                    flagsForSs.addAll(lwFlags);
+                }
+            }
+        }
+        return ssFlags;
+    }
+
+    /**
+     * Gets the flags relevant to the labware using the ancestry.
+     * @param ancestry the ancestry of the labware
+     * @param lw the labware to get flags for
+     * @param ssFlags a map of flags on slot-samples that include the labware's ancestors
+     * @return the flags recorded on ancestors of the given labware
+     */
+    @NotNull
+    List<LabwareFlag> flagsForLabware(Ancestry ancestry, Labware lw, Map<SlotSample, List<LabwareFlag>> ssFlags) {
+        Set<LabwareFlag> flags = new LinkedHashSet<>();
+        SlotSample.stream(lw).forEach(lwSs -> {
+            for (SlotSample ss : ancestry.ancestors(lwSs)) {
+                final List<LabwareFlag> ancestorFlags = ssFlags.get(ss);
+                if (!nullOrEmpty(ancestorFlags)) {
+                    flags.addAll(ancestorFlags);
+                }
+            }
+        });
+        if (flags.isEmpty()) {
+            return List.of();
+        }
+        return new ArrayList<>(flags);
+    }
+
+    @Override
+    public List<FlagDetail> toDetails(UCMap<List<LabwareFlag>> flagMap) {
+        return flagMap.entrySet().stream()
+                .map(e -> toDetail(e.getKey(), e.getValue()))
+                .collect(toList());
+    }
+
+    /**
+     * Converts a barcode and list of flags to a FlagDetail object
+     * @param barcode the barcode of the labware
+     * @param flags the flags applicable to the labware
+     * @return a flagdetail summarising the flags for that labwares
+     */
+    FlagDetail toDetail(String barcode, List<LabwareFlag> flags) {
+        List<FlagSummary> summaries = flags.stream()
+                .map(flag -> new FlagSummary(flag.getLabware().getBarcode(), flag.getDescription()))
+                .collect(toList());
+        return new FlagDetail(barcode, summaries);
+    }
+
+    // TODO replace this with a record after Java upgrade
+    /** A hash key comprising an op id and a labware id */
+    static class OpIdLwId {
+        final Integer opId;
+        final Integer lwId;
+
+        public OpIdLwId(Integer opId, Integer lwId) {
+            this.opId = opId;
+            this.lwId = lwId;
+        }
+
+        public int opId() {
+            return this.opId;
+        }
+        public int lwId() {
+            return this.lwId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            OpIdLwId that = (OpIdLwId) o;
+            return (Objects.equals(this.opId(), that.opId())
+                    && Objects.equals(this.lwId(), that.lwId()));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(opId(), lwId());
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[opId=%s, lwId=%s]", opId(), lwId());
+        }
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanService.java
@@ -19,7 +19,8 @@ public interface PlanService {
     /**
      * Gets the plan data for a destination labware barcode.
      * @param barcode the barcode of a labware for which a plan has been recorded
+     * @param loadFlags true to require that flags are loaded for labware
      * @return the plan data for that barcode
      */
-    PlanData getPlanData(String barcode);
+    PlanData getPlanData(String barcode, boolean loadFlags);
 }

--- a/src/main/resources/db/changelog/changelog-2.32.xml
+++ b/src/main/resources/db/changelog/changelog-2.32.xml
@@ -1,0 +1,32 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="2.32.0" author="dr6">
+        <createTable tableName="labware_flag">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="labware_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_labware_flag_labware" referencedTableName="labware" referencedColumnNames="id"/>
+            </column>
+            <column name="user_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_labware_flag_user" referencedTableName="user" referencedColumnNames="id"/>
+            </column>
+            <column name="operation_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_labware_flag_operation" referencedTableName="operation" referencedColumnNames="id"/>
+            </column>
+            <column name="description" type="VARCHAR(512)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -27,4 +27,5 @@
     <include relativeToChangelogFile="true" file="changelog-2.25.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.26.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.31.xml"/>
+    <include relativeToChangelogFile="true" file="changelog-2.32.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1094,6 +1094,22 @@ type WorkProgress {
     mostRecentOperation: String
 }
 
+"""Summary of a particular labware flag."""
+type FlagSummary {
+    """The labware barcode that was flagged."""
+    barcode: String!
+    """The description of the flag."""
+    description: String!
+}
+
+"""Information about flags related to some labware."""
+type FlagDetail {
+    """The barcode of the labware whose flags have been looked up."""
+    barcode: String!
+    """Summaries of the flags applicable to the specified labware."""
+    flags: [FlagSummary!]!
+}
+
 """A measurement given as a number of seconds for some particular named measure."""
 input TimeMeasurement {
     name: String!
@@ -1720,6 +1736,14 @@ input QCLabware {
     comments: [Int!]!
 }
 
+"""Raise a flag on a piece of labware."""
+input FlagLabwareRequest {
+    """The barcode of the flagged labware."""
+    barcode: String!
+    """The description of the flag."""
+    description: String!
+}
+
 """Request to record QC and completion time for one or more labware."""
 input QCLabwareRequest {
     """The name of the operation to record."""
@@ -1853,6 +1877,8 @@ type Query {
     suggestedWorkForLabware(barcodes: [String!]!, includeInactive: Boolean): SuggestedWorkResponse!
     """Get suggested labware for work."""
     suggestedLabwareForWork(workNumber: String!, forRelease: Boolean): [Labware!]!
+    """Get labware flag details applicable to the specified labware."""
+    labwareFlagDetails(barcodes: [String!]!): [FlagDetail!]!
 
     """Get the specified storage location."""
     location(locationBarcode: String!): Location!
@@ -2029,6 +2055,8 @@ type Mutation {
     recordCompletion(request: CompletionRequest!): OperationResult!
     """Record analyser operation."""
     recordAnalyser(request: AnalyserRequest!): OperationResult!
+    """Flag labware."""
+    flagLabware(request: FlagLabwareRequest!): OperationResult!
     """Record QC labware request."""
     recordQCLabware(request: QCLabwareRequest!): OperationResult!
 

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -216,6 +216,34 @@ type Labware {
     created: Timestamp!
 }
 
+"""Labware with an additional field specifying whether it is flagged."""
+type LabwareFlagged {
+    """The unique id of this labware."""
+    id: Int!
+    """The unique barcode of this labware."""
+    barcode: String!
+    """The external barcode of this labware, as input by the user."""
+    externalBarcode: String
+    """The type of labware."""
+    labwareType: LabwareType!
+    """The slots in this labware. The number of slots and their addresses are determined by the labware type."""
+    slots: [Slot!]!
+    """Has this labware been released?"""
+    released: Boolean!
+    """Has this labware been destroyed?"""
+    destroyed: Boolean!
+    """Has this labware been discarded?"""
+    discarded: Boolean!
+    """Has this labware been marked as used?"""
+    used: Boolean!
+    """The state, derived from the contents and other fields on the labware."""
+    state: LabwareState!
+    """The time when this labware was created in the application."""
+    created: Timestamp!
+    """Is there a labware flag applicable to this labware?"""
+    flagged: Boolean!
+}
+
 """A solution used in an operation."""
 type Solution {
     """The unique name of the solution."""
@@ -1785,6 +1813,8 @@ type Query {
     probePanels(includeDisabled: Boolean): [ProbePanel!]!
     """Get the labware with the given barcode."""
     labware(barcode: String!): Labware!
+    """Get the labware and check if it is flagged."""
+    labwareFlagged(barcode: String!): LabwareFlagged!
     """Get all printers available, or get all printers that support a named label type."""
     printers(labelType: String): [Printer!]!
     """Get all enabled comments in a particular category, or all enabled in any category; optionally include disabled."""

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1007,11 +1007,11 @@ type History {
 """Information about a plan previously recorded, now being looked up."""
 type PlanData {
     """One or more items of source labware for the plan."""
-    sources: [Labware!]!
+    sources: [LabwareFlagged!]!
     """The planned operation."""
     plan: PlanOperation!
     """The single item of destination labware for the plan."""
-    destination: Labware!
+    destination: LabwareFlagged!
 }
 
 """A project that work can be associated with."""

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1385,7 +1385,7 @@ type OpPassFail {
 """A piece of labware and an extract result, if any exists."""
 type ExtractResult {
     """The labware the result refers to."""
-    labware: Labware!
+    labware: LabwareFlagged!
     """The result, if any."""
     result: PassFail
     """The concentration recorded, if any."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/EntityCreator.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/EntityCreator.java
@@ -70,6 +70,10 @@ public class EntityCreator {
     private WorkTypeRepo workTypeRepo;
     @Autowired
     private WorkRepo workRepo;
+    @Autowired
+    private OperationRepo opRepo;
+    @Autowired
+    private ActionRepo actionRepo;
 
     @Autowired
     private EntityManager entityManager;
@@ -251,6 +255,17 @@ public class EntityCreator {
 
     public Work createWorkLike(Work otherWork) {
         return createWork(otherWork.getWorkType(), otherWork.getProject(), otherWork.getProgram(), otherWork.getCostCode(), otherWork.getWorkRequester());
+    }
+
+    public Operation simpleOp(OperationType opType, User user, Labware source, Labware dest) {
+        Slot slot0 = source.getFirstSlot();
+        Slot slot1 = dest.getFirstSlot();
+        Sample sam0 = slot0.getSamples().get(0);
+        Sample sam1 = slot1.getSamples().get(0);
+        Operation op = opRepo.save(new Operation(null, opType, null, List.of(), user));
+        Action action = actionRepo.save(new Action(null, op.getId(), slot0, slot1, sam1, sam0));
+        op.setActions(List.of(action));
+        return op;
     }
 
     public Printer createPrinter(String name, LabelType labelType) {

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLabwareFlags.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLabwareFlags.java
@@ -1,0 +1,93 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+
+/**
+ * Tests recording and lookup up labware flags
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestLabwareFlags {
+    @Autowired
+    GraphQLTester tester;
+    @Autowired
+    EntityCreator entityCreator;
+
+    @Transactional
+    @Test
+    public void testRecordFlags() throws Exception {
+        User user = entityCreator.createUser("user1");
+        entityCreator.createOpType("Flag labware", null, OperationTypeFlag.IN_PLACE);
+        Sample sample = entityCreator.createSample(null, null);
+        Sample sample2 = entityCreator.createSample(sample.getTissue(), null);
+        LabwareType lt = entityCreator.createLabwareType("lt", 1, 1);
+        Labware lw1 = entityCreator.createLabware("STAN-1", lt, sample);
+        tester.setUser(user);
+        String mutation = tester.readGraphQL("flaglabware.graphql");
+        Object response1 = tester.post(mutation.replace("[BC]", lw1.getBarcode())
+                .replace("[DESC]", "Alpha"));
+        Integer op1Id = chainGet(response1, "data", "flagLabware", "operations", 0, "id");
+        assertNotNull(op1Id);
+
+        OperationType ot = entityCreator.createOpType("ot", null);
+
+        Labware lw2 = createOp(lw1, lt, ot, user, sample2, "STAN-2");
+        Object response2 = tester.post(mutation.replace("[BC]", lw2.getBarcode())
+                .replace("[DESC]", "Beta"));
+        Integer op2Id = chainGet(response2, "data", "flagLabware", "operations", 0, "id");
+        assertNotNull(op2Id);
+
+        createOp(lw2, lt, ot, user, sample2, "STAN-3");
+        testLookUpFlags();
+
+    }
+
+    private Labware createOp(Labware source, LabwareType lt, OperationType ot, User user, Sample sample, String barcode) {
+        Labware lw = entityCreator.createLabware(barcode, lt, sample);
+        entityCreator.simpleOp(ot, user, source, lw);
+        return lw;
+    }
+
+    private void testLookUpFlags() throws Exception {
+        String query = tester.readGraphQL("lookupflags.graphql");
+        Object response = tester.post(query);
+        List<Map<String, ?>> lfds = chainGet(response, "data", "labwareFlagDetails");
+        assertThat(lfds).hasSize(2);
+        Map<String, ?> lfd1 = lfds.stream()
+                .filter(d -> d.get("barcode").equals("STAN-1"))
+                .findAny()
+                .orElseThrow();
+        Map<String, ?> lfd3 = lfds.stream()
+                .filter(d -> d.get("barcode").equals("STAN-3"))
+                .findAny()
+                .orElseThrow();
+
+        List<Map<String, String>> flags1 = chainGet(lfd1, "flags");
+        assertThat(flags1).containsExactly(Map.of("barcode", "STAN-1", "description", "Alpha"));
+
+        List<Map<String, String>> flags3 = chainGet(lfd3, "flags");
+        assertThat(flags3).containsExactlyInAnyOrder(
+                Map.of("barcode", "STAN-1", "description", "Alpha"),
+                Map.of("barcode", "STAN-2", "description", "Beta")
+        );
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLabwareFlags.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLabwareFlags.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
 
@@ -89,5 +90,10 @@ public class TestLabwareFlags {
                 Map.of("barcode", "STAN-1", "description", "Alpha"),
                 Map.of("barcode", "STAN-2", "description", "Beta")
         );
+
+        query = tester.readGraphQL("labwareflagged.graphql");
+        response = tester.post(query);
+        assertEquals("STAN-1", chainGet(response, "data", "labwareFlagged", "barcode"));
+        assertEquals(Boolean.TRUE, chainGet(response, "data", "labwareFlagged", "flagged"));
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/flag/TestFlagLabwareService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/flag/TestFlagLabwareService.java
@@ -1,0 +1,156 @@
+package uk.ac.sanger.sccp.stan.service.flag;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.FlagLabwareRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.OperationService;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.assertProblem;
+import static uk.ac.sanger.sccp.stan.Matchers.assertValidationException;
+
+/**
+ * Tests {@link FlagLabwareServiceImp}
+ */
+class TestFlagLabwareService {
+    @Mock
+    private OperationService mockOpService;
+
+    @Mock
+    private LabwareFlagRepo mockFlagRepo;
+    @Mock
+    private LabwareRepo mockLwRepo;
+    @Mock
+    private OperationTypeRepo mockOpTypeRepo;
+
+    @InjectMocks
+    private FlagLabwareServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @Test
+    void testRecord_noRequest() {
+        User user = EntityFactory.getUser();
+        assertValidationException(() -> service.record(user, null),
+                List.of("No request supplied."));
+        verify(service, never()).create(any(), any(), any(), any());
+    }
+
+    @Test
+    void testRecord_valid() {
+        User user = EntityFactory.getUser();
+        Labware lw = EntityFactory.getTube();
+        String desc = "  Alpha beta   gamma.  ";
+        when(mockLwRepo.findByBarcode(lw.getBarcode())).thenReturn(Optional.of(lw));
+        final Integer flagId = 500;
+        when(mockFlagRepo.save(any())).then(invocation -> {
+            LabwareFlag flag = invocation.getArgument(0);
+            flag.setId(flagId);
+            return flag;
+        });
+        OperationType opType = EntityFactory.makeOperationType("Flag labware", null, OperationTypeFlag.IN_PLACE);
+
+        when(mockOpTypeRepo.findByName(opType.getName())).thenReturn(Optional.of(opType));
+
+        OperationResult opres = new OperationResult(List.of(new Operation()), List.of(lw));
+        doReturn(opres).when(service).create(any(), any(), any(), any());
+
+        assertSame(opres, service.record(user, new FlagLabwareRequest(lw.getBarcode(), desc)));
+
+        verify(service).loadLabware(any(), eq(lw.getBarcode()));
+        verify(service).checkDescription(any(), eq(desc));
+        verify(service).loadOpType(any());
+        verify(service).create(user, opType, lw, "Alpha beta gamma.");
+    }
+
+    @Test
+    void testRecord_invalid() {
+        when(mockLwRepo.findByBarcode(any())).thenReturn(Optional.empty());
+        when(mockOpTypeRepo.findByName(any())).thenReturn(Optional.empty());
+
+        assertValidationException(() -> service.record(null, new FlagLabwareRequest("STAN-404", null)),
+                List.of("No user specified.", "Unknown labware barcode: \"STAN-404\"", "Missing flag description.",
+                        "Flag labware operation type is missing."));
+
+        verify(service).loadLabware(any(), eq("STAN-404"));
+        verify(service).checkDescription(any(), isNull());
+        verify(service).loadOpType(any());
+        verify(service, never()).create(any(), any(), any(), any());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"STAN-1, true,",
+            "STAN-404, false, Unknown labware barcode: \"STAN-404\"",
+            ", false, No labware barcode supplied.",
+    })
+    void testLoadLabware(String barcode, boolean exists, String expectedProblem) {
+        Labware lw = exists ? EntityFactory.getTube() : null;
+        if (barcode!=null && !barcode.isEmpty()) {
+            when(mockLwRepo.findByBarcode(barcode)).thenReturn(Optional.ofNullable(lw));
+        }
+
+        final List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        assertSame(lw, service.loadLabware(problems, barcode));
+        assertProblem(problems, expectedProblem);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", , Missing flag description.",
+            "'',,Missing flag description.",
+            "'   alpha  beta ', alpha beta,",
+            "long,,Description too long.",
+            "max,,,",
+    })
+    void testCheckDescription(String input, String expectedOutput, String expectedProblem) {
+        int maxLen = FlagLabwareServiceImp.MAX_DESCRIPTION_LEN;
+        if ("long".equals(input)) {
+            input = "X".repeat(maxLen+1);
+            expectedOutput = input;
+        } else if ("max".equals(input)) {
+            input = "X".repeat(maxLen);
+            expectedOutput = input;
+        }
+        final List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        assertEquals(expectedOutput, service.checkDescription(problems, input));
+        assertProblem(problems, expectedProblem);
+    }
+
+    @Test
+    void testCreate() {
+        Labware lw = EntityFactory.getTube();
+        User user = EntityFactory.getUser();
+        String desc = "Alpha beta";
+        OperationType opType = EntityFactory.makeOperationType("Flag labware", null, OperationTypeFlag.IN_PLACE);
+
+        Operation op = new Operation();
+        op.setId(500);
+        when(mockOpService.createOperationInPlace(any(), any(), any(), any(), any())).thenReturn(op);
+
+        assertEquals(new OperationResult(List.of(op), List.of(lw)), service.create(user, opType, lw, desc));
+
+        verify(mockOpService).createOperationInPlace(opType, user, lw, null, null);
+        verify(mockFlagRepo).save(new LabwareFlag(null, lw, desc, user, op.getId()));
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/flag/TestFlagLookupService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/flag/TestFlagLookupService.java
@@ -1,0 +1,213 @@
+package uk.ac.sanger.sccp.stan.service.flag;
+
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareFlagRepo;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+import uk.ac.sanger.sccp.stan.service.flag.FlagLookupServiceImp.OpIdLwId;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.Ancestry;
+import uk.ac.sanger.sccp.stan.service.releasefile.Ancestoriser.SlotSample;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+/** Tests {@link FlagLookupServiceImp} */
+class TestFlagLookupService {
+    @Mock
+    private Ancestoriser mockAncestoriser;
+    @Mock
+    private LabwareFlagRepo mockFlagRepo;
+    @Mock
+    private OperationRepo mockOpRepo;
+
+    @InjectMocks
+    private FlagLookupServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    static List<Labware> getLabware(int number) {
+        if (number < 1) {
+            return List.of();
+        }
+        Labware lw1 = EntityFactory.getTube();
+        Sample sample = lw1.getFirstSlot().getSamples().get(0);
+        LabwareType lt = lw1.getLabwareType();
+        return Stream.concat(Stream.of(lw1), IntStream.range(1, number).mapToObj(i -> EntityFactory.makeLabware(lt, sample)))
+                .collect(toList());
+
+    }
+
+    @Test
+    void testLookUp() {
+        Ancestry mockAncestry = mock(Ancestry.class);
+        doReturn(mockAncestry).when(service).loadAncestry(any());
+        Labware lw1 = EntityFactory.getTube();
+        Sample sam = lw1.getFirstSlot().getSamples().get(0);
+        Labware lw2 = EntityFactory.makeLabware(lw1.getLabwareType(), sam);
+        Labware lw3 = EntityFactory.makeLabware(lw1.getLabwareType(), sam);
+        List<Labware> labware = List.of(lw1, lw2);
+        Set<SlotSample> slotSamples = Stream.of(lw1, lw2, lw3)
+                .map(Labware::getFirstSlot)
+                .map(slot -> new SlotSample(slot, sam))
+                .collect(toSet());
+        when(mockAncestry.keySet()).thenReturn(slotSamples);
+        LabwareFlag flag = new LabwareFlag(100, lw3, "flag alpha", null, 200);
+        Map<SlotSample, List<LabwareFlag>> directFlags = Map.of(new SlotSample(lw3.getFirstSlot(), sam), List.of(flag));
+        doReturn(directFlags).when(service).loadDirectFlags(any());
+
+        doReturn(List.of(flag)).when(service).flagsForLabware(mockAncestry, lw1, directFlags);
+        doReturn(List.of()).when(service).flagsForLabware(mockAncestry, lw2, directFlags);
+
+        UCMap<List<LabwareFlag>> result = service.lookUp(labware);
+        assertEquals(List.of(flag), result.get(lw1.getBarcode()));
+        assertThat(result.get(lw2.getBarcode())).isNullOrEmpty();
+
+        verify(service).loadAncestry(labware);
+        verify(service).loadDirectFlags(slotSamples);
+        verify(service, times(labware.size())).flagsForLabware(any(), any(), any());
+    }
+
+    @Test
+    void testLookUp_noLabware() {
+        assertThat(service.lookUp(List.of())).isEmpty();
+        verify(service, never()).loadAncestry(any());
+    }
+
+    @Test
+    void testLookUp_noFlags() {
+        Ancestry mockAncestry = mock(Ancestry.class);
+        doReturn(mockAncestry).when(service).loadAncestry(any());
+        Labware lw1 = EntityFactory.getTube();
+        Slot slot = lw1.getFirstSlot();
+        Set<SlotSample> slotSamples = Set.of(new SlotSample(slot, slot.getSamples().get(0)));
+        when(mockAncestry.keySet()).thenReturn(slotSamples);
+        doReturn(Map.of()).when(service).loadDirectFlags(any());
+
+        final List<Labware> labware = List.of(lw1);
+        assertThat(service.lookUp(labware)).isEmpty();
+        verify(service).loadAncestry(labware);
+        verify(service).loadDirectFlags(slotSamples);
+        verify(service, never()).flagsForLabware(any(), any(), any());
+    }
+
+    @Test
+    void testLoadAncestry() {
+        List<Labware> labware = getLabware(2);
+        List<SlotSample> expectedSlotSamples = labware.stream()
+                .flatMap(lw -> lw.getSlots().stream())
+                .flatMap(slot -> slot.getSamples().stream().map(sam -> new SlotSample(slot, sam)))
+                .collect(toList());
+        Ancestry ancestry = mock(Ancestry.class);
+        when(mockAncestoriser.findAncestry(any())).thenReturn(ancestry);
+        assertSame(ancestry, service.loadAncestry(labware));
+        verify(mockAncestoriser).findAncestry(expectedSlotSamples);
+    }
+
+    @Test
+    void testLoadDirectFlags() {
+        List<Labware> labware = getLabware(2);
+        List<Integer> lwIds = labware.stream().map(Labware::getId).collect(toList());
+        Set<SlotSample> slotSamples = labware.stream().flatMap(SlotSample::stream).collect(toSet());
+        List<LabwareFlag> flags = List.of(new LabwareFlag(100, labware.get(0), "flag0", null, 200),
+                new LabwareFlag(101, labware.get(0), "flag1", null, 201),
+                new LabwareFlag(102, labware.get(1), "flag2", null, 202));
+        when(mockFlagRepo.findAllByLabwareIdIn(any())).thenReturn(flags);
+        Map<SlotSample, List<LabwareFlag>> ssFlagMap = Map.of(slotSamples.iterator().next(), flags);
+        doReturn(ssFlagMap).when(service).makeSsFlagMap(any(), any());
+
+        assertSame(ssFlagMap, service.loadDirectFlags(slotSamples));
+
+        verify(mockFlagRepo).findAllByLabwareIdIn(new HashSet<>(lwIds));
+        verify(service).makeSsFlagMap(Set.of(200,201,202),
+                Map.of(new OpIdLwId(200, lwIds.get(0)), flags.subList(0,1),
+                        new OpIdLwId(201, lwIds.get(0)), flags.subList(1,2),
+                        new OpIdLwId(202, lwIds.get(1)), flags.subList(2,3)));
+    }
+
+    @Test
+    void testLoadDirectFlags_noFlags() {
+        Labware lw = EntityFactory.getTube();
+        Slot slot = lw.getFirstSlot();
+        Set<SlotSample> slotSamples = Set.of(new SlotSample(slot, slot.getSamples().get(0)));
+        when(mockFlagRepo.findAllByLabwareIdIn(any())).thenReturn(List.of());
+        assertThat(service.loadDirectFlags(slotSamples)).isEmpty();
+        verify(mockFlagRepo).findAllByLabwareIdIn(Set.of(lw.getId()));
+    }
+
+    @Test
+    void testMakeSsFlagMap() {
+        List<Labware> labware = getLabware(2);
+        List<SlotSample> slotSamples = labware.stream()
+                .map(Labware::getFirstSlot)
+                .map(slot -> new SlotSample(slot, slot.getSamples().get(0)))
+                .collect(toList());
+        List<Operation> ops = labware.stream()
+                .map(List::of)
+                .map(lwList -> EntityFactory.makeOpForLabware(null, lwList, lwList))
+                .collect(toList());
+        when(mockOpRepo.findAllById(any())).thenReturn(ops);
+        List<LabwareFlag> flags = IntStream.range(0, labware.size())
+                .mapToObj(i -> new LabwareFlag(100+i, labware.get(i), "flag"+i, null, ops.get(i).getId()))
+                .collect(toList());
+        Map<OpIdLwId, List<LabwareFlag>> opIdLwIdMap = flags.stream()
+                .collect(toMap(flag -> new OpIdLwId(flag.getOperationId(), flag.getLabware().getId()), List::of));
+        Set<Integer> opIds = ops.stream().map(Operation::getId).collect(toSet());
+
+        Map<SlotSample, List<LabwareFlag>> expected = IntStream.range(0, labware.size())
+                .boxed()
+                .collect(toMap(slotSamples::get, i -> flags.subList(i, i+1)));
+
+        assertEquals(expected, service.makeSsFlagMap(opIds, opIdLwIdMap));
+
+        verify(mockOpRepo).findAllById(opIds);
+    }
+
+    @Test
+    void testFlagsForLabware() {
+        Ancestry ancestry = mock(Ancestry.class);
+        LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Sample sam1 = EntityFactory.getSample();
+        Sample sam2 = new Sample(sam1.getId()+1, null, sam1.getTissue(), sam1.getBioState());
+        Labware lw = EntityFactory.makeLabware(lt, sam1, sam2);
+        List<SlotSample> lwSs = SlotSample.stream(lw).collect(toList());
+        Labware other = EntityFactory.makeLabware(lt, sam1, sam2);
+        SlotSample ss1 = new SlotSample(other.getFirstSlot(), sam1);
+        SlotSample ss2 = new SlotSample(other.getSlots().get(1), sam2);
+        SlotSample ss3 = new SlotSample(other.getFirstSlot(), sam2);
+        List<LabwareFlag> flags = IntStream.range(0,4)
+                .mapToObj(i -> new LabwareFlag(10+i, null, null, null, null))
+                .collect(toList());
+        Map<SlotSample, List<LabwareFlag>> ssFlags = Map.of(
+                ss1, List.of(flags.get(0), flags.get(1)),
+                ss2, List.of(flags.get(2)),
+                ss3, List.of(flags.get(3))
+        );
+
+        when(ancestry.ancestors(lwSs.get(0))).thenReturn(Set.of(lwSs.get(0), ss1));
+        when(ancestry.ancestors(lwSs.get(1))).thenReturn(Set.of(lwSs.get(1), ss2));
+
+        assertThat(service.flagsForLabware(ancestry, lw, ssFlags)).containsExactlyInAnyOrderElementsOf(flags.subList(0, 3));
+    }
+}

--- a/src/test/resources/graphql/flaglabware.graphql
+++ b/src/test/resources/graphql/flaglabware.graphql
@@ -1,0 +1,8 @@
+mutation {
+    flagLabware(request: {
+        barcode: "[BC]"
+        description: "[DESC]"
+    }) {
+        operations { id }
+    }
+}

--- a/src/test/resources/graphql/labwareflagged.graphql
+++ b/src/test/resources/graphql/labwareflagged.graphql
@@ -1,0 +1,6 @@
+query {
+    labwareFlagged(barcode: "STAN-1") {
+        barcode
+        flagged
+    }
+}

--- a/src/test/resources/graphql/lookupflags.graphql
+++ b/src/test/resources/graphql/lookupflags.graphql
@@ -1,0 +1,9 @@
+query {
+    labwareFlagDetails(barcodes: ["STAN-1", "STAN-3"]) {
+        barcode
+        flags {
+            barcode
+            description
+        }
+    }
+}


### PR DESCRIPTION
For #310 
You can flag a labware with a description of the issue. A "Flag labware" op will be recorded against the labware.
You can look up flags relevant to given labware. Relevant flags means all flags occurring on the given labware or its ancestors.
