### PR TITLE
x1125 LibraryPrepRequest

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -102,6 +102,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
     final OrientationService orientationService;
     final SSStudyService ssStudyService;
     final ReactivateService reactivateService;
+    final LibraryPrepService libraryPrepService;
     final UserAdminService userAdminService;
 
     @Autowired
@@ -132,9 +133,9 @@ public class GraphQLMutation extends BaseGraphQLResource {
                            SampleProcessingService sampleProcessingService, SolutionTransferService solutionTransferService,
                            ParaffinProcessingService paraffinProcessingService, OpWithSlotCommentsService opWithSlotCommentsService,
                            ProbeService probeService, CompletionService completionService, AnalyserService analyserService,
-                           FlagLabwareService flagLabwareService, QCLabwareService qcLabwareService,
-                           OrientationService orientationService, SSStudyService ssStudyService,
-                           ReactivateService reactivateService,
+                           FlagLabwareService flagLabwareService,
+                           QCLabwareService qcLabwareService, OrientationService orientationService, SSStudyService ssStudyService,
+                           ReactivateService reactivateService, LibraryPrepService libraryPrepService,
                            UserAdminService userAdminService) {
         super(objectMapper, authComp, userRepo);
         this.ldapService = ldapService;
@@ -194,6 +195,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         this.orientationService = orientationService;
         this.ssStudyService = ssStudyService;
         this.reactivateService = reactivateService;
+        this.libraryPrepService = libraryPrepService;
         this.userAdminService = userAdminService;
     }
 
