### PR TITLE
x1167 Make lifestage optional

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelDataService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelDataService.java
@@ -341,11 +341,14 @@ public class LabwareLabelDataService {
     }
 
     public String prefix(LifeStage lifeStage) {
-        return switch (lifeStage) {
-            case fetal -> "F";
-            case paediatric -> "P";
-            default -> "";
-        };
+        if (lifeStage!=null) {
+            return switch (lifeStage) {
+                case fetal -> "F";
+                case paediatric -> "P";
+                default -> "";
+            };
+        }
+        return "";
     }
 
     public List<LabelContent> getPlannedContent(List<PlanAction> planActions, Comparator<Slot> slotOrder) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/OriginalSampleRegisterServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/OriginalSampleRegisterServiceImp.java
@@ -99,7 +99,7 @@ public class OriginalSampleRegisterServiceImp implements IRegisterService<Origin
 
         checkFormat(problems, request, "Donor identifier", OriginalSampleData::getDonorIdentifier, true, donorNameValidator);
         checkFormat(problems, request, "External identifier", OriginalSampleData::getExternalIdentifier, false, externalNameValidator);
-        checkFormat(problems, request, "Life stage", OriginalSampleData::getLifeStage, true, null);
+        checkFormat(problems, request, "Life stage", OriginalSampleData::getLifeStage, false, null);
         checkFormat(problems, request, "HuMFre number", OriginalSampleData::getHmdmc, false, hmdmcValidator);
         checkFormat(problems, request, "Replicate number", OriginalSampleData::getReplicateNumber, false, replicateValidator);
         checkFormat(problems, request, "Species", OriginalSampleData::getSpecies, true, null);

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationImp.java
@@ -95,9 +95,6 @@ public class RegisterValidationImp implements RegisterValidation {
             } else if (donorNameValidation!=null) {
                 donorNameValidation.validate(block.getDonorIdentifier(), this::addProblem);
             }
