### PR TITLE
x1139 Change amplification behaviour

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -76,6 +76,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final SlotRegionService slotRegionService;
     final RecentOpService recentOpService;
     final FlagLookupService flagLookupService;
+    final MeasurementService measurementService;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, UserRepo userRepo,
@@ -97,7 +98,8 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                WorkService workService, VisiumPermDataService visiumPermDataService,
                                NextReplicateService nextReplicateService, WorkSummaryService workSummaryService,
                                LabwareService labwareService, FileStoreService fileStoreService,
-                               SlotRegionService slotRegionService, RecentOpService recentOpService, FlagLookupService flagLookupService) {
+                               SlotRegionService slotRegionService, RecentOpService recentOpService,
+                               FlagLookupService flagLookupService, MeasurementService measurementService) {
         super(objectMapper, authComp, userRepo);
         this.sessionConfig = sessionConfig;
         this.versionInfo = versionInfo;
@@ -140,6 +142,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.slotRegionService = slotRegionService;
         this.recentOpService = recentOpService;
         this.flagLookupService = flagLookupService;
+        this.measurementService = measurementService;
     }
 
     public DataFetcher<User> getUser() {
@@ -330,6 +333,16 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
             List<String> barcodes = dfe.getArgument("barcodes");
             List<Labware> labware = labwareRepo.findByBarcodeIn(barcodes);
             return flagLookupService.lookUpDetails(labware);
+        };
+    }
+
+    public DataFetcher<String> getMeasurementValueFromLabwareOrParent() {
+        return dfe -> {
+            String barcode = dfe.getArgument("barcode");
+            String name = dfe.getArgument("name");
+            return measurementService.getMeasurementFromLabwareOrParent(barcode, name)
+                    .map(Measurement::getValue)
+                    .orElse(null);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -336,13 +336,12 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         };
     }
 
