### PR TITLE
x1190 Support "ignoreExternalNames" parameter in block reg post req

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/RegistrationFileController.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/RegistrationFileController.java
@@ -50,9 +50,10 @@ public class RegistrationFileController {
 
     @PostMapping(value = "/register/block", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> receiveBlockFile(@RequestParam("file") MultipartFile file,
-                                              @RequestParam(value="existingExternalNames", required=false) List<String> existingExternalNames)
+                                              @RequestParam(value="existingExternalNames", required=false) List<String> existingExternalNames,
+                                              @RequestParam(value="ignoreExternalNames", required=false) List<String> ignoreExternalNames)
             throws URISyntaxException {
-        BiFunction<User, MultipartFile, RegisterResult> biFunction = (user, multipartFile) -> fileRegisterService.registerBlocks(user, multipartFile, existingExternalNames);
+        BiFunction<User, MultipartFile, RegisterResult> biFunction = (user, multipartFile) -> fileRegisterService.registerBlocks(user, multipartFile, existingExternalNames, ignoreExternalNames);
         return receiveFile("block", file, biFunction);
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/UnreleaseServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/UnreleaseServiceImp.java
@@ -12,10 +12,8 @@ import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.utils.UCMap;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/FileRegisterService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/FileRegisterService.java
@@ -32,7 +32,7 @@ public interface FileRegisterService {
      * @exception UncheckedIOException the file cannot be read
      */
     default RegisterResult registerBlocks(User user, MultipartFile multipartFile) throws ValidationException, UncheckedIOException {
-        return registerBlocks(user, multipartFile, null);
+        return registerBlocks(user, multipartFile, null, null);
     }
 
     /**
@@ -40,11 +40,12 @@ public interface FileRegisterService {
      * @param user the user responsible
      * @param multipartFile the file data
      * @param existingExternalNames known existing tissue external names to reregister
+     * @param ignoreExternalNames external names of rows to exclude from the request
      * @return the result of the registration
      * @exception ValidationException the data received is invalid
      * @exception UncheckedIOException the file cannot be read
      */
-    RegisterResult registerBlocks(User user, MultipartFile multipartFile, List<String> existingExternalNames)
+    RegisterResult registerBlocks(User user, MultipartFile multipartFile, List<String> existingExternalNames, List<String> ignoreExternalNames)
             throws ValidationException, UncheckedIOException;
 
     /**


### PR DESCRIPTION
If the user tries to block reg and gets clashes, they can unrelease the affected tissues; then they should have the option to resubmit the file but exclude the tissues that have been unreleased.

For #386 
