### PR TITLE
x1145 Let sanger users create a Stan enduser account without approval

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -11,6 +11,7 @@ import graphql.schema.idl.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
+import uk.ac.sanger.sccp.stan.model.User;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
@@ -134,6 +135,7 @@ public class GraphQLProvider {
                         .dataFetcher("version", graphQLDataFetchers.versionInfo())
                 )
                 .type(newTypeWiring("Mutation")
+                        .dataFetcher("registerAsEndUser", graphQLMutation.userSelfRegister(User.Role.enduser))
                         .dataFetcher("login", graphQLMutation.logIn())
                         .dataFetcher("logout", graphQLMutation.logOut())
                         .dataFetcher("register", transact(graphQLMutation.register()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/UserRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/UserRepo.java
@@ -4,6 +4,7 @@ import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.User;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.Optional;
 
 import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
@@ -14,4 +15,6 @@ public interface UserRepo extends CrudRepository<User, Integer> {
     default User getByUsername(String username) throws EntityNotFoundException {
         return findByUsername(username).orElseThrow(() -> new EntityNotFoundException("User not found: "+repr(username)));
     }
+
+    List<User> findAllByRole(User.Role role);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/AuthService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/AuthService.java
@@ -1,0 +1,32 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.request.LoginResult;
+
+/**
+ * Service dealing with user authentication
+ */
+public interface AuthService {
+        /**
+     * Logs in
+     * @param username the username to log in
+     * @param password the password to authenticate the user
+     * @return a login result describing the result of the login
+     */
+    LoginResult logIn(String username, String password);
+
+    /**
+     * Logs out the current logged in user, if any
+     * @return a description of the result of logging out
+     */
+    String logOut();
+
+    /**
+     * Creates a Stan user authenticated with the given credentials
+     * @param username the username to create
+     * @param password the password to authenticate the user
+     * @param role the role to create the user with
+     * @return the result of attempting to log in with the given credentials
+     */
+    LoginResult selfRegister(String username, String password, User.Role role);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/AuthServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/AuthServiceImp.java
@@ -1,0 +1,133 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.AuthenticationComponent;
+import uk.ac.sanger.sccp.stan.config.SessionConfig;
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.repo.UserRepo;
+import uk.ac.sanger.sccp.stan.request.LoginResult;
+
+import java.util.*;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * @author dr6
+ */
+@Service
+public class AuthServiceImp implements AuthService {
+    Logger log = LoggerFactory.getLogger(AuthServiceImp.class);
+    private final SessionConfig sessionConfig;
+    private final UserRepo userRepo;
+    private final AuthenticationComponent authComp;
+    private final LDAPService ldapService;
+    private final EmailService emailService;
+    private final UserAdminService userAdminService;
+
+    @Autowired
+    public AuthServiceImp(SessionConfig sessionConfig,
+                          UserRepo userRepo, AuthenticationComponent authComp,
+                          LDAPService ldapService, EmailService emailService, UserAdminService userAdminService) {
+        this.sessionConfig = sessionConfig;
+        this.userRepo = userRepo;
+        this.authComp = authComp;
+        this.ldapService = ldapService;
+        this.emailService = emailService;
+        this.userAdminService = userAdminService;
+    }
+
+    /**
+     * Gets the username of the logged in user, if any
+     * @return the logged in username, or null
+     */
+    @Nullable
+    public String loggedInUsername() {
+        var auth = authComp.getAuthentication();
+        if (auth != null) {
+            var princ = auth.getPrincipal();
+            if (princ instanceof User) {
+                return ((User) princ).getUsername();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public LoginResult logIn(String username, String password) {
+        if (log.isInfoEnabled()) {
+            log.info("Login attempt by {}", repr(username));
+        }
+        Optional<User> optUser = userRepo.findByUsername(username);
+        if (optUser.isEmpty()) {
+            return new LoginResult("Username not in database.", null);
+        }
+        User user = optUser.get();
+        if (user.getRole()==User.Role.disabled) {
+            return new LoginResult("Username is disabled.", null);
+        }
+        if (!ldapService.verifyCredentials(username, password)) {
+            return new LoginResult("Login failed.", null);
+        }
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user, password, new ArrayList<>());
+        authComp.setAuthentication(authentication, sessionConfig.getMaxInactiveMinutes());
+        log.info("Login succeeded for user {}", user);
+        return new LoginResult("OK", user);
+    }
+
+    @Override
+    public String logOut() {
+        if (log.isInfoEnabled()) {
+            log.info("Logout requested by {}", repr(loggedInUsername()));
+        }
+        authComp.setAuthentication(null, 0);
+        return "OK";
+    }
+
+    @Override
+    public LoginResult selfRegister(String username, String password, User.Role role) {
+        if (log.isInfoEnabled()) {
+            log.info("selfRegister attempt by {}", repr(username));
+        }
+        username = userAdminService.validateUsername(username);
+        if (!ldapService.verifyCredentials(username, password)) {
+            return new LoginResult("Authentication failed.", null);
+        }
+        Optional<User> optUser = userRepo.findByUsername(username);
+        User user;
+        if (optUser.isEmpty()) {
+            user = userAdminService.addUser(username, role);
+            log.info("Login succeeded as new user {}", user);
+            sendNewUserEmail(user);
+        } else {
+            user = optUser.get();
+            if (user.getRole()== User.Role.disabled) {
+                return new LoginResult("Username is disabled.", null);
+            }
+            log.info("Login succeeded for existing user {}", user);
+        }
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user, password, new ArrayList<>());
+        authComp.setAuthentication(authentication, sessionConfig.getMaxInactiveMinutes());
+        return new LoginResult("OK", user);
+    }
+
+    /**
+     * Tries to send an email to admin users about the new user being created.
+     * @param user the new user
+     */
+    public void sendNewUserEmail(User user) {
+        List<User> admins = userRepo.findAllByRole(User.Role.admin);
+        if (admins.isEmpty()) {
+            return;
+        }
+        List<String> usernames = admins.stream().map(User::getUsername).toList();
+        String body = "User "+user.getUsername()+" has registered themself as "+user.getRole()+" on %service.";
+        emailService.tryEmail(usernames, "New user created on %service", body);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/UserAdminService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/UserAdminService.java
@@ -28,6 +28,36 @@ public class UserAdminService {
     }
 
     /**
+     * Validates a given username
+     * @param username the username to validate
+     * @return the name in a sanitised form
+     * @exception IllegalArgumentException if the username is unsuitable
+     */
+    public String validateUsername(String username) {
+        username = trimAndRequire(username, "Username not supplied.").toLowerCase();
+        usernameValidator.checkArgument(username);
+        return username;
+    }
+
+    /**
+     * Creates a new user with the given username.
+     * The username will be stripped and made lower case.
+     * @param username the username
+     * @param role the role for the new user
+     * @return the newly created user
+     * @exception IllegalArgumentException if the username is unsuitable
+     * @exception EntityExistsException if the user already exists
+     */
+    public User addUser(String username, User.Role role) {
+        username = validateUsername(username);
+        requireNonNull(role, "User role is null");
+        if (userRepo.findByUsername(username).isPresent()) {
+            throw new EntityExistsException("User already exists: "+username);
+        }
+        return userRepo.save(new User(null, username, role));
+    }
+
+    /**
      * Creates a new user with the given username.
      * The username will be stripped and made lower case.
      * @param username the username
@@ -36,12 +66,7 @@ public class UserAdminService {
      * @exception EntityExistsException if the user already exists
      */
     public User addUser(String username) {
-        username = trimAndRequire(username, "Username not supplied.").toLowerCase();
-        usernameValidator.checkArgument(username);
-        if (userRepo.findByUsername(username).isPresent()) {
-            throw new EntityExistsException("User already exists: "+username);
-        }
-        return userRepo.save(new User(null, username, User.Role.normal));
+        return addUser(username, User.Role.normal);
     }
 
     /**

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1973,6 +1973,8 @@ Send information to the application.
 These typically require a user with the suitable permission for the particular request.
 """
 type Mutation {
+    """Log in with your Sanger id and create an end user account."""
+    registerAsEndUser(username: String!, password: String!): LoginResult!
     """Log in with the given credentials."""
     login(username: String!, password: String!): LoginResult!
     """Log out; end the current login session."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/TestLogin.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/TestLogin.java
@@ -10,13 +10,17 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.test.context.ActiveProfiles;
 import uk.ac.sanger.sccp.stan.model.User;
 import uk.ac.sanger.sccp.stan.repo.UserRepo;
+import uk.ac.sanger.sccp.stan.service.EmailService;
 import uk.ac.sanger.sccp.stan.service.LDAPService;
 
 import java.util.*;
+import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+
 /**
  * @author dr6
  */
@@ -30,6 +34,8 @@ public class TestLogin {
     private LDAPService mockLdapService;
     @MockBean
     private UserRepo mockUserRepo;
+    @MockBean
+    private EmailService mockEmailService;
 
     @Autowired
     private GraphQLTester tester;
@@ -64,5 +70,34 @@ public class TestLogin {
         tester.setUser(new User("dr6", User.Role.normal));
         Map<String, Map<String, Map<String, String>>> userResult = tester.post(query);
         assertEquals(Map.of("data", Map.of("user", Map.of("username", "dr6", "role", "normal"))), userResult);
+    }
+
+    @Test
+    public void testSelfRegister() throws Exception {
+        final String mutation = "mutation { registerAsEndUser(username: \"user1\", password: \"42\") " +
+                "{ user { username role } } }";
+        User newUser = new User(100, "user1", User.Role.enduser);
+        List<User> adminUsers = IntStream.rangeClosed(1,2)
+                .mapToObj(i -> new User(i, "admin"+i, User.Role.admin))
+                .toList();
+        List<String> recipients = adminUsers.stream().map(User::getUsername).toList();
+        when(mockUserRepo.findAllByRole(User.Role.admin)).thenReturn(adminUsers);
+        when(mockEmailService.tryEmail(any(), any(), any())).thenReturn(true);
+        when(mockUserRepo.findByUsername(any())).thenReturn(Optional.empty());
+        when(mockUserRepo.save(any())).thenReturn(newUser);
+        when(mockLdapService.verifyCredentials("user1", "42")).thenReturn(true);
+
+        Object response = tester.post(mutation);
+        Map<String, String> userData = chainGet(response, "data", "registerAsEndUser", "user");
+        assertEquals("user1", userData.get("username"));
+        assertEquals("enduser", userData.get("role"));
+        verify(mockUserRepo, atLeastOnce()).findByUsername(eq("user1"));
+        verify(mockUserRepo).save(new User("user1", User.Role.enduser));
+        verify(mockLdapService).verifyCredentials("user1", "42");
+        verify(mockEmailService).tryEmail(recipients, "New user created on %service",
+                "User user1 has registered themself as enduser on %service.");
+
+        verify(tester.mockAuthComp).setAuthentication(eq(new UsernamePasswordAuthenticationToken(newUser, "42", new ArrayList<>())), anyInt());
+
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestUserRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestUserRepo.java
@@ -1,0 +1,65 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.model.User;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Tests {@link UserRepo} */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+class TestUserRepo {
+    @Autowired
+    UserRepo userRepo;
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    @Transactional
+    void testFindByUsername(boolean exists) {
+        if (exists) {
+            User user = userRepo.save(new User("bananas", User.Role.normal));
+            assertThat(userRepo.findByUsername("BANANAS")).contains(user);
+        } else {
+            assertThat(userRepo.findByUsername("BANANAS")).isEmpty();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    @Transactional
+    void testGetByUsername(boolean exists) {
+        if (exists) {
+            User user = userRepo.save(new User("bananas", User.Role.normal));
+            assertEquals(user, userRepo.getByUsername("BANANAS"));
+        } else {
+            assertThat(assertThrows(EntityNotFoundException.class, () -> userRepo.getByUsername("BANANAS")))
+                    .hasMessage("User not found: \"BANANAS\"");
+        }
+    }
+
+    @Test
+    @Transactional
+    void testFindByRole() {
+        userRepo.deleteAll();
+        var adminUsers = userRepo.saveAll(IntStream.rangeClosed(1,2)
+                .mapToObj(i -> new User("admin"+i, User.Role.admin))
+                .toList());
+        var normalUsers = userRepo.saveAll(IntStream.rangeClosed(1,2)
+                .mapToObj(i -> new User("user"+i, User.Role.normal))
+                .toList());
+        assertThat(userRepo.findAllByRole(User.Role.admin)).containsExactlyInAnyOrderElementsOf(adminUsers);
+        assertThat(userRepo.findAllByRole(User.Role.normal)).containsExactlyInAnyOrderElementsOf(normalUsers);
+        assertThat(userRepo.findAllByRole(User.Role.disabled)).isEmpty();
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestAuthService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestAuthService.java
@@ -1,0 +1,196 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import uk.ac.sanger.sccp.stan.AuthenticationComponent;
+import uk.ac.sanger.sccp.stan.config.SessionConfig;
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.repo.UserRepo;
+import uk.ac.sanger.sccp.stan.request.LoginResult;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+/** Test {@link AuthServiceImp} */
+class TestAuthService {
+    @Mock
+    private SessionConfig mockSessionConfig;
+    @Mock
+    private UserRepo mockUserRepo;
+    @Mock
+    private AuthenticationComponent mockAuthComp;
+    @Mock
+    private LDAPService mockLdapService;
+    @Mock
+    private EmailService mockEmailService;
+    @Mock
+    private UserAdminService mockUserAdminService;
+
+    @InjectMocks
+    private AuthServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={true,false})
+    void testLoggedInUsername(boolean loggedIn) {
+        String username;
+        if (loggedIn) {
+            username = "user1";
+            User user = new User(100, username, User.Role.normal);
+            Authentication auth = mock(Authentication.class);
+            when(auth.getPrincipal()).thenReturn(user);
+            when(mockAuthComp.getAuthentication()).thenReturn(auth);
+        } else {
+            username = null;
+            when(mockAuthComp.getAuthentication()).thenReturn(null);
+        }
+        assertEquals(username, service.loggedInUsername());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"normal,true",
+            ",true",
+            "disabled,true",
+            "normal,false",
+    })
+    void testLogin(User.Role role, boolean valid) {
+        String username = "un";
+        String password = "pw";
+        final int maxInactiveMinutes = 10;
+        User foundUser = role==null ? null : new User(100, username, role);
+        when(mockLdapService.verifyCredentials(username, password)).thenReturn(valid);
+        when(mockUserRepo.findByUsername(username)).thenReturn(Optional.ofNullable(foundUser));
+        when(mockSessionConfig.getMaxInactiveMinutes()).thenReturn(maxInactiveMinutes);
+        LoginResult result = service.logIn(username, password);
+        String expectedMessage;
+        User expectedUser = null;
+        if (role==null) {
+            expectedMessage = "Username not in database.";
+        } else if (role== User.Role.disabled) {
+            expectedMessage = "Username is disabled.";
+        } else if (!valid) {
+            expectedMessage = "Login failed.";
+        } else {
+            expectedUser = foundUser;
+            expectedMessage = "OK";
+        }
+        assertEquals(expectedMessage, result.getMessage());
+        assertSame(expectedUser, result.getUser());
+        if (result.getUser()!=null) {
+            Authentication authentication = new UsernamePasswordAuthenticationToken(foundUser, password, new ArrayList<>());
+            verify(mockAuthComp).setAuthentication(authentication, maxInactiveMinutes);
+        } else {
+            verifyNoInteractions(mockAuthComp);
+        }
+    }
+
+    @Test
+    void testLogOut() {
+        service.logOut();
+        verify(mockAuthComp).setAuthentication(null, 0);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", true",
+            "normal, true",
+            "disabled, true",
+            ", false",
+    })
+    void testSelfRegister(User.Role existingRole, boolean valid) {
+        final int maxInactiveMinutes = 10;
+        final String sanUsername = "user1";
+        final String password = "pw";
+        final String inputUsername = " USER1";
+        final User.Role suppliedRole = User.Role.enduser;
+        when(mockSessionConfig.getMaxInactiveMinutes()).thenReturn(maxInactiveMinutes);
+        User existingUser = (existingRole==null ? null : new User(100, sanUsername, existingRole));
+        when(mockUserAdminService.validateUsername(inputUsername)).thenReturn(sanUsername);
+        when(mockLdapService.verifyCredentials(sanUsername, password)).thenReturn(valid);
+        when(mockUserRepo.findByUsername(sanUsername)).thenReturn(Optional.ofNullable(existingUser));
+        User newUser;
+        if (existingRole==null && valid) {
+            newUser = new User(200, sanUsername, suppliedRole);
+            when(mockUserAdminService.addUser(sanUsername, suppliedRole)).thenReturn(newUser);
+        } else {
+            newUser = null;
+        }
+        doNothing().when(service).sendNewUserEmail(any());
+        User expectedUser;
+        String expectedMessage;
+        LoginResult result = service.selfRegister(inputUsername, password, suppliedRole);
+        if (newUser!=null) {
+            expectedUser = newUser;
+            expectedMessage = "OK";
+        } else if (valid && existingRole != User.Role.disabled) {
+            expectedUser = existingUser;
+            expectedMessage = "OK";
+        } else {
+            expectedUser = null;
+            expectedMessage = valid ? "Username is disabled." : "Authentication failed.";
+        }
+
+        assertSame(expectedUser, result.getUser());
+        assertEquals(expectedMessage, result.getMessage());
+
+        if (expectedUser!=null) {
+            Authentication authentication = new UsernamePasswordAuthenticationToken(expectedUser, password, new ArrayList<>());
+            verify(mockAuthComp).setAuthentication(authentication, maxInactiveMinutes);
+        } else {
+            verifyNoInteractions(mockAuthComp);
+        }
+        if (newUser!=null) {
+            verify(service).sendNewUserEmail(newUser);
+        } else {
+            verify(service, never()).sendNewUserEmail(any());
+        }
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    void testSendNewUserEmail(boolean anyAdmins) {
+        User newUser = new User(100, "user1", User.Role.enduser);
+        List<User> adminUsers;
+        if (anyAdmins) {
+            adminUsers = IntStream.rangeClosed(1,2)
+                    .mapToObj(i -> new User(100+i, "admin"+i, User.Role.admin))
+                    .toList();
+        } else {
+            adminUsers = List.of();
+        }
+        when(mockUserRepo.findAllByRole(User.Role.admin)).thenReturn(adminUsers);
+        when(mockEmailService.tryEmail(any(), any(), any())).thenReturn(true);
+
+        service.sendNewUserEmail(newUser);
+
+        if (!anyAdmins) {
+            verifyNoInteractions(mockEmailService);
+        } else {
+            List<String> adminUsernames = adminUsers.stream().map(User::getUsername).toList();
+            verify(mockEmailService).tryEmail(adminUsernames, "New user created on %service",
+                    "User user1 has registered themself as enduser on %service.");
+        }
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestEmailService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestEmailService.java
@@ -148,4 +148,31 @@ public class TestEmailService {
 
         verify(service).send(desc+" release", body + path, new String[] { recipient }, ccArray);
     }
+
+    @ParameterizedTest
+    @CsvSource({",",
+            "alpha, alpha@sanger.ac.uk",
+            "beta@gamma, beta@gamma",
+    })
+    public void testUsernameToEmail(String input, String expected) {
+        assertEquals(expected, service.usernameToEmail(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testTryEmail(boolean succeeds) {
+        if (succeeds) {
+            doNothing().when(service).send(any(), any(), any(), any());
+        } else {
+            doThrow(RuntimeException.class).when(service).send(any(), any(), any(), any());
+        }
+        List<String> recipients = List.of("alpha", "beta@gamma");
+        doReturn("Stan test").when(mockMailConfig).getServiceDescription();
+        assertEquals(succeeds, service.tryEmail(recipients, "Email from %service",
+                "%service has done stuff."));
+        verify(service).send("Email from Stan test",
+                "Stan test has done stuff.",
+                new String[] { "alpha@sanger.ac.uk", "beta@gamma" },
+                null);
+    }
 }


### PR DESCRIPTION
Moved auth stuff from mutations into new AuthService. Let a sanger user with credentials create a new enduser account in Stan. When that happens, notify all Stan admin users by email.

For #340 