@@ -892,6 +894,15 @@ public class GraphQLMutation extends BaseGraphQLResource {
             List<ReactivateLabware> items = arg(dfe, "items", new TypeReference<>() {});
             logRequest("Reactivate labware", user, items);
             return reactivateService.reactivate(user, items);
+        };
+    }
+
+    public DataFetcher<OperationResult> libraryPrep() {
+        return dfe -> {
+            User user = checkUser(dfe, User.Role.normal);
+            LibraryPrepRequest request = arg(dfe, "request", LibraryPrepRequest.class);
+            logRequest("Library prep", user, request);
+            return libraryPrepService.perform(user, request);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -217,6 +217,7 @@ public class GraphQLProvider {
                         .dataFetcher("recordQCLabware", transact(graphQLMutation.recordQcLabware()))
                         .dataFetcher("recordOrientationQC", transact(graphQLMutation.recordOrientationQC()))
                         .dataFetcher("reactivateLabware", transact(graphQLMutation.reactivateLabware()))
+                        .dataFetcher("libraryPrep", graphQLMutation.libraryPrep()) // internal transaction
 
                         .dataFetcher("addUser", transact(graphQLMutation.addUser()))
                         .dataFetcher("setUserRole", transact(graphQLMutation.setUserRole()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/LibraryPrepRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/LibraryPrepRequest.java
@@ -1,0 +1,119 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.stan.request.ReagentTransferRequest.ReagentTransfer;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyDestination;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopySource;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A request to record transfer, dual index and amplification ops.
+ * @author dr6
+ */
+public class LibraryPrepRequest {
+    private String workNumber;
+    private List<SlotCopySource> sources;
+    private SlotCopyDestination destination;
+    private List<ReagentTransfer> reagentTransfers;
+    private String reagentPlateType;
+    private List<SlotMeasurementRequest> slotMeasurements;
+
+    /**
+     * The work number to associate with these operations.
+     */
+    public String getWorkNumber() {
+        return this.workNumber;
+    }
+
+    public void setWorkNumber(String workNumber) {
+        this.workNumber = workNumber;
+    }
+
+    /**
+     * The source labware for this request.
+     */
+    public List<SlotCopySource> getSources() {
+        return this.sources;
+    }
+
+    public void setSources(List<SlotCopySource> sources) {
+        this.sources = sources;
+    }
+
+    /**
+     * The one destination labware for this request, and the description of what is transferred into it.
+     */
+    public SlotCopyDestination getDestination() {
+        return this.destination;
+    }
+
+    public void setDestination(SlotCopyDestination destination) {
+        this.destination = destination;
+    }
+
+    /**
+     * The transfers from aliquot slots to destination slots.
+     */
+    public List<ReagentTransfer> getReagentTransfers() {
+        return this.reagentTransfers;
+    }
+
+    public void setReagentTransfers(List<ReagentTransfer> reagentTransfers) {
+        this.reagentTransfers = reagentTransfers;
+    }
+
+    /**
+     * The type of reagent plate involved.
+     */
+    public String getReagentPlateType() {
+        return this.reagentPlateType;
+    }
+
+    public void setReagentPlateType(String reagentPlateType) {
+        this.reagentPlateType = reagentPlateType;
+    }
+
+    /**
+     * The measurement to record on slots in the destination.
+     */
+    public List<SlotMeasurementRequest> getSlotMeasurements() {
+        return this.slotMeasurements;
+    }
+
+    public void setSlotMeasurements(List<SlotMeasurementRequest> slotMeasurements) {
+        this.slotMeasurements = slotMeasurements;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LibraryPrepRequest that = (LibraryPrepRequest) o;
+        return (Objects.equals(this.workNumber, that.workNumber)
+                && Objects.equals(this.sources, that.sources)
+                && Objects.equals(this.destination, that.destination)
+                && Objects.equals(this.reagentTransfers, that.reagentTransfers)
+                && Objects.equals(this.reagentPlateType, that.reagentPlateType)
+                && Objects.equals(this.slotMeasurements, that.slotMeasurements));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(workNumber, sources, destination, reagentTransfers, reagentPlateType, slotMeasurements);
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe(this)
+                .add("workNumber", workNumber)
+                .add("sources", sources)
+                .add("destination", destination)
+                .add("reagentTransfers", reagentTransfers)
+                .add("reagentPlateType", reagentPlateType)
+                .add("slotMeasurements", slotMeasurements)
+                .reprStringValues()
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepService.java
@@ -1,0 +1,20 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.request.LibraryPrepRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+
+/**
+ * Service for performing library prep, which comprises Transfer, Dual index and Amplification ops.
+ */
+public interface LibraryPrepService {
+    /**
+     * Validates and records the request.
+     * This method internally executes a transaction and may discard labware from storage.
+     * @param user the user responsible
+     * @param request the request to perform
+     * @return the destination labware and operations recorded
+     * @exception ValidationException if the request fails validation
+     */
+    OperationResult perform(User user, LibraryPrepRequest request) throws ValidationException;
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepServiceImp.java
@@ -1,0 +1,122 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.Transactor;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.model.reagentplate.ReagentPlate;
+import uk.ac.sanger.sccp.stan.request.*;
+import uk.ac.sanger.sccp.stan.service.store.StoreService;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+/**
+ * @author dr6
+ */
+@Service
+public class LibraryPrepServiceImp implements LibraryPrepService {
+    private final SlotCopyService slotCopyService;
+    private final ReagentTransferService reagentTransferService;
+    private final OpWithSlotMeasurementsService opWithSlotMeasurementsService;
+    private final StoreService storeService;
+    private final LibraryPrepValidationService valService;
+    private final Transactor transactor;
+
+    @Autowired
+    public LibraryPrepServiceImp(SlotCopyService slotCopyService, ReagentTransferService reagentTransferService,
+                                 OpWithSlotMeasurementsService opWithSlotMeasurementsService, StoreService storeService,
+                                 LibraryPrepValidationService valService,
+                                 Transactor transactor) {
+        this.slotCopyService = slotCopyService;
+        this.reagentTransferService = reagentTransferService;
+        this.opWithSlotMeasurementsService = opWithSlotMeasurementsService;
+        this.storeService = storeService;
+        this.valService = valService;
+        this.transactor = transactor;
+    }
+
+    @Override
+    public OperationResult perform(User user, LibraryPrepRequest request) throws ValidationException {
+        Collection<String> problems = new LinkedHashSet<>();
+        if (user==null) {
+            problems.add("No user supplied.");
+        }
+        if (request==null) {
+            problems.add("No request supplied.");
+            throw new ValidationException(problems);
+        }
+        RequestData data = new RequestData(request, user, problems);
+
+        OperationResult result = transactor.transact("LibraryPrep",
+                () -> performInsideTransaction(data));
+        if (!result.getOperations().isEmpty() && !data.barcodesToUnstore.isEmpty()) {
+            storeService.discardStorage(user, data.barcodesToUnstore);
+        }
+        return result;
+    }
+
+    /**
+     * This should be called inside a transaction.
+     * Validates the request, and either executes it, or throws a validation exception.
+     * Further information loaded as part of the validation is stored in the {@code data} parameter.
+     * @param data the data about the request
+     * @return the destination labware and operations recorded
+     * @exception ValidationException if validation fails
+     */
+    public OperationResult performInsideTransaction(RequestData data) throws ValidationException {
+        valService.validate(data);
+        if (!data.problems.isEmpty()) {
+            throw new ValidationException(data.problems);
+        }
+        return record(data);
+    }
+
+    /**
+     * Records the requested operations. This is called after successful validation.
+     * @param data the data about the request, including the information loaded during validation.
+     * @return the destination labware and operations recorded
+     */
+    public OperationResult record(RequestData data) {
+        OperationResult scResult = slotCopyService.record(data.user, data.slotCopyData, data.barcodesToUnstore);
+        data.destination = scResult.getLabware().getFirst();
+        OperationResult rtResult = reagentTransferService.record(data.user, data.reagentOpType, data.work, data.request.getReagentTransfers(),
+                data.reagentPlates, data.destination, data.reagentPlateType);
+        data.destination = rtResult.getLabware().getFirst();
+        OperationResult ampResult = opWithSlotMeasurementsService.execute(data.user, data.destination, data.ampOpType,
+                data.work, data.comments, data.sanitisedMeasurements);
+        data.destination = ampResult.getLabware().getFirst();
+        List<Operation> ops = Stream.of(scResult, rtResult, ampResult)
+                .flatMap(r -> r.getOperations().stream())
+                .toList();
+        return new OperationResult(ops, List.of(data.destination));
+    }
+
+    /**
+     * Structure to contain information about the request.
+     * New data is stored in this object during validation and execution of the request.
+     */
+    public static class RequestData {
+        final LibraryPrepRequest request;
+        final User user;
+        final Collection<String> problems;
+        SlotCopyValidationService.Data slotCopyData;
+        String reagentPlateType;
+        OperationType reagentOpType, ampOpType;
+        List<Comment> comments;
+        Work work;
+        Labware destination;
+        UCMap<ReagentPlate> reagentPlates;
+        LabwareType destLabwareType;
+        Set<String> barcodesToUnstore;
+        List<SlotMeasurementRequest> sanitisedMeasurements;
+
+        public RequestData(LibraryPrepRequest request, User user, Collection<String> problems) {
+            this.request = request;
+            this.user = user;
+            this.problems = problems;
+            this.barcodesToUnstore = new HashSet<>();
+        }
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepValidationService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepValidationService.java
@@ -1,0 +1,10 @@
+package uk.ac.sanger.sccp.stan.service;
+
+public interface LibraryPrepValidationService {
+    /**
+     * Performs validations for all the operations that will be performed for library prep.
+     * Problems are recorded in the data's {@code problems} field.
+     * @param data the request data
+     */
+    void validate(LibraryPrepServiceImp.RequestData data);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepValidationServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LibraryPrepValidationServiceImp.java
@@ -1,0 +1,96 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.Address;
+import uk.ac.sanger.sccp.stan.request.LibraryPrepRequest;
+import uk.ac.sanger.sccp.stan.request.ReagentTransferRequest.ReagentTransfer;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyContent;
+import uk.ac.sanger.sccp.stan.service.LibraryPrepServiceImp.RequestData;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toSet;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+
+/**
+ * @author dr6
+ */
+@Service
+public class LibraryPrepValidationServiceImp implements LibraryPrepValidationService {
+    private final SlotCopyValidationService scValService;
+    private final ReagentTransferValidatorService rtValService;
+    private final ReagentTransferService rtService;
+    private final OpWithSlotMeasurementsService owsmService;
+
+    @Autowired
+    public LibraryPrepValidationServiceImp(SlotCopyValidationService scValService,
+                                           ReagentTransferValidatorService rtValService,
+                                           ReagentTransferService rtService,
+                                           OpWithSlotMeasurementsService owsmService) {
+        this.scValService = scValService;
+        this.rtValService = rtValService;
+        this.rtService = rtService;
+        this.owsmService = owsmService;
+    }
+
+    @Override
+    public void validate(RequestData data) {
+        scValidate(data);
+        rtValidate(data);
+        owsmValidate(data);
+    }
+
+    /**
+     * Validates the slotcopy part of the request and updates the data.
+     * @param data data related to the request
+     */
+    public void scValidate(RequestData data) {
+        var request = data.request;
+
+        SlotCopyRequest scRequest = new SlotCopyRequest("Transfer", request.getWorkNumber(), request.getSources(),
+                List.of(request.getDestination()));
+        data.slotCopyData = scValService.validateRequest(data.user, scRequest);
+        if (!nullOrEmpty(data.slotCopyData.destLabware)) {
+            data.destination = data.slotCopyData.destLabware.values().iterator().next();
+            data.destLabwareType = data.destination.getLabwareType();
+        } else {
+            data.destLabwareType = data.slotCopyData.lwTypes.get(request.getDestination().getLabwareType());
+        }
+        data.work = data.slotCopyData.work;
+        data.problems.addAll(data.slotCopyData.problems);
+    }
+
+    /**
+     * Validates the reagent transfer part of the request and updates the data.
+     * @param data data related to the request
+     */
+    public void rtValidate(RequestData data) {
+        LibraryPrepRequest request = data.request;
+        final List<ReagentTransfer> reagentTransfers = request.getReagentTransfers();
+        data.reagentOpType = rtService.loadOpType(data.problems, "Dual index plate");
+        data.reagentPlates = rtService.loadReagentPlates(reagentTransfers);
+        data.reagentPlateType = rtService.checkPlateType(data.problems, data.reagentPlates.values(), request.getReagentPlateType());
+        rtValService.validateTransfers(data.problems, reagentTransfers, data.reagentPlates, data.destLabwareType);
+    }
+
+    /**
+     * Validates the Amplification part of the request and updates the data.
+     * @param data data related to the request
+     */
+    public void owsmValidate(RequestData data) {
+        if (data.destLabwareType==null) {
+            return;
+        }
+        Set<Address> filledAddresses = data.request.getDestination().getContents().stream()
+                .map(SlotCopyContent::getDestinationAddress)
+                .filter(Objects::nonNull)
+                .collect(toSet());
+        owsmService.validateAddresses(data.problems, data.destLabwareType, filledAddresses, data.request.getSlotMeasurements());
+        data.ampOpType = owsmService.loadOpType(data.problems, "Amplification");
+        data.comments = owsmService.validateComments(data.problems, data.request.getSlotMeasurements());
+        data.sanitisedMeasurements = owsmService.sanitiseMeasurements(data.problems, data.ampOpType, data.request.getSlotMeasurements());
+        owsmService.checkForDupeMeasurements(data.problems, data.sanitisedMeasurements);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/OpWithSlotMeasurementsService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/OpWithSlotMeasurementsService.java
@@ -1,8 +1,9 @@
 package uk.ac.sanger.sccp.stan.service;
 
-import uk.ac.sanger.sccp.stan.model.User;
-import uk.ac.sanger.sccp.stan.request.OpWithSlotMeasurementsRequest;
-import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.request.*;
+
+import java.util.*;
 
 /**
  * Service for performing an operation recording measurements in slots.
@@ -17,4 +18,56 @@ public interface OpWithSlotMeasurementsService {
      * @exception ValidationException if the validation fails
      */
     OperationResult perform(User user, OpWithSlotMeasurementsRequest request) throws ValidationException;
+
+    /**
+     * Loads the op type and checks that it is in-place
+     * @param problems receptacle for problems found
+     * @param opTypeName the name of the operation to record
+     * @return the op type loaded
+     */
+    OperationType loadOpType(Collection<String> problems, String opTypeName);
+
+    void validateAddresses(Collection<String> problems, LabwareType lt, Set<Address> filledSlotAddresses,
+                           List<SlotMeasurementRequest> slotMeasurements);
+
+    /**
+     * Checks for problems with comment ids, if any.
+     * @param problems receptacle for problems found
+     * @param sms the slot measurement requests
+     * @return the indicated comments
+     */
+    List<Comment> validateComments(Collection<String> problems, Collection<SlotMeasurementRequest> sms);
+
+    /**
+     * Validates and sanitises measurement names and values.
+     * Problems include missing names, missing values, invalid names (for the op type), and whatever problems are
+     * found when sanitising the measurement value.
+     * @param problems receptacle for problems found
+     * @param opType the op type requested
+     * @param slotMeasurements the requested measurements
+     * @return the validated measurements
+     */
+    List<SlotMeasurementRequest> sanitiseMeasurements(Collection<String> problems, OperationType opType,
+                                                      Collection<SlotMeasurementRequest> slotMeasurements);
+
+    /**
+     * Checks for occurrences where the same measurement name is requested in the same address.
+     * The measurement names should already be sanitised so that they are easy to identify.
+     * @param problems receptacle for problems found
+     * @param smrs the measurement requests
+     */
+    void checkForDupeMeasurements(Collection<String> problems, Collection<SlotMeasurementRequest> smrs);
+
+    /**
+     * Executes the request. Records the op; links it to the given work (if any); records the measurements (if any)
+     * @param user the user responsible for the request
+     * @param lw the labware to record the operation and measurements on
+     * @param opType the type of op to record
+     * @param work the work to link to the op (if any)
+     * @param sanitisedMeasurements the specification of what measurements to record
+     * @return the op and labware
+     */
+    OperationResult execute(User user, Labware lw, OperationType opType, Work work,
+                            Collection<Comment> comments,
+                            Collection<SlotMeasurementRequest> sanitisedMeasurements);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ReagentTransferService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ReagentTransferService.java
@@ -1,8 +1,12 @@
 package uk.ac.sanger.sccp.stan.service;
 
-import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.model.reagentplate.ReagentPlate;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
 import uk.ac.sanger.sccp.stan.request.ReagentTransferRequest;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.Collection;
 
 /**
  * Service for recording a reagent transfer operation
@@ -17,4 +21,44 @@ public interface ReagentTransferService {
      * @exception ValidationException the request validation failed
      */
     OperationResult perform(User user, ReagentTransferRequest request) throws ValidationException;
+
+    /**
+     * Loads and checks the operation type
+     * @param problems receptacle for problems
+     * @param opName the name of the op type
+     * @return the operation type loaded, if any
+     */
+    OperationType loadOpType(Collection<String> problems, String opName);
+
+    /**
+     * Loads any reagent plates already in the database matching any of the specified barcodes.
+     * Unrecognised or missing barcodes are omitted without error.
+     * @param transfers reagent transfers, specifying reagent plate barcodes
+     * @return a map of barcode to reagent plates
+     */
+    UCMap<ReagentPlate> loadReagentPlates(Collection<ReagentTransferRequest.ReagentTransfer> transfers);
+
+    /**
+     * Checks the given plate type is suitable.
+     * It must be equal to either {@link ReagentPlate#TYPE_FFPE} or {@link ReagentPlate#TYPE_FRESH_FROZEN}.
+     * It must match existing plates.
+     * @param problems receptacle for problems
+     * @param existingPlates the existing reagent plates (if any) referred to by the request
+     * @param plateTypeArg the plate type as given in the request
+     */
+    String checkPlateType(Collection<String> problems, Collection<ReagentPlate> existingPlates, String plateTypeArg);
+
+    /**
+     * Records the specified transfers.
+     * @param user the user responsible
+     * @param opType the type of operation to record
+     * @param work the work number (if any) to link the operation with
+     * @param transfers the transfers to make
+     * @param reagentPlates the reagent plates that already exist
+     * @param lw the destination labware
+     * @param plateType the plate type for new plates
+     * @return the operations and affected labware
+     */
+    OperationResult record(User user, OperationType opType, Work work, Collection<ReagentTransferRequest.ReagentTransfer> transfers,
+                           UCMap<ReagentPlate> reagentPlates, Labware lw, String plateType);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ReagentTransferValidatorService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ReagentTransferValidatorService.java
@@ -1,0 +1,29 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.LabwareType;
+import uk.ac.sanger.sccp.stan.model.reagentplate.ReagentPlate;
+import uk.ac.sanger.sccp.stan.request.ReagentTransferRequest.ReagentTransfer;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.Collection;
+
+/**
+ * Validates the reagent transfers for a reagent transfer op
+ */
+public interface ReagentTransferValidatorService {
+    /**
+     * Checks for problems with the specified transfers. Problems include:<ul>
+     * <li>invalid or missing reagent plate barcodes</li>
+     * <li>invalid or missing reagent slot addresses</li>
+     * <li>invalid or missing destination slot addresses</li>
+     * <li>reagent slot addresses already used in a previous operation</li>
+     * <li>reagent slot addresses given multiple times in this request</li>
+     * </ul>
+     * @param problems receptacle for problems
+     * @param transfers the transfers to validate
+     * @param reagentPlates the existing reagent plates
+     * @param lt the destination labware type, if known
+     */
+    void validateTransfers(Collection<String> problems, Collection<ReagentTransfer> transfers,
+                           UCMap<ReagentPlate> reagentPlates, LabwareType lt);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ReagentTransferValidatorServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ReagentTransferValidatorServiceImp.java
@@ -1,0 +1,140 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.Address;
+import uk.ac.sanger.sccp.stan.model.LabwareType;
+import uk.ac.sanger.sccp.stan.model.reagentplate.ReagentPlate;
+import uk.ac.sanger.sccp.stan.request.ReagentTransferRequest;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.pluralise;
+
+/**
+ * @author dr6
+ */
+@Service
+public class ReagentTransferValidatorServiceImp implements ReagentTransferValidatorService {
+    private final Validator<String> reagentPlateBarcodeValidator;
+
+    @Autowired
+    public ReagentTransferValidatorServiceImp(
+            @Qualifier("reagentPlateBarcodeValidator") Validator<String> reagentPlateBarcodeValidator
+    ) {
+        this.reagentPlateBarcodeValidator = reagentPlateBarcodeValidator;
+    }
+
+    @Override
+    public void validateTransfers(Collection<String> problems, Collection<ReagentTransferRequest.ReagentTransfer> transfers,
+                                  UCMap<ReagentPlate> reagentPlates, LabwareType lt) {
+        if (transfers==null || transfers.isEmpty()) {
+            problems.add("No transfers specified.");
+            return;
+        }
+        boolean missingPlateBarcodes = false;
+        boolean missingReagentAddresses = false;
+        boolean missingDestAddresses = false;
+        Set<ReagentTransferServiceImp.RSlot> seenReagentSlots = new HashSet<>();
+        Set<ReagentTransferServiceImp.RSlot> invalidReagentSlots = new LinkedHashSet<>();
+        Set<ReagentTransferServiceImp.RSlot> alreadyUsedReagentSlots = new LinkedHashSet<>();
+        Set<ReagentTransferServiceImp.RSlot> repeatedReagentSlots = new LinkedHashSet<>();
+        Set<Address> invalidDestSlots = new LinkedHashSet<>();
+        Set<String> newBarcodesSeen = new HashSet<>();
+
+        for (var transfer : transfers) {
+            String barcode = transfer.getReagentPlateBarcode();
+            Address rAddress = transfer.getReagentSlotAddress();
+            Address dAddress = transfer.getDestinationAddress();
+            ReagentPlate plate;
+            if (barcode==null || barcode.isEmpty()) {
+                missingPlateBarcodes = true;
+                plate = null;
+                barcode = null;
+            } else {
+                plate = reagentPlates.get(barcode);
+                if (plate==null && newBarcodesSeen.add(barcode.toUpperCase())) {
+                    reagentPlateBarcodeValidator.validate(barcode, problems::add);
+                }
+            }
+            if (rAddress==null) {
+                missingReagentAddresses = true;
+            } else if (barcode!=null) {
+                checkReagentSlotAddress(invalidReagentSlots, alreadyUsedReagentSlots, repeatedReagentSlots,
+                        seenReagentSlots, barcode, rAddress, plate);
+            }
+            if (dAddress==null) {
+                missingDestAddresses = true;
+            } else if (lt!=null) {
+                if (lt.indexOf(dAddress) < 0) {
+                    invalidDestSlots.add(dAddress);
+                }
+            }
+        }
+
+        if (missingPlateBarcodes) {
+            problems.add("Missing reagent plate barcode for transfer.");
+        }
+        if (missingReagentAddresses) {
+            problems.add("Missing reagent slot address for transfer.");
+        }
+        if (missingDestAddresses) {
+            problems.add("Missing destination slot address for transfer.");
+        }
+        describeProblem(problems, "Invalid reagent slot{s} specified: ", invalidReagentSlots);
+        describeProblem(problems, "Invalid destination slot{s} specified: ", invalidDestSlots);
+        describeProblem(problems, "Reagent slot{s} already used: ", alreadyUsedReagentSlots);
+        describeProblem(problems, "Repeated reagent slot{s} specified: ", repeatedReagentSlots);
+    }
+
+    /**
+     * Checks for problems with the reagent slot address
+     * @param invalidReagentSlots receptacle for invalid reagent slots found
+     * @param alreadyUsedReagentSlots receptacle for already used reagent slots found
+     * @param repeatedReagentSlots receptacle for repeated reagent slots found
+     * @param seenRSlots running collection of reagent slots specified, to check for dupes
+     * @param barcode the reagent plate barcode specified
+     * @param rAddress the reagent slot address specified
+     * @param plate the existing reagent plate (if any) matching the given barcode
+     */
+    private void checkReagentSlotAddress(Set<ReagentTransferServiceImp.RSlot> invalidReagentSlots, Set<ReagentTransferServiceImp.RSlot> alreadyUsedReagentSlots,
+                                         Set<ReagentTransferServiceImp.RSlot> repeatedReagentSlots, Set<ReagentTransferServiceImp.RSlot> seenRSlots,
+                                         String barcode, Address rAddress, ReagentPlate plate) {
+        ReagentTransferServiceImp.RSlot rslot = new ReagentTransferServiceImp.RSlot(rAddress, plate!=null ? plate.getBarcode() : barcode);
+        if (plate != null) {
+            var optSlot = plate.optSlot(rAddress);
+            if (optSlot.isEmpty()) {
+                invalidReagentSlots.add(rslot);
+                return;
+            }
+            var reagentSlot = optSlot.get();
+            if (reagentSlot.isUsed()) {
+                alreadyUsedReagentSlots.add(rslot);
+                return;
+            }
+        } else {
+            // Since the reagent plate doesn't exist yet, we assume its size
+            // (a safe assumption, since it is the only size we support).
+            if (ReagentPlate.PLATE_LAYOUT_96.indexOf(rAddress) < 0) {
+                invalidReagentSlots.add(new ReagentTransferServiceImp.RSlot(rAddress, barcode));
+            }
+        }
+        if (!seenRSlots.add(rslot)) {
+            repeatedReagentSlots.add(rslot);
+        }
+    }
+
+    /**
+     * Adds a problem listing the given items, if there are any
+     * @param problems the receptacle for problems
+     * @param description the pluralisable description of the problem
+     * @param items the items associated with the problem
+     */
+    private static void describeProblem(Collection<String> problems, String description, Collection<?> items) {
+        if (!items.isEmpty()) {
+            problems.add(pluralise(description, items.size()) + items);
+        }
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyService.java
@@ -4,6 +4,8 @@ import uk.ac.sanger.sccp.stan.model.User;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
 import uk.ac.sanger.sccp.stan.request.SlotCopyRequest;
 
+import java.util.Set;
+
 /**
  * Service to record an operation that creates new labware
  * and copies the contents of existing labware by specified slot addresses
@@ -18,4 +20,14 @@ public interface SlotCopyService {
      * @exception ValidationException if validation fails
      */
     OperationResult perform(User user, SlotCopyRequest request) throws ValidationException;
+
+    /**
+     * Records the specified operation.
+     * This is called inside a transaction, after validation.
+     * @param user the user responsible
+     * @param data the information about the request
+     * @param barcodesToUnstore receptacle for barcodes to unstore
+     * @return the result
+     */
+    OperationResult record(User user, SlotCopyValidationService.Data data, Set<String> barcodesToUnstore);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyServiceImp.java
@@ -1,28 +1,26 @@
 package uk.ac.sanger.sccp.stan.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.ac.sanger.sccp.stan.Transactor;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.OperationResult;
 import uk.ac.sanger.sccp.stan.request.SlotCopyRequest;
-import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyContent;
-import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyDestination;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.*;
+import uk.ac.sanger.sccp.stan.service.SlotCopyValidationService.Data;
 import uk.ac.sanger.sccp.stan.service.store.StoreService;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
-import uk.ac.sanger.sccp.utils.BasicUtils;
 import uk.ac.sanger.sccp.utils.UCMap;
 
 import javax.persistence.EntityManager;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static uk.ac.sanger.sccp.utils.BasicUtils.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.coalesce;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
 
 /**
  * Service to perform an operation copying the contents of slots to new labware
@@ -43,48 +41,34 @@ public class SlotCopyServiceImp implements SlotCopyService {
             ).map(String::toUpperCase)
             .collect(toSet());
 
-    private final OperationTypeRepo opTypeRepo;
-    private final LabwareTypeRepo lwTypeRepo;
     private final LabwareRepo lwRepo;
     private final SampleRepo sampleRepo;
     private final SlotRepo slotRepo;
-    private final BioStateRepo bsRepo;
     private final LabwareNoteRepo lwNoteRepo;
+    private final SlotCopyValidationService valService;
     private final LabwareService lwService;
     private final OperationService opService;
     private final StoreService storeService;
     private final WorkService workService;
-    private final LabwareValidatorFactory labwareValidatorFactory;
     private final EntityManager entityManager;
     private final Transactor transactor;
-    private final Validator<String> preBarcodeValidator;
-    private final Validator<String> lotNumberValidator;
 
     @Autowired
-    public SlotCopyServiceImp(OperationTypeRepo opTypeRepo, LabwareTypeRepo lwTypeRepo, LabwareRepo lwRepo,
-                              SampleRepo sampleRepo, SlotRepo slotRepo, BioStateRepo bsRepo, LabwareNoteRepo lwNoteRepo,
-                              LabwareService lwService, OperationService opService, StoreService storeService,
-                              WorkService workService,
-                              LabwareValidatorFactory labwareValidatorFactory, EntityManager entityManager,
-                              Transactor transactor,
-                              @Qualifier("cytAssistBarcodeValidator") Validator<String> preBarcodeValidator,
-                              @Qualifier("lotNumberValidator") Validator<String> lotNumberValidator) {
-        this.opTypeRepo = opTypeRepo;
-        this.lwTypeRepo = lwTypeRepo;
+    public SlotCopyServiceImp(LabwareRepo lwRepo, SampleRepo sampleRepo, SlotRepo slotRepo, LabwareNoteRepo lwNoteRepo,
+                              SlotCopyValidationService valService, LabwareService lwService,
+                              OperationService opService, StoreService storeService, WorkService workService,
+                              EntityManager entityManager, Transactor transactor) {
         this.lwRepo = lwRepo;
         this.sampleRepo = sampleRepo;
         this.slotRepo = slotRepo;
-        this.bsRepo = bsRepo;
         this.lwNoteRepo = lwNoteRepo;
+        this.valService = valService;
         this.lwService = lwService;
         this.opService = opService;
         this.storeService = storeService;
         this.workService = workService;
-        this.labwareValidatorFactory = labwareValidatorFactory;
         this.entityManager = entityManager;
         this.transactor = transactor;
-        this.preBarcodeValidator = preBarcodeValidator;
-        this.lotNumberValidator = lotNumberValidator;
     }
 
     @Override
@@ -108,469 +92,22 @@ public class SlotCopyServiceImp implements SlotCopyService {
      */
     public OperationResult performInsideTransaction(User user, SlotCopyRequest request, final Set<String> barcodesToUnstore)
             throws ValidationException {
-        Collection<String> problems = new LinkedHashSet<>();
-        OperationType opType = loadEntity(problems, request.getOperationType(), "operation type", opTypeRepo::findByName);
-        UCMap<Labware> existingDestinations = loadExistingDestinations(problems, opType, request.getDestinations());
-        UCMap<LabwareType> lwTypes = loadLabwareTypes(problems, request.getDestinations());
-        checkPreBarcodes(problems, request.getDestinations(), lwTypes);
-        checkPreBarcodesInUse(problems, request.getDestinations(), existingDestinations);
-        UCMap<Labware> sourceMap = loadSources(problems, request);
-        validateSources(problems, sourceMap.values());
-        UCMap<Labware.State> sourceStateMap = checkListedSources(problems, request);
-        validateLotNumbers(problems, request.getDestinations());
-        validateContents(problems, lwTypes, sourceMap, existingDestinations, request);
-        validateOps(problems, request.getDestinations(), opType, lwTypes);
-        UCMap<BioState> bs = validateBioStates(problems, request.getDestinations());
-        checkExistingDestinations(problems, request.getDestinations(), existingDestinations, lwTypes, bs);
-        Work work = workService.validateUsableWork(problems, request.getWorkNumber());
-        if (!problems.isEmpty()) {
-            throw new ValidationException("The operation could not be validated.", problems);
+        Data data = valService.validateRequest(user, request);
+        if (!data.problems.isEmpty()) {
+            throw new ValidationException("The operation could not be validated.", data.problems);
         }
-        OperationResult opres = executeOps(user, request.getDestinations(), opType, lwTypes, bs, sourceMap, work,
-                existingDestinations);
-        final Labware.State newSourceState = (opType.discardSource() ? Labware.State.discarded
-                : opType.markSourceUsed() ? Labware.State.used : null);
-        updateSources(sourceStateMap, sourceMap.values(), newSourceState, barcodesToUnstore);
+        return record(user, data, barcodesToUnstore);
+    }
+
+    @Override
+    public OperationResult record(User user, Data data, final Set<String> barcodesToUnstore) {
+        OperationResult opres = executeOps(user, data.request.getDestinations(), data.opType, data.lwTypes, data.bioStates,
+                data.sourceLabware, data.work, data.destLabware);
+        final Labware.State newSourceState = (data.opType.discardSource() ? Labware.State.discarded
+                : data.opType.markSourceUsed() ? Labware.State.used : null);
+        updateSources(data.request.getSources(), data.sourceLabware.values(), newSourceState, barcodesToUnstore);
         return opres;
     }
-
-    // region Loading and validating
-
-    /**
-     * Checks for problems with lot numbers.
-     * Lot numbers are optional, but their format is prescribed.
-     * @param problems receptacle for problems
-     * @param destinations the request destinations
-     */
-    public void validateLotNumbers(Collection<String> problems, Collection<SlotCopyDestination> destinations) {
-        for (SlotCopyDestination destination : destinations) {
-            if (!nullOrEmpty(destination.getLotNumber())) {
-                lotNumberValidator.validate(destination.getLotNumber(), problems::add);
-            }
-            if (!nullOrEmpty(destination.getProbeLotNumber())) {
-                lotNumberValidator.validate(destination.getProbeLotNumber(), problems::add);
-            }
-        }
-    }
-
-    /**
-     * Loads labware specified as existing labware to put further samples into
-     * @param problems receptacle for problems
-     * @param opType the operation type
-     * @param destinations the request destinations
-     * @return the specified labware
-     */
-    public UCMap<Labware> loadExistingDestinations(Collection<String> problems, OperationType opType,
-                                                   List<SlotCopyDestination> destinations) {
-        List<String> barcodes = destinations.stream()
-                .map(SlotCopyDestination::getBarcode)
-                .filter(s -> !nullOrEmpty(s))
-                .collect(toList());
-        if (barcodes.isEmpty()) {
-            return new UCMap<>(0); // none
-        }
-        if (opType != null && !opType.supportsActiveDest()) {
-            problems.add("Reusing existing destinations is not supported for operation type "+opType.getName()+".");
-        }
-        LabwareValidator val = labwareValidatorFactory.getValidator();
-        val.setUniqueRequired(true);
-        val.loadLabware(lwRepo, barcodes);
-        val.validateActiveDestinations();
-        problems.addAll(val.getErrors());
-        return UCMap.from(val.getLabware(), Labware::getBarcode);
-    }
-
-    /**
-     * Checks that the information is correct if given for existing destination labware
-     * @param problems receptacle for problems
-     * @param destinations the request destinations
-     * @param labware map of labware from barcode
-     * @param lwTypes map of labware type from name
-     * @param bs map of bio states from name
-     */
-    public void checkExistingDestinations(Collection<String> problems, List<SlotCopyDestination> destinations,
-                                               UCMap<Labware> labware, UCMap<LabwareType> lwTypes, UCMap<BioState> bs) {
-        for (SlotCopyDestination dest : destinations) {
-            if (nullOrEmpty(dest.getBarcode())) {
-                continue;
-            }
-            Labware lw = labware.get(dest.getBarcode());
-            if (lw==null) {
-                continue;
-            }
-            checkExistingLabwareType(problems, lw, lwTypes.get(dest.getLabwareType()));
-            checkExistingLabwareBioState(problems, lw, bs.get(dest.getBioState()));
-        }
-    }
-
-    /**
-     * Checks that specified labware type matches existing labware
-     * @param problems receptacle for problems
-     * @param lw existing labware, if any
-     * @param lt specified labware type, if any
-     */
-    public void checkExistingLabwareType(Collection<String> problems, Labware lw, LabwareType lt) {
-        if (lw!=null && lt!=null && !lw.getLabwareType().equals(lt)) {
-            problems.add(String.format("Labware type %s specified for labware %s but it already has type %s.",
-                    lt.getName(), lw.getBarcode(), lw.getLabwareType().getName()));
-        }
-    }
-
-    /**
-     * Checks that specified bio state matches existing labware
-     * @param problems receptacle for problems
-     * @param lw existing labware, if any
-     * @param newBs specified bio state, if any
-     */
-    public void checkExistingLabwareBioState(Collection<String> problems, Labware lw, BioState newBs) {
-        if (lw!=null && newBs!=null) {
-            Set<BioState> lwBs = lw.getSlots().stream()
-                    .flatMap(slot -> slot.getSamples().stream().map(Sample::getBioState))
-                    .collect(toSet());
-            if (lwBs.size() == 1) {
-                BioState oldBs = lwBs.iterator().next();
-                if (!oldBs.equals(newBs)) {
-                    problems.add(String.format("Bio state %s specified for labware %s, which already uses bio state %s.",
-                            newBs.getName(), lw.getBarcode(), oldBs.getName()));
-                }
-            }
-        }
-    }
-
-    /**
-     * Loads the labware types specified for destinations
-     * @param problems receptacle for problems
-     * @param destinations the destinations specified in the request
-     * @return a map of barcodes to labware
-     */
-    public UCMap<LabwareType> loadLabwareTypes(Collection<String> problems, List<SlotCopyDestination> destinations) {
-        boolean anyMissing = false;
-        Set<String> lwTypeNames = new HashSet<>(destinations.size());
-        for (SlotCopyDestination dest : destinations) {
-            String name = dest.getLabwareType();
-            if (nullOrEmpty(name)) {
-                if (nullOrEmpty(dest.getBarcode())) {
-                    anyMissing = true;
-                }
-            } else {
-                lwTypeNames.add(name);
-            }
-        }
-        if (anyMissing) {
-            problems.add("Labware type name missing from request.");
-        }
-        if (lwTypeNames.isEmpty()) {
-            return new UCMap<>();
-        }
-        UCMap<LabwareType> lwTypes = UCMap.from(lwTypeRepo.findAllByNameIn(lwTypeNames), LabwareType::getName);
-        List<String> missing = destinations.stream()
-                .map(SlotCopyDestination::getLabwareType)
-                .filter(s -> s!=null && !s.isEmpty() && lwTypes.get(s)==null)
-                .distinct()
-                .map(BasicUtils::repr)
-                .collect(toList());
-        if (!missing.isEmpty()) {
-            problems.add("Unknown labware types: "+missing);
-        }
-        return lwTypes;
-    }
-
-    /**
-     * Helper to load an entity using a function that returns an optional.
-     * If it cannot be loaded, a problem is added to {@code problems}, and this method returns null
-     * @param problems the receptacle for problems
-     * @param name the name of the thing to load
-     * @param desc the name of the type of thing
-     * @param loadFn the function that returns an {@code Optional<E>}
-     * @param <E> the type of thing being loaded
-     * @return the thing loaded, or null if it could not be loaded
-     */
-    public <E> E loadEntity(Collection<String> problems, String name, String desc, Function<String, Optional<E>> loadFn) {
-        if (name==null || name.isEmpty()) {
-            problems.add("No "+desc+" specified.");
-            return null;
-        }
-        var opt = loadFn.apply(name);
-        if (opt.isEmpty()) {
-            problems.add("Unknown "+desc+": "+repr(name));
-            return null;
-        }
-        return opt.get();
-    }
-
-    /**
-     * Checks the format and presence of the prebarcodes, if any
-     * @param problems receptacle for problems found
-     * @param destinations the specification of destinations
-     * @param lwTypes the labware type specified in the request (if any)
-     */
-    public void checkPreBarcodes(Collection<String> problems, List<SlotCopyDestination> destinations, UCMap<LabwareType> lwTypes) {
-        Set<String> missing = new LinkedHashSet<>();
-        Set<String> unexpected = new LinkedHashSet<>();
-        for (SlotCopyDestination dest : destinations) {
-            String barcode = dest.getPreBarcode();
-            LabwareType lt = lwTypes.get(dest.getLabwareType());
-            if (barcode==null || barcode.isEmpty()) {
-                if (lt != null && lt.isPrebarcoded()) {
-                    missing.add(lt.getName());
-                }
-            } else if (lt != null && !lt.isPrebarcoded()) {
-                unexpected.add(lt.getName());
-            } else {
-                preBarcodeValidator.validate(barcode.toUpperCase(), problems::add);
-            }
-        }
-        if (!missing.isEmpty()) {
-            problems.add("Expected a prebarcode for labware type: "+missing);
-        }
-        if (!unexpected.isEmpty()) {
-            problems.add("Prebarcode not expected for labware type: "+unexpected);
-        }
-    }
-
-    /**
-     * Checks the prebarcodes are available for use: that means they must be unique in this request,
-     * and not already used as a regular or external labware barcode.
-     * @param problems receptacle for problems
-     * @param destinations the requested destinations
-     * @param existingDestinations the existing labware destinations
-     */
-    public void checkPreBarcodesInUse(Collection<String> problems, List<SlotCopyDestination> destinations,
-                                      UCMap<Labware> existingDestinations) {
-        Set<String> seen = new HashSet<>(destinations.size());
-        for (SlotCopyDestination dest : destinations) {
-            String prebc = dest.getPreBarcode();
-            if (nullOrEmpty(prebc)) {
-                continue;
-            }
-            prebc = prebc.toUpperCase();
-            Labware existingDest = existingDestinations.get(dest.getBarcode());
-            if (existingDest!=null) {
-                if (!prebc.equalsIgnoreCase(existingDest.getExternalBarcode())
-                    && !prebc.equalsIgnoreCase(existingDest.getBarcode())) {
-                    problems.add(String.format("External barcode %s cannot be added to existing labware %s.",
-                            repr(prebc), existingDest.getBarcode()));
-                }
-            } else if (!seen.add(prebc)) {
-                problems.add("External barcode given multiple times: "+prebc);
-            } else {
-                if (lwRepo.existsByBarcode(prebc)) {
-                    problems.add("Labware already exists with barcode "+prebc+".");
-                } else if (lwRepo.existsByExternalBarcode(prebc)) {
-                    problems.add("Labware already exists with external barcode "+prebc+".");
-                }
-            }
-        }
-    }
-
-    /**
-     * Loads the specified source labware into a {@code UCMap} from labware barcode.
-     * @param problems receptacle for problems
-     * @param request the request
-     * @return a map of labware from its barcode
-     */
-    public UCMap<Labware> loadSources(Collection<String> problems, SlotCopyRequest request) {
-        Set<String> sourceBarcodes = new HashSet<>();
-        for (SlotCopyDestination dest : request.getDestinations()) {
-            for (SlotCopyContent content : dest.getContents()) {
-                String barcode = content.getSourceBarcode();
-                if (barcode == null || barcode.isEmpty()) {
-                    problems.add("Missing source barcode.");
-                    continue;
-                }
-                sourceBarcodes.add(barcode.toUpperCase());
-            }
-        }
-        if (sourceBarcodes.isEmpty()) {
-            return new UCMap<>();
-        }
-        UCMap<Labware> lwMap = UCMap.from(lwRepo.findByBarcodeIn(sourceBarcodes), Labware::getBarcode);
-        List<String> unknownBarcodes = sourceBarcodes.stream()
-                .filter(bc -> lwMap.get(bc)==null)
-                .collect(toList());
-        if (!unknownBarcodes.isEmpty()) {
-            problems.add(pluralise("Unknown source barcode{s}: ", unknownBarcodes.size())
-                    + reprCollection(unknownBarcodes));
-        }
-        return lwMap;
-    }
-
-    /**
-     * Checks the sources and states specified in the request are reasonable.
-     * @param problems receptacle for problems
-     * @param request the request
-     * @return a map of labware barcode to its new state
-     */
-    public UCMap<Labware.State> checkListedSources(Collection<String> problems, SlotCopyRequest request) {
-        UCMap<Labware.State> bcStates = new UCMap<>(request.getSources().size());
-        if (request.getSources().isEmpty()) {
-            return bcStates;
-        }
-        Set<Labware.State> allowedStates = EnumSet.of(Labware.State.active, Labware.State.discarded, Labware.State.used);
-        Set<String> usedSourceBarcodes = request.getDestinations().stream()
-                .flatMap(dest -> dest.getContents().stream())
-                .map(SlotCopyContent::getSourceBarcode)
-                .filter(bc -> bc!=null && !bc.isEmpty())
-                .map(String::toUpperCase)
-                .collect(toSet());
-        for (var src : request.getSources()) {
-            String bc = src.getBarcode();
-            if (bc==null || bc.isEmpty()) {
-                problems.add("Source specified without barcode.");
-            } else if (bcStates.containsKey(bc)) {
-                problems.add("Repeated source barcode: "+bc);
-            } else if (src.getLabwareState()==null) {
-                problems.add("Source given without labware state: " + bc);
-            } else if (!allowedStates.contains(src.getLabwareState())) {
-                problems.add("Unsupported new labware state: "+src.getLabwareState());
-            } else {
-                bcStates.put(bc, src.getLabwareState());
-            }
-        }
-        Set<String> unexpectedSourceBarcodes = bcStates.keySet()
-                .stream()
-                .filter(bc -> !usedSourceBarcodes.contains(bc))
-                .collect(toSet());
-        if (!unexpectedSourceBarcodes.isEmpty()) {
-            problems.add("Source barcodes specified that do not map to any destination slots: "+unexpectedSourceBarcodes);
-        }
-        return bcStates;
-    }
-
-    /**
-     * Validate some specifics for the ops being requested
-     * @param problems receptacle for problems
-     * @param dests the requested destinations
-     * @param opType the operation type
-     * @param lwTypes map to get lw types by name
-     */
-    public void validateOps(Collection<String> problems, List<SlotCopyDestination> dests, OperationType opType,
-                            UCMap<LabwareType> lwTypes) {
-        if (opType!=null && opType.getName().equalsIgnoreCase(CYTASSIST_OP)) {
-            for (SlotCopyDestination dest : dests) {
-                validateCytOp(problems, dest.getContents(), lwTypes.get(dest.getLabwareType()));
-            }
-        }
-    }
-
-    /**
-     * Validates some things specific to the cytassist operation
-     * @param problems receptacle for problems
-     * @param contents the transfer contents specified in the request
-     * @param lwType the labware type for this destination
-     */
-    public void validateCytOp(Collection<String> problems, Collection<SlotCopyContent> contents, LabwareType lwType) {
-        if (lwType != null) {
-            if (!lwType.getName().equalsIgnoreCase(CYTASSIST_SLIDE) && !lwType.getName().equalsIgnoreCase(CYTASSIST_SLIDE_XL)) {
-                problems.add(String.format("Expected labware type %s or %s for operation %s.",
-                        CYTASSIST_SLIDE, CYTASSIST_SLIDE_XL, CYTASSIST_OP));
-            }
-            if (lwType.getName().equalsIgnoreCase(CYTASSIST_SLIDE) && contents != null && !contents.isEmpty()) {
-                for (SlotCopyContent content : contents) {
-                    Address ad = content.getDestinationAddress();
-                    if (ad != null && ad.getColumn()==1 && ad.getRow() > 1 && ad.getRow() < 4) {
-                        problems.add("Slots B1 and C1 are disallowed for use in this operation.");
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Validates that the source labware is usable using {@link LabwareValidator}.
-     * @param problems the receptacle for problems
-     * @param labware the source labware being validated
-     */
-    public void validateSources(Collection<String> problems, Collection<Labware> labware) {
-        LabwareValidator validator = labwareValidatorFactory.getValidator(labware);
-        validator.setUniqueRequired(false);
-        validator.setSingleSample(false);
-        validator.validateSources();
-        problems.addAll(validator.getErrors());
-    }
-
-    /**
-     * Validates that the instructions of what to copy are valid for the source labware and new labware type
-     * @param problems the receptacle for problems
-     * @param lwTypes the types of the destination labware (values be null if a valid labware type was not specified)
-     * @param lwMap the map of source barcode to labware (some labware may be missing if there were invalid/missing barcodes)
-     * @param existingDestinations map of existing labware to add samples to
-     * @param request the request
-     */
-    public void validateContents(Collection<String> problems, UCMap<LabwareType> lwTypes, UCMap<Labware> lwMap,
-                                 UCMap<Labware> existingDestinations, SlotCopyRequest request) {
-        if (request.getDestinations().isEmpty()) {
-            problems.add("No destinations specified.");
-            return;
-        }
-        if (request.getDestinations().stream()
-                .anyMatch(dest -> dest==null || dest.getContents()==null || dest.getContents().isEmpty())) {
-            problems.add("No contents specified in destination.");
-        }
-        for (var dest : request.getDestinations()) {
-            Set<SlotCopyContent> contentSet = new HashSet<>(dest.getContents().size());
-            Labware destLw = existingDestinations.get(dest.getBarcode());
-            LabwareType lt = destLw != null ? destLw.getLabwareType() : lwTypes.get(dest.getLabwareType());
-            for (var content : dest.getContents()) {
-                Address destAddress = content.getDestinationAddress();
-                if (!contentSet.add(content)) {
-                    problems.add("Repeated copy specified: "+content);
-                    continue;
-                }
-                if (destAddress == null) {
-                    problems.add("No destination address specified.");
-                } else if (destLw != null) {
-                    Slot slot = destLw.optSlot(destAddress).orElse(null);
-                    if (slot==null) {
-                        problems.add(String.format("No such slot %s in labware %s.", destAddress, destLw.getBarcode()));
-                    } else if (!slot.getSamples().isEmpty()) {
-                        problems.add(String.format("Slot %s in labware %s is not empty.", destAddress, destLw.getBarcode()));
-                    }
-                } else if (lt != null && lt.indexOf(destAddress) < 0) {
-                    problems.add("Invalid address " + destAddress + " for labware type " + lt.getName() + ".");
-                }
-                Address sourceAddress = content.getSourceAddress();
-                Labware lw = lwMap.get(content.getSourceBarcode());
-                if (sourceAddress == null) {
-                    problems.add("No source address specified.");
-                } else if (lw != null && lw.getLabwareType().indexOf(sourceAddress) < 0) {
-                    problems.add("Invalid address " + sourceAddress + " for source labware " + lw.getBarcode() + ".");
-                } else if (lw != null && lw.getSlot(sourceAddress).getSamples().isEmpty()) {
-                    problems.add(String.format("Slot %s in labware %s is empty.", sourceAddress, lw.getBarcode()));
-                }
-            }
-        }
-    }
-
-    public UCMap<BioState> validateBioStates(Collection<String> problems, Collection<SlotCopyDestination> dests) {
-        Set<String> bsNames = new HashSet<>();
-        for (SlotCopyDestination dest : dests) {
-            if (dest!=null && dest.getBioState()!=null) {
-                bsNames.add(dest.getBioState());
-            }
-        }
-        if (bsNames.isEmpty()) {
-            return new UCMap<>();
-        }
-        UCMap<BioState> bioStates = UCMap.from(bsRepo.findAllByNameIn(bsNames), BioState::getName);
-        Set<String> unknown = bsNames.stream()
-                .filter(name -> !bioStates.containsKey(name))
-                .collect(toSet());
-        if (!unknown.isEmpty()) {
-            problems.add("Unknown bio state: "+unknown);
-        }
-        Set<String> wrongBs = bioStates.values().stream()
-                .map(BioState::getName)
-                .filter(name -> !VALID_BS_UPPER.contains(name.toUpperCase()))
-                .collect(toSet());
-        if (!wrongBs.isEmpty()) {
-            problems.add("Bio state not allowed for this operation: "+wrongBs);
-        }
-        return bioStates;
-    }
-    // endregion
-
     // region Executing
 
     public OperationResult executeOps(User user, Collection<SlotCopyDestination> dests,
@@ -719,16 +256,18 @@ public class SlotCopyServiceImp implements SlotCopyService {
 
     /**
      * Update the lw state of source labware.
-     * @param bcStateMap links of source barcode to explicit states
+     * @param scss links of source barcode to explicit states
      * @param sources source labware
      * @param defaultState default new state (if any)
      * @param barcodesToUnstore receptacle to put barcodes that need to be unstored
      */
-    public void updateSources(UCMap<Labware.State> bcStateMap, Collection<Labware> sources,
+    public void updateSources(List<SlotCopySource> scss, Collection<Labware> sources,
                               Labware.State defaultState, final Set<String> barcodesToUnstore) {
+        UCMap<Labware.State> stateMap = new UCMap<>(scss.size());
+        scss.forEach(scs -> stateMap.put(scs.getBarcode(), scs.getLabwareState()));
         final List<Labware> toUpdate = new ArrayList<>(sources.size());
         for (Labware lw : sources) {
-            Labware.State newState = bcStateMap.getOrDefault(lw.getBarcode(), defaultState);
+            Labware.State newState = stateMap.getOrDefault(lw.getBarcode(), defaultState);
             if (newState==Labware.State.discarded && !lw.isDiscarded()) {
                 lw.setDiscarded(true);
                 barcodesToUnstore.add(lw.getBarcode());

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyValidationService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyValidationService.java
@@ -1,0 +1,55 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+/**
+ * Service for validating a {@link SlotCopyRequest} (e.g. Transfer op)
+ */
+public interface SlotCopyValidationService {
+    /**
+     * Data built up and tracked during verification
+     */
+    class Data {
+        SlotCopyRequest request;
+        final Collection<String> problems = new LinkedHashSet<>();
+        OperationType opType;
+        Work work;
+        UCMap<Labware> sourceLabware;
+        UCMap<Labware> destLabware;
+        UCMap<BioState> bioStates;
+        UCMap<LabwareType> lwTypes;
+
+        public Data(SlotCopyRequest request) {
+            this.request = request;
+        }
+
+        public void addProblem(String problem) {
+            this.problems.add(problem);
+        }
+    }
+
+    /**
+     * Validates the given input. Records loaded information and problems found inside the parameter object.
+     * @param user the user responsible for the request
+     * @param data the validation data object
+     */
+    void validate(User user, Data data);
+
+    /**
+     * Creates a data object; validates it using {@link #validate}, and returns it.
+     * Loaded information and problems are recorded inside the data object.
+     * @param user the user responsible for the request
+     * @param request the request object
+     * @return the validation data object
+     */
+    default Data validateRequest(User user, SlotCopyRequest request) {
+        Data data = new Data(request);
+        validate(user, data);
+        return data;
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyValidationServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyValidationServiceImp.java
@@ -1,0 +1,468 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.*;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelper;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelperFactory;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toSet;
+import static uk.ac.sanger.sccp.stan.service.SlotCopyServiceImp.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * @author dr6
+ */
+@Service
+public class SlotCopyValidationServiceImp implements SlotCopyValidationService {
+    private final LabwareTypeRepo lwTypeRepo;
+    private final LabwareRepo lwRepo;
+    private final BioStateRepo bsRepo;
+    private final ValidationHelperFactory valHelperFactory;
+    private final Validator<String> preBarcodeValidator;
+    private final Validator<String> lotNumberValidator;
+
+    @Autowired
+    public SlotCopyValidationServiceImp(LabwareTypeRepo lwTypeRepo, LabwareRepo lwRepo, BioStateRepo bsRepo,
+                                        ValidationHelperFactory valHelperFactory,
+                                        @Qualifier("cytAssistBarcodeValidator") Validator<String> preBarcodeValidator,
+                                        @Qualifier("lotNumberValidator") Validator<String> lotNumberValidator) {
+        this.lwTypeRepo = lwTypeRepo;
+        this.lwRepo = lwRepo;
+        this.bsRepo = bsRepo;
+        this.valHelperFactory = valHelperFactory;
+        this.preBarcodeValidator = preBarcodeValidator;
+        this.lotNumberValidator = lotNumberValidator;
+    }
+
+    @Override
+    public void validate(User user, Data data) {
+        if (user==null) {
+            data.addProblem("No user supplied.");
+        }
+        SlotCopyRequest request = data.request;
+        if (request==null) {
+            data.addProblem("No request supplied.");
+            return;
+        }
+        ValidationHelper val = valHelperFactory.getHelper();
+        if (data.opType==null) {
+            data.opType = val.checkOpType(request.getOperationType());
+        }
+        if (data.destLabware==null) {
+            data.destLabware = loadExistingDestinations(val, data.opType, request.getDestinations());
+        }
+        if (data.lwTypes==null) {
+            data.lwTypes = loadLabwareTypes(data.problems, request.getDestinations());
+        }
+        checkPreBarcodes(data.problems, request.getDestinations(), data.lwTypes);
+        checkPreBarcodesInUse(data.problems, request.getDestinations(), data.destLabware);
+        if (data.sourceLabware == null) {
+            data.sourceLabware = loadSources(data.problems, val, request.getDestinations());
+        }
+        checkListedSources(data.problems, request);
+        validateLotNumbers(data.problems, request.getDestinations());
+        validateContents(data.problems, data.lwTypes, data.sourceLabware, data.destLabware, request);
+        validateOps(data.problems, request.getDestinations(), data.opType, data.lwTypes);
+        data.bioStates = validateBioStates(data.problems, request.getDestinations());
+        checkExistingDestinations(data.problems, request.getDestinations(), data.destLabware, data.bioStates);
+        if (data.work==null) {
+            data.work = val.checkWork(request.getWorkNumber());
+        }
+        data.problems.addAll(val.getProblems());
+    }
+
+    /**
+     * Loads the specified labware types; looks for problems
+     * @param problems receptacle for problems
+     * @param scds the info from the request
+     * @return a map of found labware types from their names
+     */
+    public UCMap<LabwareType> loadLabwareTypes(Collection<String> problems, List<SlotCopyDestination> scds) {
+        boolean anyMissing = false;
+        Set<String> lwTypeNames = new LinkedHashSet<>();
+        for (SlotCopyDestination scd : scds) {
+            if (nullOrEmpty(scd.getBarcode())) {
+                if (nullOrEmpty(scd.getLabwareType())) {
+                    anyMissing = true;
+                } else {
+                    lwTypeNames.add(scd.getLabwareType());
+                }
+            }
+        }
+        if (anyMissing) {
+            problems.add("Labware type missing from request.");
+        }
+        if (lwTypeNames.isEmpty()) {
+            return new UCMap<>(0);
+        }
+        UCMap<LabwareType> lwTypes = UCMap.from(lwTypeRepo.findAllByNameIn(lwTypeNames), LabwareType::getName);
+        List<String> missing = lwTypeNames.stream()
+                .filter(name -> lwTypes.get(name)==null)
+                .toList();
+        if (!missing.isEmpty()) {
+            problems.add("Unknown labware type: "+missing);
+        }
+        return lwTypes;
+    }
+
+    /**
+     * Loads labware specified as existing labware to put further samples into
+     * @param val validation helper that checks and accumulates problems
+     * @param opType the operation type
+     * @param destinations the request destinations
+     * @return the specified labware
+     */
+    public UCMap<Labware> loadExistingDestinations(ValidationHelper val,
+                                                   OperationType opType,
+                                                   List<SlotCopyDestination> destinations) {
+        List<String> barcodes = destinations.stream()
+                .map(SlotCopyDestination::getBarcode)
+                .filter(s -> !nullOrEmpty(s))
+                .toList();
+        if (barcodes.isEmpty()) {
+            return new UCMap<>(0); // none
+        }
+        if (opType != null && !opType.supportsActiveDest()) {
+            val.getProblems().add("Reusing existing destinations is not supported for operation type "+opType.getName()+".");
+        }
+        return val.loadActiveDestinations(barcodes);
+    }
+
+    /**
+     * Checks the prebarcodes in the request are suitable
+     * @param problems receptacle for problems
+     * @param scds info from the request
+     * @param lwTypes loaded labware types
+     */
+    public void checkPreBarcodes(Collection<String> problems, List<SlotCopyDestination> scds, UCMap<LabwareType> lwTypes) {
+        Set<String> missing = new LinkedHashSet<>();
+        Set<String> unexpected = new LinkedHashSet<>();
+        for (SlotCopyDestination scd : scds) {
+            String barcode = scd.getPreBarcode();
+            LabwareType lt = lwTypes.get(scd.getLabwareType());
+            if (nullOrEmpty(barcode)) {
+                if (lt != null && lt.isPrebarcoded()) {
+                    missing.add(lt.getName());
+                }
+            } else if (lt != null && !lt.isPrebarcoded()) {
+                unexpected.add(lt.getName());
+            } else {
+                preBarcodeValidator.validate(barcode.toUpperCase(), problems::add);
+            }
+        }
+        if (!missing.isEmpty()) {
+            problems.add("Expected a prebarcode for labware type: "+missing);
+        }
+        if (!unexpected.isEmpty()) {
+            problems.add("Prebarcode not expected for labware type: "+unexpected);
+        }
+    }
+
+    /**
+     * Checks if any of the given prebarcodes for new labware are already in use on existing labware
+     * @param problems receptacle for problems
+     * @param scds info from the request
+     * @param existingDestinations any existing destinations that are referenced
+     */
+    public void checkPreBarcodesInUse(Collection<String> problems, List<SlotCopyDestination> scds,
+                                      UCMap<Labware> existingDestinations) {
+        Set<String> seen = new HashSet<>(scds.size());
+        for (SlotCopyDestination scd : scds) {
+            String prebc = scd.getPreBarcode();
+            if (nullOrEmpty(prebc)) {
+                continue;
+            }
+            prebc = prebc.toUpperCase();
+            Labware existingDest = existingDestinations.get(scd.getBarcode());
+            if (existingDest!=null) {
+                if (!prebc.equalsIgnoreCase(existingDest.getExternalBarcode())
+                        && !prebc.equalsIgnoreCase(existingDest.getBarcode())) {
+                    problems.add(String.format("External barcode %s cannot be added to existing labware %s.",
+                            repr(prebc), existingDest.getBarcode()));
+                }
+            } else if (!seen.add(prebc)) {
+                problems.add("External barcode given multiple times: "+prebc);
+            } else {
+                if (lwRepo.existsByBarcode(prebc)) {
+                    problems.add("Labware already exists with barcode "+prebc+".");
+                } else if (lwRepo.existsByExternalBarcode(prebc)) {
+                    problems.add("Labware already exists with external barcode "+prebc+".");
+                }
+            }
+        }
+    }
+
+    /**
+     * Loads source labware
+     * @param problems receptacle for problems
+     * @param val validation helper
+     * @param scds info from the request
+     * @return map of source labware from its barcodes
+     */
+    public UCMap<Labware> loadSources(Collection<String> problems, ValidationHelper val, List<SlotCopyDestination> scds) {
+        Set<String> sourceBarcodes = new HashSet<>();
+        for (SlotCopyDestination scd : scds) {
+            for (SlotCopyContent content : scd.getContents()) {
+                String barcode = content.getSourceBarcode();
+                if (nullOrEmpty(barcode)) {
+                    problems.add("Missing source barcode.");
+                } else {
+                    sourceBarcodes.add(barcode.toUpperCase());
+                }
+            }
+        }
+        return val.checkLabware(sourceBarcodes);
+    }
+
+    /**
+     * Checks the sources and states specified in the request are reasonable.
+     * @param problems receptacle for problems
+     * @param request the request
+     */
+    public void checkListedSources(Collection<String> problems, SlotCopyRequest request) {
+        if (request.getSources().isEmpty()) {
+            return;
+        }
+        Set<String> usedSourceBarcodes = request.getDestinations().stream()
+                .flatMap(dest -> dest.getContents().stream())
+                .map(SlotCopyContent::getSourceBarcode)
+                .filter(bc -> !nullOrEmpty(bc))
+                .map(String::toUpperCase)
+                .collect(toSet());
+        checkListedSources(problems, request.getSources(), usedSourceBarcodes);
+    }
+
+    /**
+     * Checks that the sources listed with labware states are correctly filled in and match
+     * the sources listed in the transfers
+     * @param problems receptacle for problems
+     * @param scSources the source barcodes and labware states
+     * @param usedSourceBarcodes the source barcodes referenced in the transfers (upper case)
+     */
+    public void checkListedSources(Collection<String> problems, Collection<SlotCopySource> scSources,
+                                   Set<String> usedSourceBarcodes) {
+        Set<String> seen = new HashSet<>();
+        Set<Labware.State> allowedStates = EnumSet.of(Labware.State.active, Labware.State.discarded, Labware.State.used);
+        for (var src : scSources) {
+            String bc = src.getBarcode();
+            if (nullOrEmpty(bc)) {
+                problems.add("Source specified without barcode.");
+                continue;
+            }
+            bc = bc.toUpperCase();
+            if (!seen.add(bc)) {
+                problems.add("Repeated source barcode: "+bc);
+            } else if (src.getLabwareState()==null) {
+                problems.add("Source specified without labware state: " + bc);
+            } else if (!allowedStates.contains(src.getLabwareState())) {
+                problems.add("Unsupported new labware state: "+src.getLabwareState());
+            }
+        }
+
+        seen.removeAll(usedSourceBarcodes);
+        if (!seen.isEmpty()) {
+            problems.add("Source barcodes specified that do not map to any destination slots: "+seen);
+        }
+    }
+
+    /**
+     * Checks that the lot numbers are valid where present
+     * @param problems receptacle for problems
+     * @param scds info from the request
+     */
+    public void validateLotNumbers(Collection<String> problems, Collection<SlotCopyDestination> scds) {
+        for (SlotCopyDestination scd : scds) {
+            if (!nullOrEmpty(scd.getLotNumber())) {
+                lotNumberValidator.validate(scd.getLotNumber(), problems::add);
+            }
+            if (!nullOrEmpty(scd.getProbeLotNumber())) {
+                lotNumberValidator.validate(scd.getProbeLotNumber(), problems::add);
+            }
+        }
+    }
+
+    /**
+     * Validates that the instructions of what to copy are valid for the source labware and new labware type
+     * @param problems the receptacle for problems
+     * @param lwTypes the types of the destination labware (values be null if a valid labware type was not specified)
+     * @param sourceLabware the map of source barcode to labware (some labware may be missing if there were invalid/missing barcodes)
+     * @param existingDestinations map of existing labware to add samples to
+     * @param request the request
+     */
+    public void validateContents(Collection<String> problems, UCMap<LabwareType> lwTypes, UCMap<Labware> sourceLabware,
+                                 UCMap<Labware> existingDestinations, SlotCopyRequest request) {
+        if (nullOrEmpty(request.getDestinations())) {
+            problems.add("No destinations specified.");
+            return;
+        }
+        if (request.getDestinations().stream()
+                .anyMatch(dest -> dest==null || nullOrEmpty(dest.getContents()))) {
+            problems.add("No contents specified in destination.");
+        }
+        for (var scd : request.getDestinations()) {
+            if (scd==null || nullOrEmpty(scd.getContents())) {
+                continue;
+            }
+            Set<SlotCopyContent> contentSet = new HashSet<>(scd.getContents().size());
+            Labware destLw = existingDestinations.get(scd.getBarcode());
+            LabwareType lt = destLw != null ? destLw.getLabwareType() : lwTypes.get(scd.getLabwareType());
+            for (var content : scd.getContents()) {
+                Address destAddress = content.getDestinationAddress();
+                if (!contentSet.add(content)) {
+                    problems.add("Repeated copy specified: "+content);
+                    continue;
+                }
+                if (destAddress == null) {
+                    problems.add("No destination address specified.");
+                } else if (destLw != null) {
+                    Slot slot = destLw.optSlot(destAddress).orElse(null);
+                    if (slot==null) {
+                        problems.add(String.format("No such slot %s in labware %s.", destAddress, destLw.getBarcode()));
+                    } else if (!slot.getSamples().isEmpty()) {
+                        problems.add(String.format("Slot %s in labware %s is not empty.", destAddress, destLw.getBarcode()));
+                    }
+                } else if (lt != null && lt.indexOf(destAddress) < 0) {
+                    problems.add("Invalid address " + destAddress + " for labware type " + lt.getName() + ".");
+                }
+                Address sourceAddress = content.getSourceAddress();
+                Labware lw = sourceLabware.get(content.getSourceBarcode());
+                if (sourceAddress == null) {
+                    problems.add("No source address specified.");
+                } else if (lw != null && lw.getLabwareType().indexOf(sourceAddress) < 0) {
+                    problems.add("Invalid address " + sourceAddress + " for source labware " + lw.getBarcode() + ".");
+                } else if (lw != null && lw.getSlot(sourceAddress).getSamples().isEmpty()) {
+                    problems.add(String.format("Slot %s in labware %s is empty.", sourceAddress, lw.getBarcode()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Validate some specifics for the ops being requested
+     * @param problems receptacle for problems
+     * @param scds the requested destinations
+     * @param opType the operation type
+     * @param lwTypes map to get lw types by name
+     */
+    public void validateOps(Collection<String> problems, List<SlotCopyDestination> scds, OperationType opType,
+                            UCMap<LabwareType> lwTypes) {
+        if (opType!=null && opType.getName().equalsIgnoreCase(CYTASSIST_OP)) {
+            for (SlotCopyDestination dest : scds) {
+                validateCytOp(problems, dest.getContents(), lwTypes.get(dest.getLabwareType()));
+            }
+        }
+    }
+
+    /**
+     * Validates some things specific to the cytassist operation
+     * @param problems receptacle for problems
+     * @param contents the transfer contents specified in the request
+     * @param lwType the labware type for this destination
+     */
+    public void validateCytOp(Collection<String> problems, Collection<SlotCopyContent> contents, LabwareType lwType) {
+        if (lwType != null) {
+            if (!lwType.getName().equalsIgnoreCase(CYTASSIST_SLIDE) && !lwType.getName().equalsIgnoreCase(CYTASSIST_SLIDE_XL)) {
+                problems.add(String.format("Expected labware type %s or %s for operation %s.",
+                        CYTASSIST_SLIDE, CYTASSIST_SLIDE_XL, CYTASSIST_OP));
+            }
+            if (lwType.getName().equalsIgnoreCase(CYTASSIST_SLIDE) && contents != null && !contents.isEmpty()) {
+                for (SlotCopyContent content : contents) {
+                    Address ad = content.getDestinationAddress();
+                    if (ad != null && ad.getColumn()==1 && ad.getRow() > 1 && ad.getRow() < 4) {
+                        problems.add("Slots B1 and C1 are disallowed for use in this operation.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Loads and checks the indicated bio states (where present).
+     * Bio states must exist, be valid for this operation, and must not contradict existing labware
+     * @param problems receptacle for problems
+     * @param scds info from request
+     * @return the loaded bio states, mapped from their names
+     */
+    public UCMap<BioState> validateBioStates(Collection<String> problems, Collection<SlotCopyDestination> scds) {
+        Set<String> bsNames = new HashSet<>();
+        for (SlotCopyDestination scd : scds) {
+            if (scd!=null && !nullOrEmpty(scd.getBioState())) {
+                bsNames.add(scd.getBioState());
+            }
+        }
+        if (bsNames.isEmpty()) {
+            return new UCMap<>();
+        }
+        UCMap<BioState> bioStates = UCMap.from(bsRepo.findAllByNameIn(bsNames), BioState::getName);
+        Set<String> unknown = bsNames.stream()
+                .filter(name -> !bioStates.containsKey(name))
+                .collect(toSet());
+        if (!unknown.isEmpty()) {
+            problems.add("Unknown bio state: "+unknown);
+        }
+        Set<String> wrongBs = bioStates.values().stream()
+                .map(BioState::getName)
+                .filter(name -> !VALID_BS_UPPER.contains(name.toUpperCase()))
+                .collect(toSet());
+        if (!wrongBs.isEmpty()) {
+            problems.add("Bio state not allowed for this operation: "+wrongBs);
+        }
+        return bioStates;
+    }
+
+    /**
+     * Checks that the information is correct if given for existing destination labware
+     * @param problems receptacle for problems
+     * @param scds the request destinations
+     * @param labware map of labware from barcode
+     * @param bs map of bio states from name
+     */
+    public void checkExistingDestinations(Collection<String> problems, List<SlotCopyDestination> scds,
+                                          UCMap<Labware> labware, UCMap<BioState> bs) {
+        for (SlotCopyDestination scd : scds) {
+            if (nullOrEmpty(scd.getBarcode())) {
+                continue;
+            }
+            Labware lw = labware.get(scd.getBarcode());
+            if (lw==null) {
+                continue;
+            }
+            if (!nullOrEmpty(scd.getLabwareType()) && !lw.getLabwareType().getName().equalsIgnoreCase(scd.getLabwareType())) {
+                problems.add(String.format("Labware type %s specified for labware %s but it has type %s.",
+                        scd.getLabwareType(), lw.getBarcode(), lw.getLabwareType().getName()));
+            }
+            checkExistingLabwareBioState(problems, lw, bs.get(scd.getBioState()));
+        }
+    }
+
+    /**
+     * Checks that specified bio state matches existing labware
+     * @param problems receptacle for problems
+     * @param lw existing labware, if any
+     * @param newBs specified bio state, if any
+     */
+    public void checkExistingLabwareBioState(Collection<String> problems, Labware lw, BioState newBs) {
+        if (lw!=null && newBs!=null) {
+            Set<BioState> lwBs = lw.getSlots().stream()
+                    .flatMap(slot -> slot.getSamples().stream().map(Sample::getBioState))
+                    .collect(toSet());
+            if (lwBs.size() == 1) {
+                BioState oldBs = lwBs.iterator().next();
+                if (!oldBs.equals(newBs)) {
+                    problems.add(String.format("Bio state %s specified for labware %s, which already uses bio state %s.",
+                            newBs.getName(), lw.getBarcode(), oldBs.getName()));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/validation/ValidationHelper.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/validation/ValidationHelper.java
@@ -52,11 +52,25 @@ public interface ValidationHelper {
     }
 
     /**
-     * Loads and checks the labware
+     * Loads and checks the labware as a source
      * @param barcodes barcodes of labware
      * @return the loaded labware, mapped from barcodes
      */
     UCMap<Labware> checkLabware(Collection<String> barcodes);
+
+    /**
+     * Loads labware and checks it is a valid active destination (for operations that support active destinations)
+     * @param barcode the labware barcode
+     * @return the loaded labware, if any
+     */
+    Labware loadActiveDestination(String barcode);
+
+    /**
+     * Loads labware and checks they are valid active destinations (for operations that support active destinations)
+     * @param barcodes the labware barcodes
+     * @return the loaded labware, if any
+     */
+    UCMap<Labware> loadActiveDestinations(Collection<String> barcodes);
 
     /**
      * Loads and checks the work
@@ -64,6 +78,13 @@ public interface ValidationHelper {
      * @return the loaded work, mapped from work numbers
      */
     UCMap<Work> checkWork(Collection<String> workNumbers);
+
+    /**
+     * Loads and checks a single work
+     * @param workNumber work number to load
+     * @return the single loaded work, if any
+     */
+    Work checkWork(String workNumber);
 
     /**
      * Loads and checks comments

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/validation/ValidationHelperImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/validation/ValidationHelperImp.java
@@ -89,8 +89,40 @@ public class ValidationHelperImp implements ValidationHelper {
     }
 
     @Override
+    public Labware loadActiveDestination(String barcode) {
+        if (nullOrEmpty(barcode)) {
+            addProblem("No destination barcode supplied.");
+            return null;
+        }
+        LabwareValidator val = lwValFactory.getValidator();
+        List<Labware> lws = val.loadLabware(lwRepo, List.of(barcode));
+        val.validateActiveDestinations();
+        problems.addAll(val.getErrors());
+        return (lws.isEmpty() ? null : lws.getFirst());
+    }
+
+    @Override
+    public UCMap<Labware> loadActiveDestinations(Collection<String> barcodes) {
+        if (nullOrEmpty(barcodes)) {
+            addProblem("No destination barcodes supplied.");
+            return new UCMap<>(0);
+        }
+        LabwareValidator val = lwValFactory.getValidator();
+        List<Labware> lws = val.loadLabware(lwRepo, barcodes);
+        val.validateActiveDestinations();
+        val.setUniqueRequired(true);
+        problems.addAll(val.getErrors());
+        return UCMap.from(lws, Labware::getBarcode);
+    }
+
+    @Override
     public UCMap<Work> checkWork(Collection<String> workNumbers) {
         return workService.validateUsableWorks(this.problems, workNumbers);
+    }
+
+    @Override
+    public Work checkWork(String workNumber) {
+        return workService.validateUsableWork(this.problems, workNumber);
     }
 
     @Override

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1571,6 +1571,22 @@ input ReagentTransferRequest {
     plateType: String!
 }
 
+"""A request to record transfer, dual index and amplification ops."""
+input LibraryPrepRequest {
+    """The work number to associate with these operations."""
+    workNumber: String!
+    """The source labware and new labware states for this request."""
+    sources: [SlotCopySource!]!
+    """The one destination labware for this request, and the description of what is transferred into it."""
+    destination: SlotCopyDestination!
+    """The transfers from aliquot slots to destination slots."""
+    reagentTransfers: [ReagentTransfer!]!
+    """The type of reagent plate involved."""
+    reagentPlateType: String
+    """The measurement to record on slots in the destination."""
+    slotMeasurements: [SlotMeasurementRequest!]!
+}
+
 """A request to process original tissue into blocks."""
 input TissueBlockRequest {
     """The work number associated with this request."""
@@ -2117,6 +2133,8 @@ type Mutation {
     recordOrientationQC(request: OrientationRequest!): OperationResult!
     """Reactivate labware."""
     reactivateLabware(items: [ReactivateLabware!]!): OperationResult!
+    """Perform library prep request."""
+    libraryPrep(request: LibraryPrepRequest!): OperationResult!
 
     """Create a new user for the application."""
     addUser(username: String!): User!

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLibraryPrepMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLibraryPrepMutation.java
@@ -1,0 +1,197 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.model.reagentplate.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.LibraryPrepRequest;
+import uk.ac.sanger.sccp.stan.service.store.StorelightClient;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.asList;
+
+/**
+ * Tests that {@link LibraryPrepRequest} is performed correctly.
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Sql("/testdata/tag_layout_setup.sql")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestLibraryPrepMutation {
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private EntityCreator entityCreator;
+    @Autowired
+    private GraphQLTester tester;
+    @Autowired
+    private LabwareRepo lwRepo;
+    @Autowired
+    private OperationRepo opRepo;
+    @Autowired
+    private LabwareNoteRepo noteRepo;
+    @Autowired
+    private ReagentPlateRepo reagentPlateRepo;
+    @Autowired
+    private ReagentSlotRepo reagentSlotRepo;
+    @Autowired
+    private ReagentActionRepo reagentActionRepo;
+    @Autowired
+    private MeasurementRepo measurementRepo;
+    @Autowired
+    private OperationCommentRepo opComRepo;
+    @Autowired
+    private TagLayoutRepo tagLayoutRepo;
+    @MockBean
+    StorelightClient mockStorelightClient;
+
+    private final Address A1 = new Address(1,1), A2 = new Address(1,2);
+
+    @Transactional
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testLibraryPrep(boolean variant) throws Exception {
+        Sample sample = entityCreator.createSample(null, null);
+        LabwareType lt = entityCreator.createLabwareType("lt", 1, 2);
+        Labware sourceLw = entityCreator.createLabware("STAN-1", lt, sample, sample);
+        BioState bs = entityCreator.createBioState("Probes");
+        Integer layoutId = tagLayoutRepo.layoutIdForReagentPlateType(ReagentPlate.TYPE_FFPE);
+        assertNotNull(layoutId);
+        Labware existingDest;
+        if (variant) {
+            Sample probeSample = entityCreator.createSample(sample.getTissue(), null, bs);
+            LabwareType lt2 = entityCreator.createLabwareType("lt2", 2, 2);
+            existingDest = entityCreator.createLabware("STAN-2", lt2, null, null, probeSample, probeSample);
+            assertEquals(Labware.State.active, existingDest.getState());
+            createReagentPlate("012345678901234567890123", ReagentPlate.TYPE_FFPE, layoutId);
+        } else {
+            existingDest = null;
+        }
+        entityCreator.createOpType("Transfer", null, OperationTypeFlag.ACTIVE_DEST);
+        entityCreator.createOpType("Dual index plate", null, OperationTypeFlag.IN_PLACE, OperationTypeFlag.REAGENT_TRANSFER);
+        entityCreator.createOpType("Amplification", null, OperationTypeFlag.IN_PLACE);
+        Work work = entityCreator.createWork(null, null, null, null, null);
+        String mutation = tester.readGraphQL(variant ? "libraryprepexistant.graphql" : "libraryprep.graphql")
+                .replace("[WORK]", work.getWorkNumber());
+        User user = entityCreator.createUser("user1");
+        tester.setUser(user);
+        stubStorelightUnstore(mockStorelightClient);
+        Object response = tester.post(mutation);
+        Object opresdata = chainGet(response, "data", "libraryPrep");
+        List<Map<String,?>> lwData = chainGet(opresdata, "labware");
+        List<Map<String,?>> opData = chainGet(opresdata, "operations");
+        assertThat(opData.stream().map(od -> chainGet(od, "operationType", "name")))
+                .containsExactly("Transfer", "Dual index plate", "Amplification");
+        assertThat(lwData).hasSize(1);
+        String destBarcode = chainGet(lwData, 0, "barcode");
+        assertNotEquals(sourceLw.getBarcode(), destBarcode);
+        if (existingDest!=null) {
+            assertEquals(existingDest.getBarcode(), destBarcode);
+        }
+        Labware lw = lwRepo.getByBarcode(destBarcode);
+        Address[] addresses = {A1, A2};
+        Arrays.stream(addresses).map(ad -> lw.getSlot(ad).getSamples())
+                        .forEach(sams -> {
+                            assertThat(sams).hasSize(1);
+                            Sample sam = sams.getFirst();
+                            assertEquals(bs, sam.getBioState());
+                        });
+        int[] opIds = opData.stream().mapToInt(od -> (Integer) od.get("id")).toArray();
+        checkTransfer(opIds[0], sourceLw, lw);
+        checkReagentTransfer(opIds[1], lw, layoutId);
+        checkAmplification(opIds[2], lw);
+        if (variant) {
+            verifyNoInteractions(mockStorelightClient);
+        } else {
+            verifyStorelightQuery(mockStorelightClient, List.of("unstoreBarcodes", sourceLw.getBarcode()), user.getUsername());
+        }
+        entityManager.refresh(work);
+        assertThat(work.getOperationIds()).containsExactlyElementsOf(Arrays.stream(opIds).boxed()::iterator);
+    }
+
+    @NotNull
+    private ReagentPlate createReagentPlate(String barcode, String plateType, Integer layoutId) {
+        ReagentPlate reagentPlate = reagentPlateRepo.save(new ReagentPlate(barcode, plateType, layoutId));
+        final ReagentPlateLayout plateLayout = reagentPlate.getPlateLayout();
+        Integer rpId = reagentPlate.getId();
+        var slots = reagentSlotRepo.saveAll(Address.stream(plateLayout.getNumRows(), plateLayout.getNumColumns())
+                .map(ad -> new ReagentSlot(null, rpId, ad, false))
+                .toList());
+        reagentPlate.setSlots(asList(slots));
+        return reagentPlate;
+    }
+
+    private void checkTransfer(int opId, Labware sourceLw, Labware lw) {
+        Operation transfer = opRepo.findById(opId).orElseThrow();
+        assertEquals("Transfer", transfer.getOperationType().getName());
+        List<Action> transferActions = transfer.getActions();
+        assertThat(transferActions.stream()
+                .map(Action::getSource)).containsExactly(sourceLw.getSlot(A1), sourceLw.getSlot(A2));
+        assertThat(transferActions.stream()
+                .map(Action::getDestination)).containsExactly(lw.getSlot(A1), lw.getSlot(A2));
+        List<LabwareNote> notes = noteRepo.findAllByOperationIdIn(List.of(transfer.getId()));
+        assertThat(notes).hasSize(3);
+        assertThat(notes).allMatch(note -> note.getLabwareId().equals(lw.getId()));
+        Map<String, String> noteMap = notes.stream()
+                .collect(toMap(LabwareNote::getName, LabwareNote::getValue));
+        assertEquals("Faculty", noteMap.get("costing"));
+        assertEquals("123456", noteMap.get("lot"));
+        assertEquals("234567", noteMap.get("probe lot"));
+    }
+
+    private void checkReagentTransfer(int opId, Labware lw, Integer layoutId) {
+        Operation op = opRepo.findById(opId).orElseThrow();
+        assertEquals("Dual index plate", op.getOperationType().getName());
+        List<Action> actions = op.getActions();
+        actions.forEach(ac -> assertEquals(ac.getSource(), ac.getDestination()));
+        Slot[] transferSlots = Stream.of(A1, A2).map(lw::getSlot).toArray(Slot[]::new);
+        Slot[] filledSlots = lw.getSlots().stream().filter(slot -> !slot.getSamples().isEmpty()).toArray(Slot[]::new);
+        assertThat(actions.stream().map(Action::getDestination)).containsExactlyInAnyOrder(filledSlots);
+        List<ReagentAction> ras = reagentActionRepo.findAllByOperationIdIn(List.of(opId));
+        assertThat(ras.stream().map(ReagentAction::getDestination)).containsExactlyInAnyOrder(transferSlots);
+        ReagentPlate rp = reagentPlateRepo.getByBarcode("012345678901234567890123");
+        assertEquals(ReagentPlate.TYPE_FFPE, rp.getPlateType());
+        assertEquals(layoutId, rp.getTagLayoutId());
+        assertThat(ras.stream().map(ReagentAction::getReagentSlot)).containsExactly(rp.getSlot(A1), rp.getSlot(A2));
+    }
+
+    private void checkAmplification(int opId, Labware lw) {
+        Operation op = opRepo.findById(opId).orElseThrow();
+        assertEquals("Amplification", op.getOperationType().getName());
+        List<Action> actions = op.getActions();
+        actions.forEach(ac -> assertEquals(ac.getSource(), ac.getDestination()));
+        Slot[] filledSlots = lw.getSlots().stream().filter(slot -> !slot.getSamples().isEmpty()).toArray(Slot[]::new);
+        assertThat(actions.stream().map(Action::getDestination)).containsExactlyInAnyOrder(filledSlots);
+        List<Measurement> measurements = measurementRepo.findAllByOperationIdIn(List.of(opId));
+        final Integer[] slotIds = {lw.getSlot(A1).getId(), lw.getSlot(A2).getId()};
+        assertThat(measurements.stream().map(Measurement::getSlotId)).containsExactly(slotIds);
+        assertThat(measurements.stream()
+                        .mapToInt(meas -> (int) Double.parseDouble(meas.getValue()))).containsExactly(10, 20);
+        assertThat(measurements.stream().map(Measurement::getName)).allMatch("Cq value"::equals);
+        List<OperationComment> opcoms = opComRepo.findAllByOperationIdIn(List.of(opId));
+        assertThat(opcoms.stream().map(OperationComment::getSlotId)).containsExactly(slotIds);
+        assertThat(opcoms.stream().mapToInt(oc -> oc.getComment().getId())).containsExactly(1,2);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepService.java
@@ -1,0 +1,191 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.Transactor;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.model.reagentplate.ReagentPlate;
+import uk.ac.sanger.sccp.stan.request.*;
+import uk.ac.sanger.sccp.stan.service.LibraryPrepServiceImp.RequestData;
+import uk.ac.sanger.sccp.stan.service.store.StoreService;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.*;
+
+/**
+ * Test {@link LibraryPrepServiceImp}
+ */
+class TestLibraryPrepService {
+    @Mock
+    private SlotCopyService mockSlotCopyService;
+    @Mock
+    private ReagentTransferService mockReagentTransferService;
+    @Mock
+    private OpWithSlotMeasurementsService mockOpWithSlotMeasurementsService;
+    @Mock
+    private StoreService mockStoreService;
+    @Mock
+    private LibraryPrepValidationService mockValService;
+    @Mock
+    private Transactor mockTransactor;
+
+    @InjectMocks
+    private LibraryPrepServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void teardown() throws Exception {
+        mocking.close();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "true,true,true",
+            "false,true,false",
+            "true,false,false",
+            "true,true,false",
+    })
+    void testPerform(boolean hasUser, boolean hasRequest, boolean succeeds) {
+        mockTransactor(mockTransactor);
+        User user = hasUser ? EntityFactory.getUser() : null;
+        LibraryPrepRequest request;
+        if (hasRequest) {
+            request = new LibraryPrepRequest();
+            request.setWorkNumber("SGP1");
+        } else {
+            request = null;
+        }
+        OperationResult opres = null;
+        if (hasRequest) {
+            if (succeeds) {
+                opres = new OperationResult(List.of(new Operation()), List.of(EntityFactory.getTube()));
+                final OperationResult finalOpRes = opres;
+                doAnswer(invocation -> {
+                    RequestData data = invocation.getArgument(0);
+                    data.barcodesToUnstore.add("unstorebarcode");
+                    return finalOpRes;
+                }).when(service).performInsideTransaction(any());
+            } else {
+                ValidationException ex = new ValidationException(List.of("Bad"));
+                doThrow(ex).when(service).performInsideTransaction(any());
+            }
+        }
+
+        if (!hasRequest) {
+            assertValidationException(() -> service.perform(user, null), List.of("No request supplied."));
+            verify(service, never()).performInsideTransaction(any());
+            verifyNoInteractions(mockTransactor);
+            return;
+        }
+
+        if (succeeds) {
+            assertSame(opres, service.perform(user, request));
+        } else {
+            assertValidationException(() -> service.perform(user, request), List.of("Bad"));
+        }
+        verify(mockTransactor).transact(eq("LibraryPrep"), any());
+        ArgumentCaptor<RequestData> dataCaptor = ArgumentCaptor.forClass(RequestData.class);
+        verify(service).performInsideTransaction(dataCaptor.capture());
+        RequestData data = dataCaptor.getValue();
+        assertSame(data.request, request);
+        assertSame(data.user, user);
+        assertProblem(data.problems, user==null ? "No user supplied." : null);
+        if (succeeds) {
+            verify(mockStoreService).discardStorage(user, Set.of("unstorebarcode"));
+        } else {
+            verifyNoInteractions(mockStoreService);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "false,false",
+            "true,false",
+            "false,true",
+            "true,true"
+    })
+    public void testPerformInsideTransaction(boolean priorProblem, boolean newProblem) {
+        RequestData data = new RequestData(new LibraryPrepRequest(), EntityFactory.getUser(), new ArrayList<>());
+        if (priorProblem) {
+            data.problems.add("Prior problem.");
+        }
+        if (newProblem) {
+            doAnswer(invocation -> {
+                RequestData rd = invocation.getArgument(0);
+                rd.problems.add("New problem.");
+                return null;
+            }).when(mockValService).validate(any());
+        }
+        List<String> expectedProblems = new ArrayList<>(2);
+        if (priorProblem) {
+            expectedProblems.add("Prior problem.");
+        }
+        if (newProblem) {
+            expectedProblems.add("New problem.");
+        }
+        OperationResult opres = expectedProblems.isEmpty() ?
+                new OperationResult(List.of(new Operation()), List.of(EntityFactory.getTube()))
+                : null;
+        doReturn(opres).when(service).record(any());
+        if (expectedProblems.isEmpty()) {
+            assertSame(opres, service.performInsideTransaction(data));
+            verify(service).record(data);
+        } else {
+            assertValidationException(() -> service.performInsideTransaction(data), expectedProblems);
+            verify(service, never()).record(any());
+        }
+    }
+
+    @Test
+    void testRecord() {
+        Labware destLw = EntityFactory.getTube();
+        Operation[] ops = IntStream.rangeClosed(1,3).mapToObj(i -> {
+            Operation op = new Operation();
+            op.setId(i);
+            return op;
+        }).toArray(Operation[]::new);
+        OperationResult[] opreses = Arrays.stream(ops).map(op -> new OperationResult(List.of(op), List.of(destLw)))
+                .toArray(OperationResult[]::new);
+        when(mockSlotCopyService.record(any(), any(), any())).thenReturn(opreses[0]);
+        when(mockReagentTransferService.record(any(), any(), any(), any(), any(), any(), any())).thenReturn(opreses[1]);
+        when(mockOpWithSlotMeasurementsService.execute(any(), any(), any(), any(), any(), any())).thenReturn(opreses[2]);
+
+        LibraryPrepRequest request = new LibraryPrepRequest();
+        User user = EntityFactory.getUser();
+        RequestData data = new RequestData(request, user, List.of());
+        data.slotCopyData = new SlotCopyValidationService.Data(new SlotCopyRequest());
+        data.reagentOpType = EntityFactory.makeOperationType("Dual index plate", null);
+        data.work = EntityFactory.makeWork("SGP1");
+        data.request.setReagentTransfers(List.of(new ReagentTransferRequest.ReagentTransfer()));
+        data.reagentPlates = UCMap.from(ReagentPlate::getBarcode, EntityFactory.makeReagentPlate("RP1"));
+        data.ampOpType = EntityFactory.makeOperationType("Amplify", null);
+        data.comments = List.of(new Comment(1, "com1", "cat1"));
+        data.sanitisedMeasurements = List.of(new SlotMeasurementRequest(new Address(1,1), "name", "value", 1));
+
+        OperationResult opres = service.record(data);
+        assertThat(opres.getOperations()).containsExactly(ops);
+        assertThat(opres.getLabware()).containsExactly(destLw);
+
+        verify(mockSlotCopyService).record(user, data.slotCopyData, data.barcodesToUnstore);
+        verify(mockReagentTransferService).record(user, data.reagentOpType, data.work, data.request.getReagentTransfers(),
+                data.reagentPlates, data.destination, data.reagentPlateType);
+        verify(mockOpWithSlotMeasurementsService).execute(user, destLw, data.ampOpType, data.work, data.comments, data.sanitisedMeasurements);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepValidationService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepValidationService.java
@@ -1,0 +1,188 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.model.reagentplate.ReagentPlate;
+import uk.ac.sanger.sccp.stan.request.*;
+import uk.ac.sanger.sccp.stan.request.ReagentTransferRequest.ReagentTransfer;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyContent;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyDestination;
+import uk.ac.sanger.sccp.stan.service.LibraryPrepServiceImp.RequestData;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.mayAddProblem;
+
+class TestLibraryPrepValidationService {
+    @Mock
+    private SlotCopyValidationService mockScValService;
+    @Mock
+    private ReagentTransferValidatorService mockRtValService;
+    @Mock
+    private ReagentTransferService mockRtService;
+    @Mock
+    private OpWithSlotMeasurementsService mockOwsmService;
+
+    @InjectMocks
+    private LibraryPrepValidationServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @Test
+    void testValidate() {
+        RequestData data = new RequestData(new LibraryPrepRequest(), EntityFactory.getUser(), List.of());
+        List<BiConsumer<LibraryPrepValidationServiceImp, RequestData>> subFunctions = List.of(
+                LibraryPrepValidationServiceImp::scValidate,
+                LibraryPrepValidationServiceImp::rtValidate,
+                LibraryPrepValidationServiceImp::owsmValidate
+        );
+        subFunctions.forEach(func -> func.accept(doNothing().when(service), any()));
+        service.validate(data);
+        subFunctions.forEach(func -> func.accept(verify(service), data));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    void testScValidate(boolean existingDest) {
+        Work work = EntityFactory.makeWork("SGP1");
+        Labware lw = (existingDest ? EntityFactory.getTube() : null);
+        LabwareType lt = EntityFactory.getTubeType();
+        when(mockScValService.validateRequest(any(), any())).then(invocation -> {
+            SlotCopyRequest scRequest = invocation.getArgument(1);
+            SlotCopyValidationService.Data scData = new SlotCopyValidationService.Data(scRequest);
+            if (existingDest) {
+                scData.destLabware = UCMap.from(Labware::getBarcode, lw);
+            } else {
+                scData.lwTypes = UCMap.from(LabwareType::getName, lt);
+            }
+            scData.work = work;
+            scData.problems.add("sc problem");
+            return scData;
+        });
+
+        LibraryPrepRequest request = new LibraryPrepRequest();
+        request.setWorkNumber("SGP1");
+        request.setSources(List.of(new SlotCopyRequest.SlotCopySource("STAN-1", Labware.State.active)));
+        request.setDestination(new SlotCopyDestination());
+        if (existingDest) {
+            request.getDestination().setBarcode("STAN-1");
+        } else {
+            request.getDestination().setLabwareType(lt.getName());
+        }
+        final User user = EntityFactory.getUser();
+        RequestData data = new RequestData(request, user, new ArrayList<>());
+
+        service.scValidate(data);
+
+        SlotCopyRequest expectedScRequest = new SlotCopyRequest("Transfer", "SGP1",
+                request.getSources(), List.of(request.getDestination()));
+        verify(mockScValService).validateRequest(user, expectedScRequest);
+
+        if (existingDest) {
+            assertSame(data.destination, lw);
+            assertSame(data.destLabwareType, lw.getLabwareType());
+        } else {
+            assertNull(data.destination);
+            assertSame(data.destLabwareType, lt);
+        }
+        assertSame(data.work, work);
+        assertThat(data.problems).containsExactly("sc problem");
+        assertNotNull(data.slotCopyData);
+    }
+
+    @Test
+    void testRtValidate() {
+        LibraryPrepRequest request = new LibraryPrepRequest();
+        User user = EntityFactory.getUser();
+        RequestData data = new RequestData(request, user, new ArrayList<>());
+        data.destLabwareType = EntityFactory.getTubeType();
+        request.setReagentTransfers(List.of(new ReagentTransfer("RPNC", null, null)));
+        request.setReagentPlateType("reagent plate type");
+        OperationType opType = EntityFactory.makeOperationType("Dual index plate", null);
+        UCMap<ReagentPlate> reagentPlates = UCMap.from(ReagentPlate::getBarcode, EntityFactory.makeReagentPlate("RPBC"));
+        String reagentPlateType = "sanitised reagent plate type";
+
+        when(mockRtService.loadOpType(any(), any())).thenReturn(opType);
+        when(mockRtService.loadReagentPlates(any())).thenReturn(reagentPlates);
+        when(mockRtService.checkPlateType(any(), any(), any())).thenReturn(reagentPlateType);
+        mayAddProblem("transfer problem").when(mockRtValService).validateTransfers(any(), any(), any(), any());
+
+        service.rtValidate(data);
+        verify(mockRtService).loadOpType(data.problems, "Dual index plate");
+        verify(mockRtService).loadReagentPlates(request.getReagentTransfers());
+        verify(mockRtService).checkPlateType(data.problems, reagentPlates.values(), request.getReagentPlateType());
+        verify(mockRtValService).validateTransfers(data.problems, request.getReagentTransfers(), reagentPlates, data.destLabwareType);
+
+        assertSame(data.reagentOpType, opType);
+        assertSame(data.reagentPlates, reagentPlates);
+        assertSame(data.reagentPlateType, reagentPlateType);
+    }
+
+    @Test
+    void testOwsmValidate_noLabwareType() {
+        RequestData data = new RequestData(new LibraryPrepRequest(), EntityFactory.getUser(), new ArrayList<>());
+        service.owsmValidate(data);
+        verifyNoInteractions(mockOwsmService);
+    }
+
+    @Test
+    public void testOwsmValidate() {
+        LibraryPrepRequest request = new LibraryPrepRequest();
+        final SlotCopyDestination scd = new SlotCopyDestination();
+        final Address A1 = new Address(1, 1), A2 = new Address(1, 2);
+        scd.setContents(List.of(
+                new SlotCopyContent("STAN-1", A1, A1),
+                new SlotCopyContent("STAN-2", A1, A2),
+                new SlotCopyContent("STAN-3", A1, null)
+        ));
+        request.setDestination(scd);
+        request.setSlotMeasurements(List.of(new SlotMeasurementRequest()));
+
+        User user = EntityFactory.getUser();
+        RequestData data = new RequestData(request, user, new ArrayList<>());
+        data.destLabwareType = EntityFactory.getTubeType();
+
+        OperationType opType = EntityFactory.makeOperationType("Amplification", null);
+        List<Comment> validatedComments = List.of(new Comment(1, "Bananas", "custard"));
+        List<SlotMeasurementRequest> sanitisedMeasurements = List.of(new SlotMeasurementRequest(A1, "Alpha", "Beta", 1));
+
+        mayAddProblem("Bad address").when(mockOwsmService).validateAddresses(any(), any(), any(), any());
+        when(mockOwsmService.loadOpType(any(), any())).thenReturn(opType);
+        when(mockOwsmService.validateComments(any(), any())).thenReturn(validatedComments);
+        when(mockOwsmService.sanitiseMeasurements(any(), any(), any())).thenReturn(sanitisedMeasurements);
+        mayAddProblem("Bad measurement").when(mockOwsmService).checkForDupeMeasurements(any(), any());
+
+        service.owsmValidate(data);
+        verify(mockOwsmService).validateAddresses(data.problems, data.destLabwareType, Set.of(A1, A2), data.request.getSlotMeasurements());
+        verify(mockOwsmService).loadOpType(data.problems, "Amplification");
+        verify(mockOwsmService).validateComments(data.problems, data.request.getSlotMeasurements());
+        verify(mockOwsmService).sanitiseMeasurements(data.problems, opType, data.request.getSlotMeasurements());
+        verify(mockOwsmService).checkForDupeMeasurements(data.problems, sanitisedMeasurements);
+
+        assertSame(data.ampOpType, opType);
+        assertSame(data.comments, validatedComments);
+        assertSame(data.sanitisedMeasurements, sanitisedMeasurements);
+        assertThat(data.problems).containsExactlyInAnyOrder("Bad address", "Bad measurement");
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestOpWithSlotMeasurementsService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestOpWithSlotMeasurementsService.java
@@ -205,16 +205,12 @@ public class TestOpWithSlotMeasurementsService {
             "Transfer, Operation cannot be recorded in place: Transfer",
     })
     public void testLoadOpType(String opName, String expectedProblem) {
-        OperationType opType;
-        switch (coalesce(opName, "")) {
-            case OP_VISIUM_CONC: case OP_AMP: case "Bake":
-                opType = EntityFactory.makeOperationType(opName, null, OperationTypeFlag.IN_PLACE);
-                break;
-            case "Transfer":
-                opType = EntityFactory.makeOperationType(opName, null);
-                break;
-            default: opType = null;
-        }
+        OperationType opType = switch (coalesce(opName, "")) {
+            case OP_VISIUM_CONC, OP_AMP, "Bake" ->
+                    EntityFactory.makeOperationType(opName, null, OperationTypeFlag.IN_PLACE);
+            case "Transfer" -> EntityFactory.makeOperationType(opName, null);
+            default -> null;
+        };
         if (opName!=null && !opName.isEmpty()) {
             when(mockOpTypeRepo.findByName(opName)).thenReturn(Optional.ofNullable(opType));
         }
@@ -457,23 +453,13 @@ public class TestOpWithSlotMeasurementsService {
             "Cycles,024,24,",
     })
     public void testSanitiseMeasurementValue(String name, String value, String sanValue, String problem) {
-        Sanitiser<String> san;
         List<Sanitiser<String>> sans = List.of(mockConcSan, mockCqSan, mockCycSan);
-        switch (name) {
-            case "cDNA concentration":
-            case "Library concentration":
-                san = mockConcSan;
-                break;
-            case "Cq value":
-                san = mockCqSan;
-                break;
-            case "Cycles":
-                san = mockCycSan;
-                break;
-            default:
-                san = null;
-                break;
-        }
+        Sanitiser<String> san = switch (name) {
+            case "cDNA concentration", "Library concentration" -> mockConcSan;
+            case "Cq value" -> mockCqSan;
+            case "Cycles" -> mockCycSan;
+            default -> null;
+        };
         if (san!=null) {
             mayAddProblem(problem, sanValue).when(san).sanitise(any(), any());
         }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestQCLabwareService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestQCLabwareService.java
@@ -82,8 +82,8 @@ public class TestQCLabwareService {
         List<QCLabware> qcls = request.getLabware();
 
         doReturn(opType).when(mockVal).checkOpType(anyString(), any(OperationTypeFlag.class));
-        doReturn(lwMap).when(mockVal).checkLabware(any());
-        doReturn(workMap).when(mockVal).checkWork(any());
+        doReturn(lwMap).when(mockVal).checkLabware(anyCollection());
+        doReturn(workMap).when(mockVal).checkWork(anyCollection());
         doNothing().when(service).checkTimestamps(any(), any(), any(), any());
         doReturn(commentMap).when(mockVal).checkCommentIds(any());
 
@@ -111,8 +111,8 @@ public class TestQCLabwareService {
         assertValidationException(() -> service.perform(user, request), List.of("No labware specified."));
 
         verify(mockVal).checkOpType(request.getOperationType(), OperationTypeFlag.IN_PLACE);
-        verify(mockVal, never()).checkLabware(any());
-        verify(mockVal, never()).checkWork(any());
+        verify(mockVal, never()).checkLabware(anyCollection());
+        verify(mockVal, never()).checkWork(anyCollection());
         verify(service, never()).checkTimestamps(any(), any(), any(), any());
         verify(service, never()).checkComments(any(), any());
         verify(service, never()).record(any(), any(), any(), any(), any(), any());
@@ -133,8 +133,8 @@ public class TestQCLabwareService {
         problems.add("Problem B.");
 
         when(mockVal.checkOpType(any(), any(OperationTypeFlag.class))).thenReturn(opType);
-        when(mockVal.checkLabware(any())).thenReturn(lwMap);
-        when(mockVal.checkWork(any())).thenReturn(workMap);
+        when(mockVal.checkLabware(anyCollection())).thenReturn(lwMap);
+        when(mockVal.checkWork(anyCollection())).thenReturn(workMap);
 
         doAnswer(addProblem("Bad time")).when(service).checkTimestamps(any(), any(), any(), any());
         doAnswer(addProblem("Bad comment", commentMap)).when(service).checkComments(any(), any());

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestReagentTransferService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestReagentTransferService.java
@@ -17,15 +17,13 @@ import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.UCMap;
 
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static uk.ac.sanger.sccp.stan.Matchers.addProblem;
-import static uk.ac.sanger.sccp.stan.Matchers.assertValidationException;
+import static uk.ac.sanger.sccp.stan.Matchers.*;
 
 /**
  * Tests {@link ReagentTransferServiceImp}
@@ -34,7 +32,7 @@ public class TestReagentTransferService {
     private OperationTypeRepo mockOpTypeRepo;
     private ReagentActionRepo mockReagentActionRepo;
     private LabwareRepo mockLwRepo;
-    private Validator<String> mockReagentPlateBarcodeValidator;
+    private ReagentTransferValidatorService mockValService;
     private LabwareValidatorFactory mockLwValFactory;
     private OperationService mockOpService;
     private ReagentPlateService mockReagentPlateService;
@@ -43,13 +41,12 @@ public class TestReagentTransferService {
 
     private ReagentTransferServiceImp service;
 
-    @SuppressWarnings("unchecked")
     @BeforeEach
     void setup() {
         mockOpTypeRepo = mock(OperationTypeRepo.class);
         mockReagentActionRepo = mock(ReagentActionRepo.class);
         mockLwRepo = mock(LabwareRepo.class);
-        mockReagentPlateBarcodeValidator = mock(Validator.class);
+        mockValService = mock(ReagentTransferValidatorService.class);
         mockLwValFactory = mock(LabwareValidatorFactory.class);
         mockOpService = mock(OperationService.class);
         mockReagentPlateService = mock(ReagentPlateService.class);
@@ -57,7 +54,7 @@ public class TestReagentTransferService {
         mockBioStateReplacer = mock(BioStateReplacer.class);
 
         service = spy(new ReagentTransferServiceImp(mockOpTypeRepo, mockReagentActionRepo, mockLwRepo,
-                mockReagentPlateBarcodeValidator, mockLwValFactory, mockOpService, mockReagentPlateService,
+                mockValService, mockLwValFactory, mockOpService, mockReagentPlateService,
                 mockWorkService, mockBioStateReplacer));
     }
 
@@ -235,91 +232,20 @@ public class TestReagentTransferService {
     }
 
     @ParameterizedTest
-    @MethodSource("validateTransfersArgs")
-    public void testValidateTransfers(Collection<ReagentTransfer> transfers, UCMap<ReagentPlate> rpMap, Labware lw,
-                                      Collection<String> expectedProblems) {
-        when(mockReagentPlateBarcodeValidator.validate(any(), any())).then(invocation -> {
-            String bc = invocation.getArgument(0);
-            if (bc.contains("!")) {
-                Consumer<String> addProblem = invocation.getArgument(1);
-                addProblem.accept("Bad barcode: "+bc);
-                return false;
-            }
-            return true;
-        });
-        final List<String> problems = new ArrayList<>(expectedProblems.size());
+    @ValueSource(booleans={false,true})
+    public void testValidateTransfers(boolean valid) {
+        final String problem = valid ? null : "Bad transfers.";
+        mayAddProblem(problem).when(mockValService).validateTransfers(any(), any(), any(), any());
+
+        final List<String> problems = new ArrayList<>(valid ? 0 : 1);
+        List<ReagentTransfer> transfers = List.of(
+                new ReagentTransfer("RP1", new Address(1,1), new Address(1,2))
+        );
+        UCMap<ReagentPlate> rpMap = UCMap.from(ReagentPlate::getBarcode, EntityFactory.makeReagentPlate("RP1"));
+        Labware lw = EntityFactory.getTube();
         service.validateTransfers(problems, transfers, rpMap, lw);
-        assertThat(problems).containsExactlyInAnyOrderElementsOf(expectedProblems);
-    }
-
-    @SuppressWarnings("unchecked")
-    static Stream<Arguments> validateTransfersArgs() {
-        final String bc1 = "123";
-        final String bc2 = "456";
-        ReagentPlate rp1 = EntityFactory.makeReagentPlate(bc1);
-        ReagentPlate rp2 = EntityFactory.makeReagentPlate(bc2);
-        for (int c = 1; c <= rp2.getPlateLayout().getNumColumns(); ++c) {
-            rp2.getSlot(new Address(2,c)).setUsed(true);
-        }
-        UCMap<ReagentPlate> rpMap = UCMap.from(ReagentPlate::getBarcode, rp1, rp2);
-        Labware lw = EntityFactory.makeEmptyLabware(EntityFactory.makeLabwareType(2,3));
-        final Address A1 = new Address(1,1);
-        final Address A2 = new Address(1,2);
-        final Address B1 = new Address(2,1);
-        final Address B2 = new Address(2,2);
-
-        return Arrays.stream(new Object[][]{
-                {List.of(new ReagentTransfer(bc1, A1, A1), new ReagentTransfer(bc1, A2, A2), new ReagentTransfer(bc2, A1, B1),
-                        new ReagentTransfer("999", A1, B2)), null},
-                {null, "No transfers specified."},
-                {List.of(), "No transfers specified."},
-                {new ReagentTransfer(null, A1, A1), "Missing reagent plate barcode for transfer."},
-                {new ReagentTransfer(bc1, null, A1), "Missing reagent slot address for transfer."},
-                {new ReagentTransfer(bc1, A1, null), "Missing destination slot address for transfer."},
-                {List.of(new ReagentTransfer(bc1, new Address(1, 13), A1),
-                        new ReagentTransfer("789", new Address(1, 14), A2),
-                        new ReagentTransfer(bc1, new Address(1, 1), B1)),
-                        "Invalid reagent slots specified: [slot A13 in reagent plate 123, slot A14 in reagent plate 789]"},
-                {List.of(new ReagentTransfer(bc1, A1, new Address(3, 1)),
-                        new ReagentTransfer(bc1, A2, new Address(1, 4))),
-                        "Invalid destination slots specified: [C1, A4]"},
-                {List.of(new ReagentTransfer(bc1, A1, A1), new ReagentTransfer(bc1, A2, A2), new ReagentTransfer(bc1, A2, B1)),
-                        "Repeated reagent slot specified: [slot A2 in reagent plate 123]"},
-                {List.of(new ReagentTransfer(bc1, A1, A1), new ReagentTransfer(bc2, B1, A2), new ReagentTransfer(bc2, B2, B2)),
-                        "Reagent slots already used: [slot B1 in reagent plate 456, slot B2 in reagent plate 456]"},
-                {List.of(new ReagentTransfer("BC!", A1, A1), new ReagentTransfer(bc1, B1, A2)),
-                        "Bad barcode: BC!"},
-                {List.of(new ReagentTransfer(bc1, A1, A1), new ReagentTransfer(bc1, A1, A1),
-                        new ReagentTransfer(null, null, null),
-                        new ReagentTransfer(bc1, new Address(1, 13), new Address(3, 1)),
-                        new ReagentTransfer(bc2, B1, B2),
-                        new ReagentTransfer("BC!", A1, A1)),
-                        List.of("Missing reagent plate barcode for transfer.",
-                                "Missing reagent slot address for transfer.",
-                                "Missing destination slot address for transfer.",
-                                "Invalid reagent slot specified: [slot A13 in reagent plate 123]",
-                                "Invalid destination slot specified: [C1]",
-                                "Reagent slot already used: [slot B1 in reagent plate 456]",
-                                "Repeated reagent slot specified: [slot A1 in reagent plate 123]",
-                                "Bad barcode: BC!"
-                        )},
-        }).map(arr -> {
-            Collection<ReagentTransfer> transfers;
-            if (arr[0]==null || arr[0] instanceof Collection) {
-                transfers = (Collection<ReagentTransfer>) arr[0];
-            } else {
-                transfers = List.of((ReagentTransfer) arr[0]);
-            }
-            Collection<String> expectedProblems;
-            if (arr[1]==null) {
-                expectedProblems = List.of();
-            } else if (arr[1] instanceof Collection) {
-                expectedProblems = (Collection<String>) arr[1];
-            } else {
-                expectedProblems = List.of((String) arr[1]);
-            }
-            return Arguments.of(transfers, rpMap, lw, expectedProblems);
-        });
+        verify(mockValService).validateTransfers(problems, transfers, rpMap, lw.getLabwareType());
+        assertProblem(problems, problem);
     }
 
     @Test
@@ -331,7 +257,7 @@ public class TestReagentTransferService {
         String plateType = ReagentPlate.TYPE_FFPE;
         UCMap<ReagentPlate> rpmap = UCMap.from(ReagentPlate::getBarcode, new ReagentPlate("123", plateType));
         Labware lw = EntityFactory.getTube();
-        Sample sam = lw.getFirstSlot().getSamples().get(0);
+        Sample sam = lw.getFirstSlot().getSamples().getFirst();
         List<Action> actions = List.of(new Action(null, null, lw.getFirstSlot(), lw.getFirstSlot(), sam, sam));
         Operation op = EntityFactory.makeOpForLabware(opType, List.of(lw), List.of(lw));
         doNothing().when(service).createReagentPlates(any(), any(), any());
@@ -384,7 +310,7 @@ public class TestReagentTransferService {
         List<Action> actions;
         if (withActions) {
             Slot slot = lw.getFirstSlot();
-            Sample sample = slot.getSamples().get(0);
+            Sample sample = slot.getSamples().getFirst();
             actions = List.of(new Action(null,  null, slot, slot, sample, sample));
         } else {
             actions = null;

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestSlotCopyValidationService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestSlotCopyValidationService.java
@@ -1,0 +1,661 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.*;
+import uk.ac.sanger.sccp.stan.service.SlotCopyValidationService.Data;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelper;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelperFactory;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.assertProblem;
+import static uk.ac.sanger.sccp.stan.Matchers.mayAddProblem;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+
+/**
+ * Tests {@link SlotCopyValidationServiceImp}
+ */
+public class TestSlotCopyValidationService {
+    @Mock
+    LabwareTypeRepo mockLwTypeRepo;
+    @Mock
+    LabwareRepo mockLwRepo;
+    @Mock
+    BioStateRepo mockBsRepo;
+    @Mock
+    ValidationHelperFactory mockValHelperFactory;
+    @Mock
+    Validator<String> mockPreBarcodeValidator;
+    @Mock
+    Validator<String> mockLotNumberValidator;
+
+    SlotCopyValidationServiceImp service;
+    AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(new SlotCopyValidationServiceImp(mockLwTypeRepo, mockLwRepo, mockBsRepo, mockValHelperFactory,
+                mockPreBarcodeValidator, mockLotNumberValidator));
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testValidate_valid(boolean valid) {
+        User user = valid ? EntityFactory.getUser() : null;
+        SlotCopyRequest request = new SlotCopyRequest("optype", "sgp1",
+                List.of(new SlotCopySource("STAN-1", Labware.State.active)),
+                List.of(new SlotCopyDestination("lt1", "pb1", SlideCosting.Faculty, "lot1",
+                        "probelot1", List.of(new SlotCopyContent("STAN1", new Address(1,1), new Address(1,2))),
+                        "bs1")));
+        Data data = new Data(request);
+        ValidationHelper val = mock(ValidationHelper.class);
+        when(mockValHelperFactory.getHelper()).thenReturn(val);
+        OperationType opType = EntityFactory.makeOperationType("optype", null);
+        doReturn(opType).when(val).checkOpType(any());
+        UCMap<Labware> destLw = UCMap.from(Labware::getBarcode, EntityFactory.makeEmptyLabware(EntityFactory.getTubeType()));
+        doReturn(destLw).when(service).loadExistingDestinations(any(), any(), any());
+        UCMap<LabwareType> lwTypes = UCMap.from(LabwareType::getName, EntityFactory.getTubeType());
+        mayAddProblem(valid ? null : "bad lw type", lwTypes).when(service).loadLabwareTypes(any(), any());
+        mayAddProblem(valid ? null : "bad prebc").when(service).checkPreBarcodes(any(), any(), any());
+        mayAddProblem(valid ? null : "used prebc").when(service).checkPreBarcodesInUse(any(), any(), any());
+        UCMap<Labware> sourceLw = UCMap.from(Labware::getBarcode, EntityFactory.getTube());
+        mayAddProblem(valid ? null : "bad source", sourceLw).when(service).loadSources(any(), any(), any());
+        mayAddProblem(valid ? null : "bad listed souce").when(service).checkListedSources(any(), any());
+        mayAddProblem(valid ? null : "bad lot").when(service).validateLotNumbers(any(), any());
+        mayAddProblem(valid ? null : "bad contents").when(service).validateContents(any(), any(), any(), any(), any());
+        mayAddProblem(valid ? null : "bad ops").when(service).validateOps(any(), any(), any(), any());
+        UCMap<BioState> bsMap = UCMap.from(BioState::getName, EntityFactory.getBioState());
+        mayAddProblem(valid ? null : "bad bs", bsMap).when(service).validateBioStates(any(), any());
+        Work work = EntityFactory.makeWork("SGP1");
+        doReturn(work).when(val).checkWork(anyString());
+        doReturn(valid ? Set.of() : Set.of("val problem")).when(val).getProblems();
+        service.validate(user, data);
+        final Collection<String> problems = data.problems;
+        if (valid) {
+            assertThat(problems).isEmpty();
+        } else {
+            assertThat(problems).containsExactlyInAnyOrder(
+                    "No user supplied.", "val problem", "bad lw type", "bad prebc", "bad source",
+                    "bad listed souce", "bad lot", "bad contents", "bad ops", "bad bs", "used prebc"
+            );
+        }
+
+        verify(val).checkOpType(request.getOperationType());
+        List<SlotCopyDestination> scds = request.getDestinations();
+        verify(service).loadExistingDestinations(val, opType, scds);
+        verify(service).loadLabwareTypes(problems, scds);
+        verify(service).checkPreBarcodes(problems, scds, lwTypes);
+        verify(service).checkPreBarcodesInUse(problems, scds, destLw);
+        verify(service).loadSources(problems, val, scds);
+        verify(service).checkListedSources(problems, request);
+        verify(service).validateLotNumbers(problems, scds);
+        verify(service).validateContents(problems, lwTypes, sourceLw, destLw, request);
+        verify(service).validateOps(problems, scds, opType, lwTypes);
+        verify(service).validateBioStates(problems, scds);
+        verify(val).checkWork(request.getWorkNumber());
+        assertSame(data.destLabware, destLw);
+        assertSame(data.sourceLabware, sourceLw);
+        assertSame(data.bioStates, bsMap);
+        assertSame(data.opType, opType);
+        assertSame(data.work, work);
+        assertSame(data.lwTypes, lwTypes);
+    }
+
+    @Test
+    public void testValidate_noRequest() {
+        final Data data = new Data(null);
+        service.validate(EntityFactory.getUser(), data);
+        assertProblem(data.problems, "No request supplied.");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "LT1/LT2,",
+            "LT1//LT2, Labware type missing from request.",
+            "LTX/LT1/LT2, Unknown labware type: [LTX]",
+    })
+    public void testLoadLabwareTypes(String joinedLtNames, String expectedProblem) {
+        String[] ltNames = joinedLtNames.split("/");
+        final List<LabwareType> lts = IntStream.rangeClosed(1,3)
+                .mapToObj(i -> EntityFactory.makeLabwareType(1,1, "LT"+i))
+                .toList();
+        Set<String> nonNullNames = Arrays.stream(ltNames)
+                .filter(name -> !nullOrEmpty(name))
+                .collect(toSet());
+        when(mockLwTypeRepo.findAllByNameIn(any())).thenReturn(lts);
+        UCMap<LabwareType> ltMap = UCMap.from(lts, LabwareType::getName);
+        List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        List<SlotCopyDestination> scds = Arrays.stream(ltNames)
+                .map(name -> new SlotCopyDestination(name, null, null, null, null, null, null))
+                .toList();
+        assertEquals(ltMap, service.loadLabwareTypes(problems, scds));
+        assertProblem(problems, expectedProblem);
+        verify(mockLwTypeRepo).findAllByNameIn(nonNullNames);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ",false,false",
+            ",true,true",
+            "Reusing existing destinations is not supported for operation type opname.,true,false",
+    })
+    public void testLoadExistingDestinations(String expectedProblem, boolean anySupplied, boolean reuseAllowed) {
+        List<String> barcodes;
+        Labware lw = null;
+        if (!anySupplied) {
+            barcodes = Arrays.asList(null, null);
+        } else {
+            barcodes = List.of("", "STAN-1");
+            lw = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType(), "STAN-1");
+        }
+        OperationType opType;
+        if (reuseAllowed) {
+            opType =EntityFactory.makeOperationType("opname", null, OperationTypeFlag.ACTIVE_DEST);
+        } else {
+            opType = EntityFactory.makeOperationType("opname", null);
+        }
+        List<SlotCopyDestination> scds = barcodes.stream()
+                .map(bc -> new SlotCopyDestination())
+                .toList();
+        if (anySupplied) {
+            for (int i = 0; i < scds.size(); ++i) {
+                scds.get(i).setBarcode(barcodes.get(i));
+            }
+        }
+        ValidationHelper val = mock(ValidationHelper.class);
+        UCMap<Labware> lwMap;
+        if (lw!=null) {
+            lwMap = UCMap.from(Labware::getBarcode, lw);
+            when(val.loadActiveDestinations(anyCollection())).thenReturn(lwMap);
+        } else {
+            lwMap = new UCMap<>(0);
+        }
+        final Set<String> problems = new HashSet<>(expectedProblem==null ? 0 : 1);
+        when(val.getProblems()).thenReturn(problems);
+        assertEquals(lwMap, service.loadExistingDestinations(val, opType, scds));
+        assertProblem(problems, expectedProblem);
+        if (anySupplied) {
+            verify(val).loadActiveDestinations(List.of("STAN-1"));
+        } else {
+            verifyNoInteractions(val);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkPreBarcodesArgs")
+    public void testCheckPreBarcodes(String expectedProblem, List<SlotCopyDestination> scds,
+                                     UCMap<LabwareType> lwTypes, List<String> expectedValidations) {
+        List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        when(mockPreBarcodeValidator.validate(any(), any())).thenReturn(true);
+        service.checkPreBarcodes(problems, scds, lwTypes);
+        if (expectedValidations==null) {
+            verifyNoInteractions(mockPreBarcodeValidator);
+        } else {
+            for (String preBc : expectedValidations) {
+                verify(mockPreBarcodeValidator).validate(eq(preBc), any());
+            }
+            verify(mockPreBarcodeValidator, times(expectedValidations.size())).validate(any(), any());
+        }
+        assertProblem(problems, expectedProblem);
+    }
+
+    static Stream<Arguments> checkPreBarcodesArgs() {
+        LabwareType ltp = EntityFactory.makeLabwareType(1,1,"ltp");
+        LabwareType ltu = EntityFactory.makeLabwareType(1,1,"ltu");
+        ltp.setPrebarcoded(true);
+        ltu.setPrebarcoded(false);
+        UCMap<LabwareType> lts = UCMap.from(LabwareType::getName, ltp, ltu);
+        SlotCopyDestination validp = new SlotCopyDestination("ltp", "prebc", null, null, null, null, null);
+        SlotCopyDestination validu = new SlotCopyDestination("ltu", null, null, null, null, null, null);
+        SlotCopyDestination invalidp = new SlotCopyDestination("ltp", null, null, null, null, null, null);
+        SlotCopyDestination invalidu = new SlotCopyDestination("ltu", "bananas", null, null, null, null, null);
+
+        return Arrays.stream(new Object[][] {
+                {null, List.of(validp), List.of("PREBC")},
+                {null, List.of(validu)},
+                {null, List.of(validp, validu), List.of("PREBC")},
+                {"Expected a prebarcode for labware type: [ltp]", List.of(validu, invalidp)},
+                {"Prebarcode not expected for labware type: [ltu]", List.of(validu, invalidu)},
+        }).map(arr -> Arguments.of(arr[0], arr[1], lts, arr.length > 2 ? arr[2] : null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkPreBarcodesInUseArgs")
+    public void testCheckPreBarcodesInUse(String expectedProblem,
+                                          List<String> preBarcodes,
+                                          List<Labware> labware,
+                                          Set<String> existingPrebcs,
+                                          Set<String> existingBcs) {
+        List<SlotCopyDestination> scds = IntStream.range(0, preBarcodes.size())
+                .mapToObj(i -> {
+                    String preBarcode = preBarcodes.get(i);
+                    SlotCopyDestination scd = new SlotCopyDestination();
+                    scd.setPreBarcode(preBarcode);
+                    scd.setBarcode(labware==null || labware.size() <= i ? null : labware.get(i).getBarcode());
+                    return scd;
+                }).toList();
+        UCMap<Labware> existingDestinations;
+        if (nullOrEmpty(labware)) {
+            existingDestinations = new UCMap<>(0);
+        } else {
+            existingDestinations = UCMap.from(labware, Labware::getBarcode);
+        }
+        if (existingBcs!=null) {
+            when(mockLwRepo.existsByBarcode(any())).thenAnswer(invocation -> existingBcs.contains(invocation.<String>getArgument(0)));
+        }
+        if (existingPrebcs!=null) {
+            when(mockLwRepo.existsByExternalBarcode(any())).thenAnswer(invocation -> existingPrebcs.contains(invocation.<String>getArgument(0)));
+        }
+        List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        service.checkPreBarcodesInUse(problems, scds, existingDestinations);
+        assertProblem(problems, expectedProblem);
+    }
+
+    static Stream<Arguments> checkPreBarcodesInUseArgs() {
+        LabwareType lt = EntityFactory.getTubeType();
+        Labware lw1 = EntityFactory.makeEmptyLabware(lt, "STAN-1");
+        Labware lw2 = EntityFactory.makeEmptyLabware(lt, "STAN-2");
+        lw1.setExternalBarcode("XB1");
+
+        return Arrays.stream(new Object[][] {
+                {null, List.of("", "PREBC1")},
+                        {null, List.of("XB1"), List.of(lw1)},
+                        {"External barcode \"PREBC1\" cannot be added to existing labware STAN-1.",
+                        List.of("PREBC1"), List.of(lw1)},
+                        {"External barcode \"PREBC1\" cannot be added to existing labware STAN-2.",
+                                List.of("PREBC1"), List.of(lw2)},
+                        {"External barcode given multiple times: PREBC1", List.of("", "PREBC1", "", "PREBC1")},
+                        {"Labware already exists with barcode BC.", List.of("PREBC1", "BC"), null, null, Set.of("BC")},
+                        {"Labware already exists with external barcode PREBC.", List.of("PREBC1", "PREBC"), null, Set.of("PREBC")},
+        }).map(arr -> arr.length == 5 ? arr : Arrays.copyOf(arr, 5))
+        .map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testLoadSources(boolean anyMissing) {
+        List<String> barcodes;
+        if (anyMissing) {
+            barcodes = List.of("STAN-1", "STAN-2", "");
+        } else {
+            barcodes = List.of("STAN-1", "STAN-2", "stan-1");
+        }
+        List<SlotCopyContent> sccs = barcodes.stream()
+                .map(bc -> new SlotCopyContent(bc, null, null))
+                .toList();
+        Set<String> expectedCheck = Set.of("STAN-1", "STAN-2");
+        List<String> problems = new ArrayList<>(anyMissing ? 1 : 0);
+        UCMap<Labware> lwMap = UCMap.from(Labware::getBarcode, EntityFactory.getTube());
+        ValidationHelper val = mock(ValidationHelper.class);
+        when(val.checkLabware(any())).thenReturn(lwMap);
+        List<SlotCopyDestination> scds = List.of(new SlotCopyDestination());
+        scds.getFirst().setContents(sccs);
+        assertSame(lwMap, service.loadSources(problems, val, scds));
+        assertProblem(problems, anyMissing ? "Missing source barcode." : null);
+        verify(val).checkLabware(expectedCheck);
+    }
+
+    @Test
+    public void testCheckListedSources_request() {
+        List<SlotCopySource> scss = List.of(new SlotCopySource("STAN-1", Labware.State.active));
+        SlotCopyDestination scd = new SlotCopyDestination();
+        List<SlotCopyContent> sccs = List.of(
+                new SlotCopyContent("STAN-1", null, null),
+                new SlotCopyContent(),
+                new SlotCopyContent("",null,null),
+                new SlotCopyContent("stan-1",null,null),
+                new SlotCopyContent("stan-2", null, null)
+        );
+        scd.setContents(sccs);
+        List<String> problems = new ArrayList<>(0);
+        doNothing().when(service).checkListedSources(any(), any(), any());
+        SlotCopyRequest request = new SlotCopyRequest();
+        request.setDestinations(List.of(scd));
+        request.setSources(scss);
+        service.checkListedSources(problems, request);
+        assertThat(problems).isEmpty();
+        verify(service).checkListedSources(problems, scss, Set.of("STAN-1", "STAN-2"));
+    }
+
+    @Test
+    public void testCheckListedSources_request_empty() {
+        List<String> problems = new ArrayList<>(0);
+        service.checkListedSources(problems, new SlotCopyRequest());
+        assertThat(problems).isEmpty();
+        verify(service, never()).checkListedSources(any(), any(), any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkListedSourcesArgs")
+    public void testCheckListedSources(String expectedProblem,
+                                       Collection<SlotCopySource> scss,
+                                       Set<String> usedSourceBarcodes) {
+        List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        service.checkListedSources(problems, scss, usedSourceBarcodes);
+        assertProblem(problems, expectedProblem);
+    }
+
+    static Stream<Arguments> checkListedSourcesArgs() {
+        Set<String> usedSourceBarcodes = Set.of("STAN-1", "STAN-2");
+
+        return Arrays.stream(new Object[][]{
+                {null, List.of()},
+                {null, List.of(
+                        new SlotCopySource("STAN-1", Labware.State.active),
+                        new SlotCopySource("STAN-2", Labware.State.discarded)
+                )},
+                {null, List.of(new SlotCopySource("STAN-1", Labware.State.used))},
+                {"Source specified without barcode.", List.of(
+                        new SlotCopySource("STAN-1", Labware.State.active),
+                        new SlotCopySource(null, Labware.State.discarded)
+                )},
+                {"Source specified without labware state: STAN-1", List.of(
+                        new SlotCopySource("STAN-1", null),
+                        new SlotCopySource("STAN-2", Labware.State.active)
+                )},
+                {"Unsupported new labware state: released", List.of(
+                        new SlotCopySource("STAN-1", Labware.State.active),
+                        new SlotCopySource("STAN-2", Labware.State.released)
+                )},
+                {"Source barcodes specified that do not map to any destination slots: [STAN-3, STAN-4]", List.of(
+                        new SlotCopySource("STAN-1", Labware.State.active),
+                        new SlotCopySource("STAN-3", Labware.State.active),
+                        new SlotCopySource("STAN-4", Labware.State.discarded)
+                )},
+        }).map(arr -> Arguments.of(arr[0], arr[1], usedSourceBarcodes));
+    }
+
+    @Test
+    public void testValidateLotNumbers() {
+        List<SlotCopyDestination> scds = IntStream.range(0,4).mapToObj(i -> new SlotCopyDestination()).toList();
+        scds.get(0).setLotNumber("LOT0");
+        scds.get(1).setProbeLotNumber("PROBE1");
+        scds.get(2).setLotNumber("LOT2");
+        scds.get(2).setProbeLotNumber("PROBE2");
+        List<String> expected = List.of("LOT0", "PROBE1", "LOT2", "PROBE2");
+        when(mockLotNumberValidator.validate(any(), any())).thenReturn(true);
+        List<String> problems = new ArrayList<>(0);
+        service.validateLotNumbers(problems, scds);
+        verify(mockLotNumberValidator, times(expected.size())).validate(any(), any());
+        expected.forEach(lot -> verify(mockLotNumberValidator).validate(eq(lot), any()));
+    }
+
+    private SlotCopyDestination makeSCD(String barcode, String ltName, List<SlotCopyContent> contents) {
+        SlotCopyDestination scd = new SlotCopyDestination();
+        scd.setBarcode(barcode);
+        scd.setLabwareType(ltName);
+        scd.setContents(contents);
+        return scd;
+    }
+
+    @Test
+    public void testValidateContents_noDestinations() {
+        List<String> problems = new ArrayList<>(1);
+        service.validateContents(problems, null, null, null, new SlotCopyRequest());
+        assertProblem(problems, "No destinations specified.");
+    }
+
+    @Test
+    public void testValidateContents() {
+        LabwareType lt = EntityFactory.makeLabwareType(1,3, "lt");
+        UCMap<LabwareType> lts = UCMap.from(LabwareType::getName, lt);
+        Sample sample = EntityFactory.getSample();
+        Labware destLw = EntityFactory.makeLabware(lt, sample);
+        destLw.setBarcode("STAN-D");
+        UCMap<Labware> existingDestinations = UCMap.from(Labware::getBarcode, destLw);
+        Labware sourceLw = EntityFactory.makeLabware(lt, sample);
+        sourceLw.setBarcode("STAN-S");
+        UCMap<Labware> sourceMap = UCMap.from(Labware::getBarcode, sourceLw);
+        final Address A1 = new Address(1,1);
+        final Address A2 = new Address(1,2);
+        final Address A3 = new Address(1,3);
+        final Address A4 = new Address(1,4);
+        // STAN-1: no contents
+        // STAN-2: OK
+        // STAN-3: Repeated content
+        // STAN-D: Missing dest address; from lw, no such slot; from lw, filled slot
+        // STAN-5: from lt, no such slot
+        // STAN-6: missing source address; from source lw, no such slot; from source lw, empty slot
+
+        List<SlotCopyDestination> scds = List.of(
+                makeSCD("STAN-1", "lt", (List<SlotCopyContent>) null),
+                makeSCD("STAN-2", "lt", List.of(
+                        new SlotCopyContent("STAN-S", A1, A1),
+                        new SlotCopyContent("BANANAS", A1, A2)
+                )),
+                makeSCD("STAN-3", "lt", List.of(
+                        new SlotCopyContent("STAN-S", A1, A1),
+                        new SlotCopyContent("STAN-S", A1, A1)
+                )),
+                makeSCD("STAN-D", "lt", List.of(
+                        new SlotCopyContent("STAN-S", A1, null),
+                        new SlotCopyContent("STAN-S", A1, A4),
+                        new SlotCopyContent("STAN-S", A1, A1)
+                )),
+                makeSCD("STAN-5", "lt", List.of(
+                        new SlotCopyContent("STAN-S", A1, A1),
+                        new SlotCopyContent("STAN_S", A1, A4)
+                )),
+                makeSCD("STAN-6", "lt", List.of(
+                        new SlotCopyContent("STAN-S", null, A1),
+                        new SlotCopyContent("STAN-S", A4, A2),
+                        new SlotCopyContent("STAN-S", A2, A3)
+                ))
+        );
+
+        SlotCopyRequest request = new SlotCopyRequest();
+        request.setDestinations(scds);
+        final List<String> problems = new ArrayList<>(10);
+        service.validateContents(problems, lts, sourceMap, existingDestinations, request);
+        assertThat(problems).containsExactlyInAnyOrder(
+                "No contents specified in destination.",
+                "Repeated copy specified: {sourceBarcode=\"STAN-S\", sourceAddress=A1, destinationAddress=A1}",
+                "No destination address specified.",
+                "No such slot A4 in labware STAN-D.",
+                "Slot A1 in labware STAN-D is not empty.",
+                "Invalid address A4 for labware type lt.",
+                "No source address specified.",
+                "Invalid address A4 for source labware STAN-S.",
+                "Slot A2 in labware STAN-S is empty."
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testValidateOps(boolean cyt) {
+        LabwareType lt = EntityFactory.getTubeType();
+        UCMap<LabwareType> lts = UCMap.from(LabwareType::getName, lt);
+        List<SlotCopyDestination> scds = List.of(
+                makeSCD(null, lt.getName(), List.of(new SlotCopyContent("SRC", null, null))),
+                makeSCD(null, lt.getName(), List.of(new SlotCopyContent("SRC2", null, null)))
+        );
+        OperationType opType = EntityFactory.makeOperationType(cyt ? "CytAssist" : "Bananas", null);
+        doNothing().when(service).validateCytOp(any(), any(), any());
+        List<String> problems = new ArrayList<>();
+        service.validateOps(problems, scds, opType, lts);
+        if (cyt) {
+            verify(service, times(scds.size())).validateCytOp(any(), any(), any());
+            scds.forEach(scd -> verify(service).validateCytOp(problems, scd.getContents(), lt));
+        } else {
+            verify(service, never()).validateCytOp(any(), any(), any());
+        }
+    }
+
+    @Test
+    public void testValidateCytOp_nolwtype() {
+        List<String> problems = new ArrayList<>(0);
+        service.validateCytOp(problems, List.of(), null);
+        assertThat(problems).isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", Visium LP CytAssist, 1 4",
+            ", Visium LP CytAssist XL, 1 2",
+            "Expected labware type Visium LP CytAssist or Visium LP CytAssist XL for operation CytAssist., Bananas, 1",
+            "Slots B1 and C1 are disallowed for use in this operation., Visium LP CytAssist, 1 2",
+            "Slots B1 and C1 are disallowed for use in this operation., Visium LP CytAssist, 3 4",
+    })
+    public void testValidateCytOp(String expectedProblem, String lwTypeName, String joinedRows) {
+        List<SlotCopyContent> contents = Arrays.stream(joinedRows.split("\\s+"))
+                .map(s  -> new SlotCopyContent(null, null, new Address(Integer.parseInt(s), 1)))
+                .toList();
+        List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        service.validateCytOp(problems, contents, EntityFactory.makeLabwareType(1,1, lwTypeName));
+        assertProblem(problems, expectedProblem);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", Probes/cDNA/Library, Probes/cDNA/Library",
+            ",,",
+            "Unknown bio state: [Bananas], Probes/Library/Bananas, Probes/Library",
+            "Bio state not allowed for this operation: [Bananas], Probes/Library/Bananas, Probes/Library/Bananas",
+    })
+    public void testValidateBioStates(String joinedProblems, String joinedBsNames, String joinedRealBsNames) {
+        List<String> expectedProblems = splitArg(joinedProblems);
+        List<String> bsNames = splitArg(joinedBsNames);
+        List<SlotCopyDestination> scds = bsNames.stream().map(bsname -> {
+            SlotCopyDestination scd = new SlotCopyDestination();
+            scd.setBioState(bsname);
+            return scd;
+        }).toList();
+        List<BioState> bss;
+        if (nullOrEmpty(joinedRealBsNames)) {
+            bss = List.of();
+        } else {
+            final int[] idCounter = {0};
+            bss = Arrays.stream(joinedRealBsNames.split("/"))
+                    .map(name -> new BioState(++idCounter[0], name))
+                    .toList();
+        }
+        final UCMap<BioState> expectedMap = UCMap.from(bss, BioState::getName);
+        when(mockBsRepo.findAllByNameIn(any())).then(
+                invocation -> invocation.<Collection<String>>getArgument(0).stream()
+                        .map(expectedMap::get)
+                        .filter(Objects::nonNull)
+                        .distinct()
+                        .toList()
+        );
+
+        List<String> problems = new ArrayList<>(expectedProblems.size());
+        assertEquals(expectedMap, service.validateBioStates(problems, scds));
+        assertThat(problems).containsExactlyInAnyOrderElementsOf(expectedProblems);
+    }
+
+    static List<String> splitArg(String arg) {
+        if (nullOrEmpty(arg)) {
+            return List.of();
+        }
+        return Arrays.asList(arg.split("/"));
+    }
+
+    static SlotCopyDestination makeSCD(String barcode, String ltName, String bsName) {
+        SlotCopyDestination scd = new SlotCopyDestination();
+        scd.setBarcode(barcode);
+        scd.setLabwareType(ltName);
+        scd.setBioState(bsName);
+        return scd;
+    }
+
+    @Test
+    public void testCheckExistingDestinations() {
+        // 1: no barcode
+        // 2: no matching lw
+        // 3: correct lw type and bs
+        // 4: no specified lw type and bs
+        // 5: wrong lw type
+        // 6: wrong bs
+
+        BioState bs1 = new BioState(1, "bs1");
+        BioState bs2 = new BioState(2, "bs2");
+
+        UCMap<BioState> bsMap = UCMap.from(BioState::getName, bs1, bs2);
+
+        LabwareType lt1 = EntityFactory.makeLabwareType(1,1,"lt1");
+
+        Sample sam1 = new Sample(1, null, EntityFactory.getTissue(), bs1);
+
+        Labware[] lws = IntStream.rangeClosed(1, 4)
+                .mapToObj(i -> {
+                    Labware lw = EntityFactory.makeLabware(lt1, sam1);
+                    lw.setBarcode("STAN-"+i);
+                    return lw;
+                })
+                .toArray(Labware[]::new);
+        UCMap<Labware> lwMap = UCMap.from(Labware::getBarcode, lws);
+
+        List<SlotCopyDestination> scds = List.of(
+                makeSCD(null, null, "bs1"),
+                makeSCD("STAN-X", null, "bs1"),
+                makeSCD("STAN-1", "lt1", "bs1"),
+                makeSCD("STAN-2", null, ""),
+                makeSCD("STAN-3", "lt2", "bs1"),
+                makeSCD("STAN-4", "lt1", "bs2")
+        );
+        List<String> problems = new ArrayList<>(2);
+        service.checkExistingDestinations(problems, scds, lwMap, bsMap);
+        for (int i = 0; i < lws.length; ++i) {
+            verify(service).checkExistingLabwareBioState(problems, lws[i], i==1 ? null : i==3 ? bs2 : bs1);
+        }
+        assertThat(problems).containsExactlyInAnyOrder(
+                "Labware type lt2 specified for labware STAN-3 but it has type lt1.",
+                "Bio state bs2 specified for labware STAN-4, which already uses bio state bs1."
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            ";alpha/beta;alpha",
+            ";alpha/beta;gamma",
+            ";alpha;alpha",
+            "Bio state Beta specified for labware STAN-1, which already uses bio state Alpha.; Alpha; Beta",
+    }, delimiterString = ";")
+    public void testCheckExistingLabwareBioState(String expectedProblem, String joinedOldBsNames, String newBsName) {
+        List<String> oldBsNames = splitArg(joinedOldBsNames);
+        UCMap<BioState> bsMap = new UCMap<>(oldBsNames.size()+1);
+        final int[] idCounter = {0};
+        for (String oldBsName : oldBsNames) {
+            if (bsMap.get(oldBsName)==null) {
+                BioState bs = new BioState(++idCounter[0], oldBsName);
+                bsMap.put(oldBsName, bs);
+            }
+        }
+        BioState newBs = bsMap.get(newBsName);
+        if (newBs==null) {
+            newBs = new BioState(++idCounter[0], newBsName);
+        }
+        final Tissue tissue = EntityFactory.getTissue();
+        Sample[] samples = oldBsNames.stream().map(bsMap::get)
+                .map(bs -> new Sample(++idCounter[0], null, tissue, bs))
+                .toArray(Sample[]::new);
+        LabwareType lt = EntityFactory.makeLabwareType(1, samples.length, "lt");
+        Labware lw = EntityFactory.makeLabware(lt, samples);
+        lw.setBarcode("STAN-1");
+
+        final List<String> problems = new ArrayList<>(expectedProblem==null ? 0 : 1);
+        service.checkExistingLabwareBioState(problems, lw, newBs);
+        assertProblem(problems, expectedProblem);
+    }
+}

--- a/src/test/resources/graphql/libraryprep.graphql
+++ b/src/test/resources/graphql/libraryprep.graphql
@@ -1,0 +1,51 @@
+mutation {
+    libraryPrep(request: {
+        sources: [{barcode: "STAN-1", labwareState: discarded}]
+        workNumber: "[WORK]"
+        reagentPlateType: "ffpe - dual index ts set a"
+        reagentTransfers: [{
+            reagentPlateBarcode: "012345678901234567890123"
+            reagentSlotAddress: "A1"
+            destinationAddress: "A1"
+        }, {
+            reagentPlateBarcode: "012345678901234567890123"
+            reagentSlotAddress: "A2"
+            destinationAddress: "A2"
+        }]
+        destination: {
+            bioState: "Probes"
+            labwareType: "6 slot slide"
+            costing: Faculty
+            lotNumber: "123456"
+            probeLotNumber: "234567"
+            contents: [{
+                destinationAddress: "A1"
+                sourceAddress: "A1"
+                sourceBarcode: "STAN-1"
+            }, {
+                destinationAddress: "A2"
+                sourceBarcode: "STAN-1"
+                sourceAddress: "A2"
+            }]
+        }
+        slotMeasurements: [{
+            address: "A1"
+            commentId: 1
+            name: "Cq value"
+            value: "10"
+        },{
+            address: "A2"
+            commentId: 2
+            name: "Cq value"
+            value: "20"
+        }]
+    }) {
+        labware {
+            barcode
+        }
+        operations {
+            operationType { name }
+            id
+        }
+    }
+}

--- a/src/test/resources/graphql/libraryprepexistant.graphql
+++ b/src/test/resources/graphql/libraryprepexistant.graphql
@@ -1,0 +1,51 @@
+mutation {
+    libraryPrep(request: {
+        sources: [{barcode: "STAN-1", labwareState: used}]
+        workNumber: "[WORK]"
+        reagentPlateType: "ffpe - dual index ts set a"
+        reagentTransfers: [{
+            reagentPlateBarcode: "012345678901234567890123"
+            reagentSlotAddress: "A1"
+            destinationAddress: "A1"
+        }, {
+            reagentPlateBarcode: "012345678901234567890123"
+            reagentSlotAddress: "A2"
+            destinationAddress: "A2"
+        }]
+        destination: {
+            barcode: "STAN-2"
+            bioState: "Probes"
+            costing: Faculty
+            lotNumber: "123456"
+            probeLotNumber: "234567"
+            contents: [{
+                destinationAddress: "A1"
+                sourceAddress: "A1"
+                sourceBarcode: "STAN-1"
+            }, {
+                destinationAddress: "A2"
+                sourceBarcode: "STAN-1"
+                sourceAddress: "A2"
+            }]
+        }
+        slotMeasurements: [{
+            address: "A1"
+            commentId: 1
+            name: "Cq value"
+            value: "10"
+        },{
+            address: "A2"
+            commentId: 2
+            name: "Cq value"
+            value: "20"
+        }]
+    }) {
+        labware {
+            barcode
+        }
+        operations {
+            operationType { name }
+            id
+        }
+    }
+}

--- a/src/test/resources/testdata/tag_layout_setup.sql
+++ b/src/test/resources/testdata/tag_layout_setup.sql
@@ -1,0 +1,7 @@
+INSERT INTO tag_layout (name) VALUES ('layout1');
+
+SET @layout=LAST_INSERT_ID();
+
+INSERT INTO reagent_plate_type_tag_layout (plate_type, tag_layout_id)
+VALUES ('FFPE - Dual Index TS Set A', @layout)
+;


### PR DESCRIPTION
Rewrite Transfer (SlotCopyService), Dual index plate (ReagentTransferService) and Amplification
(OpWithSlotMeasurementsService) to make calling into them easier and avoid too much repeated code.
LibraryPrepService validates each op with the appropriate service, and then records all three ops. The ops are carried out in one transaction, after which relevant source labware are discarded from storage.

For #326 