-            if (block.getLifeStage()==null) {
-                addProblem("Missing life stage.");
-            }
             if (block.getSpecies()==null || block.getSpecies().isEmpty()) {
                 addProblem("Missing species.");
             } else {
@@ -122,7 +119,7 @@ public class RegisterValidationImp implements RegisterValidation {
                 donor = new Donor(null, block.getDonorIdentifier(), block.getLifeStage(), species);
                 donorMap.put(donorNameUc, donor);
             } else {
-                if (block.getLifeStage()!=null && donor.getLifeStage()!=block.getLifeStage()) {
+                if (donor.getLifeStage()!=block.getLifeStage()) {
                     addProblem("Multiple different life stages specified for donor "+donor.getDonorName());
                 }
                 if (species!=null && !species.equals(donor.getSpecies())) {
@@ -137,7 +134,7 @@ public class RegisterValidationImp implements RegisterValidation {
             }
             Donor realDonor = optDonor.get();
             Donor newDonor = entry.getValue();
-            if (newDonor.getLifeStage()!=null && realDonor.getLifeStage()!=newDonor.getLifeStage()) {
+            if (realDonor.getLifeStage()!=newDonor.getLifeStage()) {
                 addProblem("Wrong life stage given for existing donor "+realDonor.getDonorName());
             }
             if (newDonor.getSpecies()!=null && !newDonor.getSpecies().equals(realDonor.getSpecies())) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/SectionRegisterValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/SectionRegisterValidation.java
@@ -2,22 +2,15 @@ package uk.ac.sanger.sccp.stan.service.register;
 
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
-import uk.ac.sanger.sccp.stan.request.register.SectionRegisterContent;
-import uk.ac.sanger.sccp.stan.request.register.SectionRegisterLabware;
-import uk.ac.sanger.sccp.stan.request.register.SectionRegisterRequest;
-import uk.ac.sanger.sccp.stan.service.SlotRegionService;
-import uk.ac.sanger.sccp.stan.service.ValidationException;
-import uk.ac.sanger.sccp.stan.service.Validator;
+import uk.ac.sanger.sccp.stan.request.register.*;
+import uk.ac.sanger.sccp.stan.service.*;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.UCMap;
 
 import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.function.*;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static uk.ac.sanger.sccp.utils.BasicUtils.*;
 import static uk.ac.sanger.sccp.utils.UCMap.toUCMap;
@@ -128,9 +121,6 @@ public class SectionRegisterValidation {
             } else if (donorNameValidation!=null) {
                 donorNameValidation.validate(content.getDonorIdentifier(), this::addProblem);
             }
-            if (content.getLifeStage()==null) {
-                addProblem("Missing life stage.");
-            }
             if (content.getSpecies()==null || content.getSpecies().isEmpty()) {
                 addProblem("Missing species.");
             } else {
@@ -148,13 +138,11 @@ public class SectionRegisterValidation {
                 donor = new Donor(null, content.getDonorIdentifier(), content.getLifeStage(), species);
                 donorMap.put(donorName, donor);
             } else {
-                if (content.getLifeStage()!=null && content.getLifeStage()!=donor.getLifeStage()) {
+                if (content.getLifeStage()!=donor.getLifeStage()) {
                     if (donor.getId()!=null) {
                         addProblem("Wrong life stage given for existing donor "+donor.getDonorName());
-                    } else if (donor.getLifeStage()!=null) {
-                        addProblem("Multiple different life stages specified for donor "+donor.getDonorName());
                     } else {
-                        donor.setLifeStage(content.getLifeStage());
+                        addProblem("Multiple different life stages specified for donor "+donor.getDonorName());
                     }
                 }
                 if (species!=null && !species.equals(donor.getSpecies())) {
@@ -512,7 +500,7 @@ public class SectionRegisterValidation {
                 .filter(x -> x!=null && !enabledPredicate.test(x))
                 .map(stringFunction)
                 .sorted()
-                .collect(toList());
+                .toList();
         if (notUsable.isEmpty()) {
             return true;
         }

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -248,7 +248,7 @@
                 <constraints nullable="false" unique="true"/>
             </column>
             <column name="life_stage" type="ENUM('adult', 'paediatric', 'fetal')">
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
             </column>
             <column name="species_id" type="INT">
                 <constraints nullable="false" foreignKeyName="fk_donor_species" referencedTableName="species" referencedColumnNames="id"/>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -137,7 +137,7 @@ type Species {
 type Donor {
     donorName: String!
     """The stage of life of this donor at the point the tissue was collected."""
-    lifeStage: LifeStage!
+    lifeStage: LifeStage
     species: Species!
 }
 
@@ -273,7 +273,7 @@ input BlockRegisterRequest {
     """The string to use as the donor name."""
     donorIdentifier: String!
     """The life stage of the donor."""
-    lifeStage: LifeStage!
+    lifeStage: LifeStage
     """The HMDMC to use for the tissue."""
     hmdmc: String
     """The name of the tissue type (the organ from which the tissue is taken)."""
@@ -317,7 +317,7 @@ input SectionRegisterContent {
     """A name for the donor."""
     donorIdentifier: String!
     """The life stage of the donor."""
-    lifeStage: LifeStage!
+    lifeStage: LifeStage
     """The external name for the tissue from which this section was taken."""
     externalIdentifier: String!
     """The name of the tissue type (organ) for the tissue."""
@@ -363,7 +363,7 @@ input OriginalSampleData {
     """The string to use as the donor name."""
     donorIdentifier: String!
     """The life stage of the donor."""
-    lifeStage: LifeStage!
+    lifeStage: LifeStage
     """The HMDMC to use for the tissue."""
     hmdmc: String
     """The name of the tissue type (the organ from which the tissue is taken)."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestOriginalSampleRegisterService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestOriginalSampleRegisterService.java
@@ -204,7 +204,7 @@ public class TestOriginalSampleRegisterService {
         verify(service).checkFormat(problemsArgCaptor.capture(), same(request), eq("Donor identifier"), any(), eq(true), same(mockDonorNameValidator));
         Collection<String> problems = problemsArgCaptor.getValue();
         verify(service).checkFormat(same(problems), same(request), eq("External identifier"), any(), eq(false), same(mockExternalNameValidator));
-        verify(service).checkFormat(same(problems), same(request), eq("Life stage"), any(), eq(true), isNull());
+        verify(service).checkFormat(same(problems), same(request), eq("Life stage"), any(), eq(false), isNull());
         verify(service).checkFormat(same(problems), same(request), eq("HuMFre number"), any(), eq(false), same(mockHmdmcValidator));
         verify(service).checkFormat(same(problems), same(request), eq("Replicate number"), any(), eq(false), same(mockReplicateValidator));
         verify(service).checkFormat(same(problems), same(request), eq("Species"), any(), eq(true), isNull());

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidation.java
@@ -598,7 +598,7 @@ public class TestRegisterValidation {
                         List.of("Multiple different life stages specified for donor Donor1")),
                 Arguments.of(Arrays.asList(null, null), Arrays.asList(null, null),
                         List.of("human", "human"),
-                        List.of(), knownSpecies, List.of(), List.of("Missing donor identifier.", "Missing life stage.")),
+                        List.of(), knownSpecies, List.of(), List.of("Missing donor identifier.")),
                 Arguments.of(List.of(""), List.of(LifeStage.adult),
                         List.of("human", "human"),
                         List.of(), knownSpecies, List.of(), List.of("Missing donor identifier.")),

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterValidation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterValidation.java
@@ -3,31 +3,20 @@ package uk.ac.sanger.sccp.stan.service.register;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.*;
 import org.mockito.stubbing.Answer;
 import uk.ac.sanger.sccp.stan.EntityFactory;
 import uk.ac.sanger.sccp.stan.Matchers;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
-import uk.ac.sanger.sccp.stan.request.register.SectionRegisterContent;
-import uk.ac.sanger.sccp.stan.request.register.SectionRegisterLabware;
-import uk.ac.sanger.sccp.stan.request.register.SectionRegisterRequest;
-import uk.ac.sanger.sccp.stan.service.SlotRegionService;
-import uk.ac.sanger.sccp.stan.service.ValidationException;
-import uk.ac.sanger.sccp.stan.service.Validator;
+import uk.ac.sanger.sccp.stan.request.register.*;
+import uk.ac.sanger.sccp.stan.service.*;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.UCMap;
 
 import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -243,9 +232,12 @@ public class TestSectionRegisterValidation {
                                 new SectionRegisterContent("DONOR1", LifeStage.adult, "human"),
                                 new SectionRegisterContent("DONOR2", LifeStage.fetal, "Human"),
                                 new SectionRegisterContent("DONOR2", LifeStage.fetal, "HUMAN"),
-                                new SectionRegisterContent("DONOR3", LifeStage.paediatric, "Hamster")),
+                                new SectionRegisterContent("DONOR3", LifeStage.paediatric, "Hamster"),
+                                new SectionRegisterContent("DONOR4", null, "human"),
+                                new SectionRegisterContent("DONOR4", null, "HUMAN")),
                         null, List.of(new Donor(null, "DONOR2", LifeStage.fetal, human),
                                 new Donor(null, "DONOR3", LifeStage.paediatric, hamster),
+                                new Donor(null, "DONOR4", null, human),
                                 donor1), knownDonors, knownSpecies
                 ),
 
@@ -260,7 +252,7 @@ public class TestSectionRegisterValidation {
                 ),
                 Arguments.of(
                         new SectionRegisterContent("DONOR1", null, "Human"),
-                        "Missing life stage.", donor1, knownDonors, knownSpecies
+                        "Wrong life stage given for existing donor DONOR1", donor1, knownDonors, knownSpecies
                 ),
                 Arguments.of(
                         new SectionRegisterContent("DONOR1", LifeStage.adult, null),
@@ -305,8 +297,8 @@ public class TestSectionRegisterValidation {
                         List.of(new SectionRegisterContent("DONOR2", null, ""),
                                 new SectionRegisterContent("Donor2", LifeStage.adult, null),
                                 new SectionRegisterContent("donor2", null, "Human")),
-                        List.of("Missing life stage.", "Missing species."),
-                        new Donor(null, "DONOR2", LifeStage.adult, human),
+                        List.of("Missing species.", "Multiple different life stages specified for donor DONOR2"),
+                        new Donor(null, "DONOR2", null, human),
                         knownDonors, knownSpecies
                 ),
 
@@ -320,12 +312,12 @@ public class TestSectionRegisterValidation {
                                 new SectionRegisterContent("DONOR3", LifeStage.fetal, "Unicorn")),
                         List.of("Wrong life stage given for existing donor DONOR1",
                                 "Wrong species given for existing donor DONOR1",
-                                "Missing life stage.", "Missing species.", "Missing donor identifier.",
-                                "Multiple different species specified for donor DONOR2",
+                                "Missing species.", "Missing donor identifier.",
                                 "Multiple different life stages specified for donor DONOR2",
+                                "Multiple different species specified for donor DONOR2",
                                 "Unknown species: \"Unicorn\""
                         ),
-                        List.of(donor1, new Donor(null, "DONOR2", LifeStage.adult, human),
+                        List.of(donor1, new Donor(null, "DONOR2", null, human),
                                 new Donor(null, "DONOR3", LifeStage.fetal, null)),
                         knownDonors, knownSpecies
                 )


### PR DESCRIPTION
The LifeStage field is now nullable in graphql and in the database. The client can offer an n/a option for life stage as long as it uses null in the request.
(Making n/a an acceptable value in the LifeStage enum would have needed more extensive rewrite because a graphql enum cannot contain a slash.)