-    public DataFetcher<String> getMeasurementValueFromLabwareOrParent() {
+    public DataFetcher<List<AddressString>> getMeasurementValueFromLabwareOrParent() {
         return dfe -> {
             String barcode = dfe.getArgument("barcode");
             String name = dfe.getArgument("name");
-            return measurementService.getMeasurementFromLabwareOrParent(barcode, name)
-                    .map(Measurement::getValue)
-                    .orElse(null);
+            var map = measurementService.getMeasurementsFromLabwareOrParent(barcode, name);
+            return measurementService.toAddressStrings(map);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -112,6 +112,7 @@ public class GraphQLProvider {
                         .dataFetcher("suggestedLabwareForWork", graphQLDataFetchers.getSuggestedLabwareForWork())
                         .dataFetcher("findLatestOp", graphQLDataFetchers.findLatestOperation())
                         .dataFetcher("labwareFlagDetails", graphQLDataFetchers.getFlagDetails())
+                        .dataFetcher("measurementValueFromLabwareOrParent", graphQLDataFetchers.getMeasurementValueFromLabwareOrParent())
 
                         .dataFetcher("users", graphQLDataFetchers.getUsers())
                         .dataFetcher("planData", graphQLDataFetchers.getPlanData())

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/MeasurementRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/MeasurementRepo.java
@@ -13,5 +13,7 @@ import java.util.List;
 public interface MeasurementRepo extends CrudRepository<Measurement, Integer> {
     List<Measurement> findAllBySlotIdIn(Collection<Integer> slotIds);
 
+    List<Measurement> findAllBySlotIdInAndName(Collection<Integer> slotIds, String name);
+
     List<Measurement> findAllByOperationIdIn(Collection<Integer> opIds);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/SlotRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/SlotRepo.java
@@ -1,5 +1,6 @@
 package uk.ac.sanger.sccp.stan.repo;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.Sample;
 import uk.ac.sanger.sccp.stan.model.Slot;
@@ -8,7 +9,13 @@ import java.util.Collection;
 import java.util.List;
 
 public interface SlotRepo extends CrudRepository<Slot, Integer> {
+    // There's some kind of warning about the argument here having the wrong type,
+    // but it works fine.
+    @SuppressWarnings("SpringDataRepositoryMethodParametersInspection")
     List<Slot> findDistinctBySamplesIn(Iterable<Sample> samples);
 
     List<Slot> findAllByIdIn(Collection<Integer> ids);
+
+    @Query("select id from Slot where labwareId in (?1)")
+    List<Integer> findSlotIdsByLabwareIdIn(Collection<Integer> labwareIds);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/AddressString.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/AddressString.java
@@ -1,0 +1,56 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.stan.model.Address;
+
+import java.util.Objects;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * An address and a string associated with that address.
+ * @author dr6
+ */
+public class AddressString {
+    private Address address;
+    private String string;
+
+    public AddressString(Address address, String string) {
+        this.address = address;
+        this.string = string;
+    }
+
+    public Address getAddress() {
+        return this.address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public String getString() {
+        return this.string;
+    }
+
+    public void setString(String string) {
+        this.string = string;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressString that = (AddressString) o;
+        return (Objects.equals(this.address, that.address)
+                && Objects.equals(this.string, that.string));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address, string);
+    }
+
+    @Override
+    public String toString() {
+        return this.address+": "+repr(this.string);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementService.java
@@ -1,0 +1,19 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.Measurement;
+
+import java.util.Optional;
+
+/**
+ * Service to help with {@link Measurement measurements}
+ */
+public interface MeasurementService {
+    /**
+     * Gets the named measurement from the indicated labware or its parent labware.
+     * @param barcode the labware barcode
+     * @param name the name of the measurement
+     * @return the measurement, if one was found
+     * @exception javax.persistence.EntityNotFoundException if the indicated labware does not exist
+     */
+    Optional<Measurement> getMeasurementFromLabwareOrParent(String barcode, String name);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementService.java
@@ -1,19 +1,29 @@
 package uk.ac.sanger.sccp.stan.service;
 
+import uk.ac.sanger.sccp.stan.model.Address;
 import uk.ac.sanger.sccp.stan.model.Measurement;
+import uk.ac.sanger.sccp.stan.request.AddressString;
 
-import java.util.Optional;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Service to help with {@link Measurement measurements}
  */
 public interface MeasurementService {
     /**
-     * Gets the named measurement from the indicated labware or its parent labware.
+     * Gets the named measurements from the each slot of the indicated labware or its parent labware.
      * @param barcode the labware barcode
      * @param name the name of the measurement
-     * @return the measurement, if one was found
+     * @return map from slot address to measurements
      * @exception javax.persistence.EntityNotFoundException if the indicated labware does not exist
      */
-    Optional<Measurement> getMeasurementFromLabwareOrParent(String barcode, String name);
+    Map<Address, List<Measurement>> getMeasurementsFromLabwareOrParent(String barcode, String name);
+
+    /**
+     * Converts a map of address to measurements to a list with one value for each address
+     * @param map a map from slot address to measurements
+     * @return a list of addresses and strings
+     */
+    List<AddressString> toAddressStrings(Map<Address, List<Measurement>> map);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementServiceImp.java
@@ -1,0 +1,44 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author dr6
+ */
+@Service
+public class MeasurementServiceImp implements MeasurementService {
+    private final LabwareRepo lwRepo;
+    private final SlotRepo slotRepo;
+    private final ActionRepo actionRepo;
+    private final MeasurementRepo measurementRepo;
+
+    @Autowired
+    public MeasurementServiceImp(LabwareRepo lwRepo, SlotRepo slotRepo, ActionRepo actionRepo, MeasurementRepo measurementRepo) {
+        this.lwRepo = lwRepo;
+        this.slotRepo = slotRepo;
+        this.actionRepo = actionRepo;
+        this.measurementRepo = measurementRepo;
+    }
+
+    @Override
+    public Optional<Measurement> getMeasurementFromLabwareOrParent(String barcode, String name) {
+        Labware lw = lwRepo.getByBarcode(barcode);
+        List<Integer> slotIds = lw.getSlots().stream()
+                .map(Slot::getId)
+                .toList();
+        List<Measurement> measurements = measurementRepo.findAllBySlotIdInAndName(slotIds, name);
+        if (!measurements.isEmpty()) {
+            return Optional.of(measurements.getFirst());
+        }
+        List<Integer> sourceLabwareIds = actionRepo.findSourceLabwareIdsForDestinationLabwareIds(List.of(lw.getId()));
+        List<Integer> sourceLabwareSlotIds = slotRepo.findSlotIdsByLabwareIdIn(sourceLabwareIds);
+        List<Measurement> sourceMeasurements = measurementRepo.findAllBySlotIdInAndName(sourceLabwareSlotIds, name);
+        return sourceMeasurements.stream().findFirst();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/MeasurementServiceImp.java
@@ -4,9 +4,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.AddressString;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
 
 /**
  * @author dr6
@@ -14,31 +19,82 @@ import java.util.Optional;
 @Service
 public class MeasurementServiceImp implements MeasurementService {
     private final LabwareRepo lwRepo;
-    private final SlotRepo slotRepo;
     private final ActionRepo actionRepo;
     private final MeasurementRepo measurementRepo;
 
     @Autowired
-    public MeasurementServiceImp(LabwareRepo lwRepo, SlotRepo slotRepo, ActionRepo actionRepo, MeasurementRepo measurementRepo) {
+    public MeasurementServiceImp(LabwareRepo lwRepo, ActionRepo actionRepo, MeasurementRepo measurementRepo) {
         this.lwRepo = lwRepo;
-        this.slotRepo = slotRepo;
         this.actionRepo = actionRepo;
         this.measurementRepo = measurementRepo;
     }
 
     @Override
-    public Optional<Measurement> getMeasurementFromLabwareOrParent(String barcode, String name) {
+    public Map<Address, List<Measurement>> getMeasurementsFromLabwareOrParent(String barcode, String name) {
         Labware lw = lwRepo.getByBarcode(barcode);
-        List<Integer> slotIds = lw.getSlots().stream()
-                .map(Slot::getId)
-                .toList();
-        List<Measurement> measurements = measurementRepo.findAllBySlotIdInAndName(slotIds, name);
-        if (!measurements.isEmpty()) {
-            return Optional.of(measurements.getFirst());
+        Map<Integer, Address> slotIdAddress = lw.getSlots().stream()
+                .collect(toMap(Slot::getId, Slot::getAddress));
+        Map<SlotIdSampleId, Set<Slot>> parentToSlot = getParentSlotIdMap(lw.getSlots());
+        Set<Integer> allSlotIds = Stream.concat(slotIdAddress.keySet().stream(),
+                        parentToSlot.keySet().stream().map(SlotIdSampleId::getSlotId))
+                .collect(toSet());
+        List<Measurement> measurements = measurementRepo.findAllBySlotIdInAndName(allSlotIds, name);
+        if (measurements.isEmpty()) {
+            return Map.of();
         }
-        List<Integer> sourceLabwareIds = actionRepo.findSourceLabwareIdsForDestinationLabwareIds(List.of(lw.getId()));
-        List<Integer> sourceLabwareSlotIds = slotRepo.findSlotIdsByLabwareIdIn(sourceLabwareIds);
-        List<Measurement> sourceMeasurements = measurementRepo.findAllBySlotIdInAndName(sourceLabwareSlotIds, name);
-        return sourceMeasurements.stream().findFirst();
+        Map<Address, List<Measurement>> map = new HashMap<>();
+        for (Measurement measurement : measurements) {
+            Address ad = slotIdAddress.get(measurement.getSlotId());
+            if (ad!=null) {
+                map.computeIfAbsent(ad, k -> new ArrayList<>()).add(measurement);
+                continue;
+            }
+            Set<Slot> targetSlots = parentToSlot.get(new SlotIdSampleId(measurement.getSlotId(), measurement.getSampleId()));
+            if (!nullOrEmpty(targetSlots)) {
+                for (Slot targetSlot : targetSlots) {
+                    map.computeIfAbsent(targetSlot.getAddress(), k -> new ArrayList<>()).add(measurement);
+                }
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public List<AddressString> toAddressStrings(Map<Address, List<Measurement>> map) {
+        if (nullOrEmpty(map)) {
+            return List.of();
+        }
+        return map.entrySet().stream()
+                .filter(e -> !nullOrEmpty(e.getValue()))
+                .map(e -> new AddressString(e.getKey(), singleValue(e.getValue())))
+                .toList();
+    }
+
+    /**
+     * Selects a measurement value from a list of measurements.
+     * Takes the value from the measurement with the highest id, since it's likely to be the latest.
+     * @param measurements the measurements
+     * @return a value from the measurements
+     * @exception NoSuchElementException if the measurements list is empty
+     */
+    public String singleValue(Collection<Measurement> measurements) {
+        return measurements.stream().max(Comparator.comparing(Measurement::getId))
+                .map(Measurement::getValue)
+                .orElseThrow();
+    }
+
+    /**
+     * Gets a map from source slot/sample ids to destination slots
+     * @param slots the destination slots to find actions for
+     * @return a map of source slot/sample id to destination slots
+     */
+    public Map<SlotIdSampleId, Set<Slot>> getParentSlotIdMap(Collection<Slot> slots) {
+        List<Action> actions = actionRepo.findAllByDestinationIn(slots);
+        Map<SlotIdSampleId, Set<Slot>> map = new HashMap<>();
+        for (Action action : actions) {
+            SlotIdSampleId key = new SlotIdSampleId(action.getSource().getId(), action.getSourceSample().getId());
+            map.computeIfAbsent(key, k -> new HashSet<>()).add(action.getDestination());
+        }
+        return map;
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/OpWithSlotMeasurementsServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/OpWithSlotMeasurementsServiceImp.java
@@ -323,8 +323,8 @@ public class OpWithSlotMeasurementsServiceImp implements OpWithSlotMeasurementsS
         if (smrs.stream().anyMatch(smr -> MEAS_CQ.equalsIgnoreCase(smr.getName()))) {
             return;
         }
-        Optional<Measurement> optMeas = measurementService.getMeasurementFromLabwareOrParent(lw.getBarcode(), MEAS_CQ);
-        if (optMeas.isEmpty()) {
+        Map<Address, List<Measurement>> meas = measurementService.getMeasurementsFromLabwareOrParent(lw.getBarcode(), MEAS_CQ);
+        if (meas.values().stream().allMatch(Objects::isNull)) {
             problems.add("No "+MEAS_CQ+" has been recorded on labware "+lw.getBarcode()+".");
         }
     }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1931,6 +1931,8 @@ type Query {
     suggestedLabwareForWork(workNumber: String!, forRelease: Boolean): [Labware!]!
     """Get labware flag details applicable to the specified labware."""
     labwareFlagDetails(barcodes: [String!]!): [FlagDetail!]!
+    """Get named measurement value from the indicated labware or its parent labware."""
+    measurementValueFromLabwareOrParent(barcode: String!, name: String!): String
 
     """Get the specified storage location."""
     location(locationBarcode: String!): Location!

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1547,6 +1547,12 @@ type SuggestedWorkResponse {
     works: [Work!]!
 }
 
+"""An address and a string associated with that address."""
+type AddressString {
+    address: Address!
+    string: String!
+}
+
 """A specification that a particular reagent slot should be transferred to an address."""
 input ReagentTransfer {
     """The barcode of a reagent plate."""
@@ -1931,8 +1937,8 @@ type Query {
     suggestedLabwareForWork(workNumber: String!, forRelease: Boolean): [Labware!]!
     """Get labware flag details applicable to the specified labware."""
     labwareFlagDetails(barcodes: [String!]!): [FlagDetail!]!
-    """Get named measurement value from the indicated labware or its parent labware."""
-    measurementValueFromLabwareOrParent(barcode: String!, name: String!): String
+    """Get named measurement values for each slot from the indicated labware or its parent labware."""
+    measurementValueFromLabwareOrParent(barcode: String!, name: String!): [AddressString!]!
 
     """Get the specified storage location."""
     location(locationBarcode: String!): Location!

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRecordOpWithSlotMeasurementsMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRecordOpWithSlotMeasurementsMutation.java
@@ -129,10 +129,11 @@ public class TestRecordOpWithSlotMeasurementsMutation {
         Labware lw2 = entityCreator.createLabware("STAN-B", lt, sam);
         entityCreator.simpleOp(simpleTransfer, user, lw1, lw2);
 
-        String query = "query { measurementValueFromLabwareOrParent(barcode: \"STAN-B\", name: \"Cq value\") }";
+        String query = "query { measurementValueFromLabwareOrParent(barcode: \"STAN-B\", name: \"Cq value\") { address, string } }";
         Object queryResult = tester.post(query);
-        String measValue = chainGet(queryResult, "data", "measurementValueFromLabwareOrParent");
-        assertEquals(10, Double.parseDouble(measValue));
+        Map<String,String> measData = chainGet(queryResult, "data", "measurementValueFromLabwareOrParent", 0);
+        assertEquals("A1", measData.get("address"));
+        assertEquals(10, Double.parseDouble(measData.get("string")));
 
         String ampMutation = baseMutation
                 .replace("OP-TYPE", amp.getName())

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRecordOpWithSlotMeasurementsMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRecordOpWithSlotMeasurementsMutation.java
@@ -1,5 +1,6 @@
 package uk.ac.sanger.sccp.stan.integrationtest;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,13 +12,14 @@ import uk.ac.sanger.sccp.stan.EntityCreator;
 import uk.ac.sanger.sccp.stan.GraphQLTester;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.MeasurementRepo;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
 
 import javax.transaction.Transactional;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
 
 /**
@@ -37,6 +39,8 @@ public class TestRecordOpWithSlotMeasurementsMutation {
 
     @Autowired
     private MeasurementRepo measurementRepo;
+    @Autowired
+    private OperationRepo opRepo;
 
     @Transactional
     @ParameterizedTest
@@ -96,5 +100,50 @@ public class TestRecordOpWithSlotMeasurementsMutation {
             assertEquals(sanMeasValues[i], measurement.getValue());
             assertEquals(lw.getFirstSlot().getId(), measurement.getSlotId());
         }
+    }
+
+    @Test
+    @Transactional
+    public void testAmplificationWithParentCqValues() throws Exception {
+        OperationType qpcr = entityCreator.createOpType("qPCR results", null, OperationTypeFlag.IN_PLACE);
+        OperationType amp = entityCreator.createOpType("Amplification", null, OperationTypeFlag.IN_PLACE);
+        OperationType simpleTransfer = entityCreator.createOpType("Simple transfer", null);
+        Sample sam = entityCreator.createSample(entityCreator.createTissue(entityCreator.createDonor("DONOR1"), "TISSUE1"), 1);
+        LabwareType lt = entityCreator.createLabwareType("lt1", 1,1);
+        Labware lw1 = entityCreator.createLabware("STAN-A", lt, sam);
+        Work work = entityCreator.createWork(null, null, null, null, null);
+        User user = entityCreator.createUser("user1");
+        String baseMutation = tester.readGraphQL("opwithslotmeasurements.graphql")
+                .replace("WORK-NUM", work.getWorkNumber())
+                .replaceFirst("\\{[^}]+\"MEAS-NAME-1\"[^}]+}", "");
+        tester.setUser(user);
+        // record a qpcr mutation to add cq measurement to the parent labware
+        String qpcrMutation = baseMutation
+                .replace("OP-TYPE", qpcr.getName())
+                .replace("MEAS-NAME-0", "CQ VALUE")
+                .replace("MEAS-VALUE-0", "10");
+        Map<String, ?> qpcrResponse = tester.post(qpcrMutation);
+
+        assertNull(qpcrResponse.get("errors"));
+
+        Labware lw2 = entityCreator.createLabware("STAN-B", lt, sam);
+        entityCreator.simpleOp(simpleTransfer, user, lw1, lw2);
+        String ampMutation = baseMutation
+                .replace("OP-TYPE", amp.getName())
+                .replace("STAN-A", "STAN-B")
+                .replace("MEAS-NAME-0", "Cycles")
+                .replace("MEAS-VALUE-0", "20");
+        Map<String, ?> ampResponse = tester.post(ampMutation);
+        assertNull(ampResponse.get("errors"));
+        Integer opId = chainGet(ampResponse, "data", "recordOpWithSlotMeasurements", "operations", 0, "id");
+        Operation op = opRepo.findById(opId).orElseThrow();
+        assertEquals(amp, op.getOperationType());
+        assertEquals(lw2.getSlots().getFirst(), op.getActions().getFirst().getDestination());
+        List<Measurement> measurements = measurementRepo.findAllByOperationIdIn(List.of(opId));
+        assertThat(measurements).hasSize(1);
+        Measurement measurement = measurements.getFirst();
+        assertEquals(lw2.getSlots().getFirst().getId(), measurement.getSlotId());
+        assertEquals("Cycles", measurement.getName());
+        assertEquals("20", measurement.getValue());
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRecordOpWithSlotMeasurementsMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRecordOpWithSlotMeasurementsMutation.java
@@ -128,6 +128,12 @@ public class TestRecordOpWithSlotMeasurementsMutation {
 
         Labware lw2 = entityCreator.createLabware("STAN-B", lt, sam);
         entityCreator.simpleOp(simpleTransfer, user, lw1, lw2);
+
+        String query = "query { measurementValueFromLabwareOrParent(barcode: \"STAN-B\", name: \"Cq value\") }";
+        Object queryResult = tester.post(query);
+        String measValue = chainGet(queryResult, "data", "measurementValueFromLabwareOrParent");
+        assertEquals(10, Double.parseDouble(measValue));
+
         String ampMutation = baseMutation
                 .replace("OP-TYPE", amp.getName())
                 .replace("STAN-A", "STAN-B")

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestMeasurementService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestMeasurementService.java
@@ -1,21 +1,22 @@
 package uk.ac.sanger.sccp.stan.service;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import uk.ac.sanger.sccp.stan.EntityFactory;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.AddressString;
 
 import java.util.*;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.sameElements;
 
 /**
  * Tests {@link MeasurementServiceImp}
@@ -23,8 +24,6 @@ import static org.mockito.Mockito.*;
 class TestMeasurementService {
     @Mock
     private LabwareRepo mockLwRepo;
-    @Mock
-    private SlotRepo mockSlotRepo;
     @Mock
     private ActionRepo mockActionRepo;
     @Mock
@@ -36,77 +35,102 @@ class TestMeasurementService {
     private AutoCloseable mocking;
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
     }
 
     @AfterEach
-    void tearDown() throws Exception {
+    void cleanup() throws Exception {
         mocking.close();
     }
 
     @ParameterizedTest
-    @MethodSource("getMeasurementFromLabwareOrParentArgs")
-    void testGetMeasurementFromLabwareOrParent(Measurement expected,
-                                               Labware lw,
-                                               List<Measurement> directMeasurements,
-                                               List<Integer> parentLabwareIds,
-                                               List<Integer> parentLabwareSlotIds,
-                                               List<Measurement> parentMeasurements) {
-        final String name = "cq";
-        final String barcode = lw.getBarcode();
-        when(mockLwRepo.getByBarcode(any())).thenReturn(lw);
-        List<Integer> slotIds = null;
-        if (directMeasurements!=null) {
-            slotIds = lw.getSlots().stream().map(Slot::getId).toList();
-            when(mockMeasurementRepo.findAllBySlotIdInAndName(slotIds, name)).thenReturn(directMeasurements);
+    @ValueSource(booleans={false,true})
+    public void testGetMeasurementsFromLabwareOrParent(boolean any) {
+        final String name = "x";
+        final Address A1 = new Address(1,1), A2 = new Address(1,2);
+        LabwareType lt = EntityFactory.makeLabwareType(1,2);
+        Sample sample = EntityFactory.getSample();
+        Labware lw = EntityFactory.makeLabware(lt, sample, sample);
+        when(mockLwRepo.getByBarcode(lw.getBarcode())).thenReturn(lw);
+        Map<SlotIdSampleId, Set<Slot>> slotIdMap = Map.of(
+                new SlotIdSampleId(100,200), Set.of(lw.getSlot(A1)),
+                new SlotIdSampleId(101,201), Set.of(lw.getSlot(A2))
+        );
+        doReturn(slotIdMap).when(service).getParentSlotIdMap(any());
+        List<Measurement> measurements;
+        if (any) {
+            measurements = List.of(
+                    new Measurement(1, name, "1", sample.getId(), 1, lw.getSlot(A1).getId()),
+                    new Measurement(2, name, "2", 200, 2, 100),
+                    new Measurement(3, name, "3", 201, 3, 101)
+            );
+        } else {
+            measurements = List.of();
         }
-        if (parentLabwareIds!=null) {
-            when(mockActionRepo.findSourceLabwareIdsForDestinationLabwareIds(any())).thenReturn(parentLabwareIds);
-        }
-        if (parentLabwareSlotIds!=null) {
-            when(mockSlotRepo.findSlotIdsByLabwareIdIn(any())).thenReturn(parentLabwareSlotIds);
-        }
-        if (parentMeasurements!=null) {
-            when(mockMeasurementRepo.findAllBySlotIdInAndName(parentLabwareSlotIds, name)).thenReturn(parentMeasurements);
-        }
+        when(mockMeasurementRepo.findAllBySlotIdInAndName(any(), any())).thenReturn(measurements);
 
-        final Optional<Measurement> result = service.getMeasurementFromLabwareOrParent(barcode, name);
-        if (expected==null) {
-            assertThat(result).isEmpty();
+        Map<Address, List<Measurement>> map = service.getMeasurementsFromLabwareOrParent(lw.getBarcode(), name);
+        Set<Integer> allSlotIds = Stream.concat(lw.getSlots().stream().map(Slot::getId), Stream.of(100,101))
+                .collect(toSet());
+        verify(service).getParentSlotIdMap(lw.getSlots());
+        verify(mockMeasurementRepo).findAllBySlotIdInAndName(sameElements(allSlotIds, false), eq(name));
+        if (any) {
+            assertThat(map).hasSize(2);
+            assertThat(map.get(A1)).containsExactlyInAnyOrderElementsOf(measurements.subList(0, 2));
+            assertThat(map.get(A2)).containsExactly(measurements.get(2));
         } else {
-            assertThat(result).containsSame(expected);
-        }
-
-        verify(mockLwRepo).getByBarcode(barcode);
-        verify(mockMeasurementRepo).findAllBySlotIdInAndName(slotIds, name);
-        if (parentLabwareIds!=null) {
-            verify(mockActionRepo).findSourceLabwareIdsForDestinationLabwareIds(List.of(lw.getId()));
-        } else {
-            verifyNoInteractions(mockActionRepo);
-        }
-        if (parentLabwareSlotIds!=null) {
-            verify(mockSlotRepo).findSlotIdsByLabwareIdIn(parentLabwareIds);
-        } else {
-            verifyNoInteractions(mockSlotRepo);
-        }
-        if (parentMeasurements!=null) {
-            verify(mockMeasurementRepo).findAllBySlotIdInAndName(parentLabwareSlotIds, name);
+            assertThat(map).isEmpty();
         }
     }
 
-    static Stream<Arguments> getMeasurementFromLabwareOrParentArgs() {
-        Labware lw = EntityFactory.getTube();
-        List<Integer> parentLabwareIds = List.of(400,401);
-        List<Integer> parentLabwareSlotIds = List.of(500,501);
-        final Measurement meas = new Measurement(600, "alpha", "beta", 1, 2, 3);
-        List<Measurement> measurements = List.of(meas);
-        List<Measurement> noMeasurements = List.of();
-        return Arrays.stream(new Object[][] {
-                {null, lw, noMeasurements, List.of(), List.of(), noMeasurements},
-                {meas, lw, measurements, null, null, null},
-                {null, lw, noMeasurements, parentLabwareIds, parentLabwareSlotIds, noMeasurements},
-                {meas, lw, noMeasurements, parentLabwareIds, parentLabwareSlotIds, measurements},
-        }).map(Arguments::of);
+    @Test
+    public void testGetParentSlotIdMap() {
+        final Address A1 = new Address(1,1), A2 = new Address(1,2);
+        LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Sample sample = EntityFactory.getSample();
+        Labware lw = EntityFactory.makeLabware(lt, sample, sample);
+        Labware parent = EntityFactory.makeLabware(lt, sample, sample);
+        List<Action> actions = List.of(
+                new Action(1, 1, parent.getSlot(A1), lw.getSlot(A2), sample, sample),
+                new Action(2, 2, parent.getSlot(A2), lw.getSlot(A1), sample, sample),
+                new Action(3, 3, parent.getSlot(A2), lw.getSlot(A2), sample, sample)
+        );
+        when(mockActionRepo.findAllByDestinationIn(any())).thenReturn(actions);
+
+        List<Slot> slots = lw.getSlots();
+        Map<SlotIdSampleId, Set<Slot>> map = service.getParentSlotIdMap(slots);
+
+        verify(mockActionRepo).findAllByDestinationIn(slots);
+
+        assertThat(map).hasSize(2);
+        assertThat(map.get(new SlotIdSampleId(parent.getSlot(A1).getId(), sample.getId())))
+                .containsExactly(lw.getSlot(A2));
+        assertThat(map.get(new SlotIdSampleId(parent.getSlot(A2).getId(), sample.getId())))
+                .containsExactlyInAnyOrder(lw.getSlot(A1), lw.getSlot(A2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testToAddressStrings(boolean any) {
+        final String name = "alpha";
+        Map<Address, List<Measurement>> map;
+        final Address A1 = new Address(1,1), A2 = new Address(1,2);
+        if (any) {
+            map = Map.of(A1, List.of(new Measurement(1, name, "1", 1, 2, 3)),
+                    A2, List.of(new Measurement(2, name, "2", 1, 2, 3),
+                            new Measurement(3, name, "3", 1, 2, 3)));
+        } else {
+            map = Map.of();
+        }
+        List<AddressString> results = service.toAddressStrings(map);
+        if (!any) {
+            assertThat(results).isEmpty();
+            return;
+        }
+        assertThat(results).containsExactlyInAnyOrder(
+                new AddressString(A1, "1"), new AddressString(A2, "3")
+        );
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestMeasurementService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestMeasurementService.java
@@ -1,0 +1,112 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link MeasurementServiceImp}
+ */
+class TestMeasurementService {
+    @Mock
+    private LabwareRepo mockLwRepo;
+    @Mock
+    private SlotRepo mockSlotRepo;
+    @Mock
+    private ActionRepo mockActionRepo;
+    @Mock
+    private MeasurementRepo mockMeasurementRepo;
+
+    @InjectMocks
+    private MeasurementServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setUp() {
+        mocking = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocking.close();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMeasurementFromLabwareOrParentArgs")
+    void testGetMeasurementFromLabwareOrParent(Measurement expected,
+                                               Labware lw,
+                                               List<Measurement> directMeasurements,
+                                               List<Integer> parentLabwareIds,
+                                               List<Integer> parentLabwareSlotIds,
+                                               List<Measurement> parentMeasurements) {
+        final String name = "cq";
+        final String barcode = lw.getBarcode();
+        when(mockLwRepo.getByBarcode(any())).thenReturn(lw);
+        List<Integer> slotIds = null;
+        if (directMeasurements!=null) {
+            slotIds = lw.getSlots().stream().map(Slot::getId).toList();
+            when(mockMeasurementRepo.findAllBySlotIdInAndName(slotIds, name)).thenReturn(directMeasurements);
+        }
+        if (parentLabwareIds!=null) {
+            when(mockActionRepo.findSourceLabwareIdsForDestinationLabwareIds(any())).thenReturn(parentLabwareIds);
+        }
+        if (parentLabwareSlotIds!=null) {
+            when(mockSlotRepo.findSlotIdsByLabwareIdIn(any())).thenReturn(parentLabwareSlotIds);
+        }
+        if (parentMeasurements!=null) {
+            when(mockMeasurementRepo.findAllBySlotIdInAndName(parentLabwareSlotIds, name)).thenReturn(parentMeasurements);
+        }
+
+        final Optional<Measurement> result = service.getMeasurementFromLabwareOrParent(barcode, name);
+        if (expected==null) {
+            assertThat(result).isEmpty();
+        } else {
+            assertThat(result).containsSame(expected);
+        }
+
+        verify(mockLwRepo).getByBarcode(barcode);
+        verify(mockMeasurementRepo).findAllBySlotIdInAndName(slotIds, name);
+        if (parentLabwareIds!=null) {
+            verify(mockActionRepo).findSourceLabwareIdsForDestinationLabwareIds(List.of(lw.getId()));
+        } else {
+            verifyNoInteractions(mockActionRepo);
+        }
+        if (parentLabwareSlotIds!=null) {
+            verify(mockSlotRepo).findSlotIdsByLabwareIdIn(parentLabwareIds);
+        } else {
+            verifyNoInteractions(mockSlotRepo);
+        }
+        if (parentMeasurements!=null) {
+            verify(mockMeasurementRepo).findAllBySlotIdInAndName(parentLabwareSlotIds, name);
+        }
+    }
+
+    static Stream<Arguments> getMeasurementFromLabwareOrParentArgs() {
+        Labware lw = EntityFactory.getTube();
+        List<Integer> parentLabwareIds = List.of(400,401);
+        List<Integer> parentLabwareSlotIds = List.of(500,501);
+        final Measurement meas = new Measurement(600, "alpha", "beta", 1, 2, 3);
+        List<Measurement> measurements = List.of(meas);
+        List<Measurement> noMeasurements = List.of();
+        return Arrays.stream(new Object[][] {
+                {null, lw, noMeasurements, List.of(), List.of(), noMeasurements},
+                {meas, lw, measurements, null, null, null},
+                {null, lw, noMeasurements, parentLabwareIds, parentLabwareSlotIds, noMeasurements},
+                {meas, lw, noMeasurements, parentLabwareIds, parentLabwareSlotIds, measurements},
+        }).map(Arguments::of);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestOpWithSlotMeasurementsService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestOpWithSlotMeasurementsService.java
@@ -532,8 +532,13 @@ public class TestOpWithSlotMeasurementsService {
     public void testValidateAmp(final boolean valid, final Labware lw, List<SlotMeasurementRequest> smrs,
                                 Measurement foundMeasurement) {
         if (lw!=null) {
-            when(mockMeasurementService.getMeasurementFromLabwareOrParent(lw.getBarcode(), MEAS_CQ))
-                    .thenReturn(Optional.ofNullable(foundMeasurement));
+            Map<Address, List<Measurement>> mal;
+            if (foundMeasurement==null) {
+                mal = Map.of();
+            } else {
+                mal = Map.of(new Address(1,1), List.of(foundMeasurement));
+            }
+            when(mockMeasurementService.getMeasurementsFromLabwareOrParent(lw.getBarcode(), MEAS_CQ)).thenReturn(mal);
         }
         assert valid || lw!=null;
         String expectedProblem = valid ? null : ("No " + MEAS_CQ + " has been recorded on labware " + lw.getBarcode() + ".");


### PR DESCRIPTION
If amp is recorded without cq value, make sure that cq
has already been recorded on this labware or its parent labware.
Add query to look up cq value.
This PR is branched off from `qpcr_results`.
For #334 