### PR TITLE
x1126 Paraffin processing makes blocks

### DIFF
--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestParaffinProcessingMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestParaffinProcessingMutation.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
 
 /**
@@ -59,11 +60,13 @@ public class TestParaffinProcessingMutation {
         Integer opId = (Integer) opData.get("id");
         final List<OperationComment> opComments = opComRepo.findAllByOperationIdIn(List.of(opId));
         assertThat(opComments).hasSize(1);
-        var opComment = opComments.get(0);
+        var opComment = opComments.getFirst();
         assertEquals(1, opComment.getComment().getId());
         entityManager.flush();
         Tissue tissue = sample.getTissue();
         entityManager.refresh(tissue);
         assertEquals("Paraffin", tissue.getMedium().getName());
+        entityManager.refresh(lw.getFirstSlot());
+        assertTrue(lw.getFirstSlot().isBlock()); // Block is created in the labware
     }
 }


### PR DESCRIPTION
If the labware doesn't already contain blocks, they will be turned into blocks by paraffin processing.
Labware supplied to this operation must be suitable for being a block: it must contain one sample, in the first slot, without a section number.