### PR TITLE
Cleanout operation

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -76,6 +76,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final FileStoreService fileStoreService;
     final SlotRegionService slotRegionService;
     final RecentOpService recentOpService;
+    final CleanedOutSlotService cleanedOutSlotService;
     final FlagLookupService flagLookupService;
     final MeasurementService measurementService;
     final GraphService graphService;
@@ -101,6 +102,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                NextReplicateService nextReplicateService, WorkSummaryService workSummaryService,
                                LabwareService labwareService, FileStoreService fileStoreService,
                                SlotRegionService slotRegionService, RecentOpService recentOpService,
+                               CleanedOutSlotService cleanedOutSlotService,
                                FlagLookupService flagLookupService, MeasurementService measurementService,
                                GraphService graphService) {
         super(objectMapper, authComp, userRepo);
@@ -144,6 +146,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.fileStoreService = fileStoreService;
         this.slotRegionService = slotRegionService;
         this.recentOpService = recentOpService;
+        this.cleanedOutSlotService = cleanedOutSlotService;
         this.flagLookupService = flagLookupService;
         this.measurementService = measurementService;
         this.graphService = graphService;
@@ -354,6 +357,13 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
             String barcode = dfe.getArgument("barcode");
             String opName = dfe.getArgument("operationType");
             return recentOpService.findLatestOp(barcode, opName);
+        };
+    }
+
+    public DataFetcher<List<Address>> cleanedOutAddresses() {
+        return dfe -> {
+            String barcode = dfe.getArgument("barcode");
+            return cleanedOutSlotService.findCleanedOutAddresses(barcode);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -99,6 +99,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
     final ReactivateService reactivateService;
     final LibraryPrepService libraryPrepService;
     final SegmentationService segmentationService;
+    final CleanOutService cleanOutService;
     final UserAdminService userAdminService;
 
     @Autowired
@@ -131,7 +132,8 @@ public class GraphQLMutation extends BaseGraphQLResource {
                            ProbeService probeService, CompletionService completionService, AnalyserService analyserService,
                            FlagLabwareService flagLabwareService,
                            QCLabwareService qcLabwareService, OrientationService orientationService, SSStudyService ssStudyService,
-                           ReactivateService reactivateService, LibraryPrepService libraryPrepService, SegmentationService segmentationService,
+                           ReactivateService reactivateService, LibraryPrepService libraryPrepService,
+                           SegmentationService segmentationService, CleanOutService cleanOutService,
                            UserAdminService userAdminService) {
         super(objectMapper, authComp, userRepo);
         this.authService = authService;
@@ -192,6 +194,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         this.reactivateService = reactivateService;
         this.libraryPrepService = libraryPrepService;
         this.segmentationService = segmentationService;
+        this.cleanOutService = cleanOutService;
         this.userAdminService = userAdminService;
     }
 
@@ -882,6 +885,15 @@ public class GraphQLMutation extends BaseGraphQLResource {
             SegmentationRequest request = arg(dfe, "request", SegmentationRequest.class);
             logRequest("Segmentation", user, request);
             return segmentationService.perform(user, request);
+        };
+    }
+
+    public DataFetcher<OperationResult> cleanOut() {
+        return dfe -> {
+            User user = checkUser(dfe, User.Role.normal);
+            CleanOutRequest request = arg(dfe, "request", CleanOutRequest.class);
+            logRequest("Clean out", user, request);
+            return cleanOutService.perform(user, request);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -223,6 +223,7 @@ public class GraphQLProvider {
                         .dataFetcher("reactivateLabware", transact(graphQLMutation.reactivateLabware()))
                         .dataFetcher("libraryPrep", graphQLMutation.libraryPrep()) // internal transaction
                         .dataFetcher("segmentation", transact(graphQLMutation.segmentation()))
+                        .dataFetcher("cleanOut", transact(graphQLMutation.cleanOut()))
 
                         .dataFetcher("addUser", transact(graphQLMutation.addUser()))
                         .dataFetcher("setUserRole", transact(graphQLMutation.setUserRole()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -112,6 +112,7 @@ public class GraphQLProvider {
                         .dataFetcher("suggestedWorkForLabware", graphQLDataFetchers.getSuggestedWorkForLabwareBarcodes())
                         .dataFetcher("suggestedLabwareForWork", graphQLDataFetchers.getSuggestedLabwareForWork())
                         .dataFetcher("findLatestOp", graphQLDataFetchers.findLatestOperation())
+                        .dataFetcher("cleanedOutAddresses", graphQLDataFetchers.cleanedOutAddresses())
                         .dataFetcher("labwareFlagDetails", graphQLDataFetchers.getFlagDetails())
                         .dataFetcher("measurementValueFromLabwareOrParent", graphQLDataFetchers.getMeasurementValueFromLabwareOrParent())
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/CleanOutRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/CleanOutRequest.java
@@ -1,0 +1,85 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.stan.model.Address;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullToEmpty;
+
+/**
+ * A request to remove samples from particular slots in labware.
+ * @author dr6
+ */
+public class CleanOutRequest {
+    private String barcode;
+    private List<Address> addresses = List.of();
+    private String workNumber;
+
+    public CleanOutRequest() {} // deserialisation constructor
+
+    public CleanOutRequest(String barcode, List<Address> addresses, String workNumber) {
+        setBarcode(barcode);
+        setAddresses(addresses);
+        setWorkNumber(workNumber);
+    }
+
+    /**
+     * The barcode of the labware.
+     */
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    /**
+     * The addresses of the slots to clean out.
+     */
+    public List<Address> getAddresses() {
+        return this.addresses;
+    }
+
+    public void setAddresses(List<Address> addresses) {
+        this.addresses = nullToEmpty(addresses);
+    }
+
+    /**
+     * The work number to link to the operation.
+     */
+    public String getWorkNumber() {
+        return this.workNumber;
+    }
+
+    public void setWorkNumber(String workNumber) {
+        this.workNumber = workNumber;
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe(this)
+                .add("barcode", barcode)
+                .add("addresses", addresses)
+                .add("workNumber", workNumber)
+                .reprStringValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CleanOutRequest that = (CleanOutRequest) o;
+        return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.addresses, that.addresses)
+                && Objects.equals(this.workNumber, that.workNumber));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(barcode, addresses, workNumber);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/CleanOutService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/CleanOutService.java
@@ -1,0 +1,16 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.User;
+import uk.ac.sanger.sccp.stan.request.CleanOutRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+
+public interface CleanOutService {
+    /**
+     * Validates and records the clean out operation
+     * @param user the user responsible for the request
+     * @param request the request to clean out
+     * @return the result of the operation
+     * @exception ValidationException the request failed validation
+     */
+    OperationResult perform(User user, CleanOutRequest request) throws ValidationException;
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/CleanOutServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/CleanOutServiceImp.java
@@ -1,0 +1,155 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.SlotRepo;
+import uk.ac.sanger.sccp.stan.request.CleanOutRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelper;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelperFactory;
+import uk.ac.sanger.sccp.stan.service.work.WorkService;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+
+/**
+ * @author dr6
+ */
+@Service
+public class CleanOutServiceImp implements CleanOutService {
+    private final ValidationHelperFactory valFactory;
+    private final OperationService opService;
+    private final WorkService workService;
+    private final SlotRepo slotRepo;
+
+    @Autowired
+    public CleanOutServiceImp(ValidationHelperFactory valFactory, OperationService opService, WorkService workService,
+                              SlotRepo slotRepo) {
+        this.valFactory = valFactory;
+        this.opService = opService;
+        this.workService = workService;
+        this.slotRepo = slotRepo;
+    }
+
+    @Override
+    public OperationResult perform(User user, CleanOutRequest request) throws ValidationException {
+        ValidationHelper val = valFactory.getHelper();
+        final Collection<String> problems = val.getProblems();
+        if (user==null) {
+            problems.add("No user supplied.");
+        }
+        if (request==null) {
+            problems.add("No request supplied.");
+            throw new ValidationException(problems);
+        }
+        OperationType opType = val.checkOpType("Clean out", OperationTypeFlag.IN_PLACE);
+        Work work = workService.validateUsableWork(problems, request.getWorkNumber());
+        Labware lw = loadLabware(val, request.getBarcode());
+        checkAddresses(problems, lw, request.getAddresses());
+        if (!problems.isEmpty()) {
+            throw new ValidationException(problems);
+        }
+        return record(user, opType, work, lw, request.getAddresses());
+    }
+
+    /**
+     * Loads the indicated labware and checks for problems
+     * @param val validation helper
+     * @param barcode barcode of labware to load
+     * @return the labware loaded, if any
+     */
+    public Labware loadLabware(ValidationHelper val, String barcode) {
+        UCMap<Labware> labware = val.checkLabware(singletonList(barcode));
+        return labware.get(barcode);
+    }
+
+    /**
+     * Checks addresses for problems
+     * @param problems receptacle for problems
+     * @param lw labware, if known
+     * @param addresses the slot addresses supplied in the request
+     */
+    public void checkAddresses(Collection<String> problems, Labware lw, List<Address> addresses) {
+        if (nullOrEmpty(addresses)) {
+            problems.add("No slot addresses supplied.");
+            return;
+        }
+        boolean anyNull = false;
+        Set<Address> uniqueAddresses = new LinkedHashSet<>();
+        Set<Address> repeatedAddresses = new LinkedHashSet<>();
+        for (Address address : addresses) {
+            if (address==null) {
+                anyNull = true;
+            } else if (!uniqueAddresses.add(address)) {
+                repeatedAddresses.add(address);
+            }
+        }
+        if (anyNull) {
+            problems.add("Null supplied as slot address.");
+        }
+        if (!repeatedAddresses.isEmpty()) {
+            problems.add("Repeated slot address: "+repeatedAddresses);
+        }
+        if (lw!=null && !uniqueAddresses.isEmpty()) {
+            checkSlots(problems, lw, uniqueAddresses);
+        }
+    }
+
+    /**
+     * Checks the validity of the addresses for slots in the given labware
+     * @param problems receptacle for problems
+     * @param lw the specified labware
+     * @param addresses the specified addresses
+     */
+    public void checkSlots(Collection<String> problems, Labware lw, Set<Address> addresses) {
+        List<Address> invalidAddresses = new ArrayList<>();
+        List<Address> emptySlotAddresses = new ArrayList<>();
+        for (Address address : addresses) {
+            Optional<Slot> optSlot = lw.optSlot(address);
+            if (optSlot.isEmpty()) {
+                invalidAddresses.add(address);
+            } else {
+                Slot slot = optSlot.get();
+                if (slot.getSamples().isEmpty()) {
+                    emptySlotAddresses.add(address);
+                }
+            }
+        }
+        if (!invalidAddresses.isEmpty()) {
+            problems.add("No slot found in labware "+lw.getBarcode()+" at address: "+invalidAddresses);
+        }
+        if (!emptySlotAddresses.isEmpty()) {
+            problems.add("Slot in labware "+lw.getBarcode()+" is empty: "+emptySlotAddresses);
+        }
+    }
+
+    /**
+     * Records the indicates operation and cleans out the specified slots
+     * @param user the user responsible for the operation
+     * @param opType the operation type to record
+     * @param work the work to link to the operation
+     * @param lw the labware affected
+     * @param addresses the addresses of the slots to clean out
+     * @return the operation and labware
+     */
+    public OperationResult record(User user, OperationType opType, Work work, Labware lw, Collection<Address> addresses) {
+        List<Slot> slots = addresses.stream()
+                .map(lw::getSlot)
+                .toList();
+        List<Action> actions = slots.stream()
+                .flatMap(slot -> slot.getSamples().stream()
+                        .map(sam -> new Action(null, null, slot, slot, sam, sam)))
+                .toList();
+        for (Slot slot : slots) {
+            slot.setSamples(List.of());
+        }
+        slotRepo.saveAll(slots);
+        List<Operation> ops = List.of(opService.createOperation(opType, user, actions, null));
+        workService.link(work, ops);
+        return new OperationResult(ops, List.of(lw));
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotService.java
@@ -1,10 +1,8 @@
 package uk.ac.sanger.sccp.stan.service;
 
-import uk.ac.sanger.sccp.stan.model.Labware;
-import uk.ac.sanger.sccp.stan.model.Slot;
+import uk.ac.sanger.sccp.stan.model.*;
 
-import java.util.Collection;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Service to check for cleaned out slots
@@ -16,4 +14,12 @@ public interface CleanedOutSlotService {
      * @return the slots from the given labware that have been cleaned out
      */
     Set<Slot> findCleanedOutSlots(Collection<Labware> labware);
+
+    /**
+     * Finds addresses of cleaned out slots in labware with the given barcode.
+     * Returns an empty list if there is no such labware.
+     * @param barcode the barcode of the labware
+     * @return the addresses of the cleaned out slots
+     */
+    List<Address> findCleanedOutAddresses(String barcode);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotService.java
@@ -1,0 +1,19 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.Labware;
+import uk.ac.sanger.sccp.stan.model.Slot;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Service to check for cleaned out slots
+ */
+public interface CleanedOutSlotService {
+    /**
+     * Finds any slots in the given labware that have been cleaned out
+     * @param labware the labware to find cleaned out slots in
+     * @return the slots from the given labware that have been cleaned out
+     */
+    Set<Slot> findCleanedOutSlots(Collection<Labware> labware);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotServiceImp.java
@@ -3,8 +3,7 @@ package uk.ac.sanger.sccp.stan.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.ac.sanger.sccp.stan.model.*;
-import uk.ac.sanger.sccp.stan.repo.OperationRepo;
-import uk.ac.sanger.sccp.stan.repo.OperationTypeRepo;
+import uk.ac.sanger.sccp.stan.repo.*;
 
 import java.util.*;
 
@@ -18,11 +17,13 @@ import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
 public class CleanedOutSlotServiceImp implements CleanedOutSlotService {
     public static final String CLEAN_OUT_OP = "Clean out";
 
+    private final LabwareRepo lwRepo;
     private final OperationTypeRepo opTypeRepo;
     private final OperationRepo opRepo;
 
     @Autowired
-    public CleanedOutSlotServiceImp(OperationTypeRepo opTypeRepo, OperationRepo opRepo) {
+    public CleanedOutSlotServiceImp(LabwareRepo lwRepo, OperationTypeRepo opTypeRepo, OperationRepo opRepo) {
+        this.lwRepo = lwRepo;
         this.opTypeRepo = opTypeRepo;
         this.opRepo = opRepo;
     }
@@ -45,5 +46,16 @@ public class CleanedOutSlotServiceImp implements CleanedOutSlotService {
                 .map(Action::getDestination)
                 .filter(slot -> labwareIds.contains(slot.getLabwareId()))
                 .collect(toSet());
+    }
+
+    @Override
+    public List<Address> findCleanedOutAddresses(String barcode) {
+        Labware lw = lwRepo.findByBarcode(barcode).orElse(null);
+        if (lw==null) {
+            return List.of();
+        }
+        return findCleanedOutSlots(List.of(lw)).stream()
+                .map(Slot::getAddress)
+                .toList();
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/CleanedOutSlotServiceImp.java
@@ -1,0 +1,49 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+import uk.ac.sanger.sccp.stan.repo.OperationTypeRepo;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toSet;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+
+/**
+ * @author dr6
+ */
+@Service
+public class CleanedOutSlotServiceImp implements CleanedOutSlotService {
+    public static final String CLEAN_OUT_OP = "Clean out";
+
+    private final OperationTypeRepo opTypeRepo;
+    private final OperationRepo opRepo;
+
+    @Autowired
+    public CleanedOutSlotServiceImp(OperationTypeRepo opTypeRepo, OperationRepo opRepo) {
+        this.opTypeRepo = opTypeRepo;
+        this.opRepo = opRepo;
+    }
+
+    @Override
+    public Set<Slot> findCleanedOutSlots(Collection<Labware> labware) {
+        if (nullOrEmpty(labware)) {
+            return Set.of();
+        }
+        Optional<OperationType> optOpType = opTypeRepo.findByName(CLEAN_OUT_OP);
+        if (optOpType.isEmpty()) {
+            return Set.of();
+        }
+        Set<Integer> labwareIds = labware.stream()
+                .map(Labware::getId)
+                .collect(toSet());
+        List<Operation> ops = opRepo.findAllByOperationTypeAndDestinationLabwareIdIn(optOpType.get(), labwareIds);
+        return ops.stream()
+                .flatMap(op -> op.getActions().stream())
+                .map(Action::getDestination)
+                .filter(slot -> labwareIds.contains(slot.getLabwareId()))
+                .collect(toSet());
+    }
+}

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1971,6 +1971,8 @@ type Query {
     labwareCosting(barcode: String!): SlideCosting
     """Look up the latest operation of some specified type whose destinations included a given labware barcode."""
     findLatestOp(barcode: String!, operationType: String!): Operation
+    """Get addresses of cleaned out slots in the specified labware.."""
+    cleanedOutAddresses(barcode: String!): [Address!]!
 
     """Get the history containing a given sample id."""
     historyForSampleId(sampleId: Int!): History!

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1860,6 +1860,16 @@ input SegmentationRequest {
     labware: [SegmentationLabware!]!
 }
 
+"""A request to remove samples from particular slots in labware."""
+input CleanOutRequest {
+    """The barcode of the labware."""
+    barcode: String!
+    """The addresses of the slots to clean out."""
+    addresses: [Address!]!
+    """The work number to link to the operation."""
+    workNumber: String!
+}
+
 """Info about the app version."""
 type VersionInfo {
     """The output of git describe."""
@@ -2186,6 +2196,8 @@ type Mutation {
     libraryPrep(request: LibraryPrepRequest!): OperationResult!
     """Record segmentation."""
     segmentation(request: SegmentationRequest!): OperationResult!
+    """Clean out a slot of a labware."""
+    cleanOut(request: CleanOutRequest!) : OperationResult!
 
     """Create a new user for the application."""
     addUser(username: String!): User!

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestCleanOutMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestCleanOutMutation.java
@@ -73,6 +73,8 @@ public class TestCleanOutMutation {
         assertThat(work.getOperationIds()).containsExactly(opId);
         assertThat(work.getSampleSlotIds()).containsExactlyInAnyOrder(new Work.SampleSlotId(samples[1].getId(), slotId),
                 new Work.SampleSlotId(samples[2].getId(), slotId));
+
+        checkCleanedOutQuery();
     }
 
     private static int checkResponse(Object response, Sample[] samples, int slotId) {
@@ -109,5 +111,11 @@ public class TestCleanOutMutation {
             assertEquals(action.getSample(), action.getSourceSample());
         }
         assertThat(op.getActions().stream().map(Action::getSample)).containsExactlyInAnyOrder(samples[1], samples[2]);
+    }
+
+    private void checkCleanedOutQuery() throws Exception {
+        Object response = tester.post(tester.readGraphQL("cleanedoutaddresses.graphql"));
+        List<String> addressData = chainGet(response, "data", "cleanedOutAddresses");
+        assertThat(addressData).containsExactly("A2");
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestCleanOutMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestCleanOutMutation.java
@@ -1,0 +1,113 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGetList;
+
+/**
+ * Tests the clean out mutation.
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestCleanOutMutation {
+    @Autowired
+    private GraphQLTester tester;
+    @Autowired
+    private EntityCreator entityCreator;
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private OperationRepo opRepo;
+
+    @Test
+    @Transactional
+    public void testCleanOut() throws Exception {
+        LabwareType lt = entityCreator.createLabwareType("lt", 1,2);
+        Tissue tissue = entityCreator.createTissue(null, "EXT1");
+        Sample[] samples = IntStream.rangeClosed(1,3)
+                .mapToObj(i -> entityCreator.createSample(tissue, i))
+                .toArray(Sample[]::new);
+        Labware lw = entityCreator.createLabware("STAN-A1", lt, new Sample[][] {
+                { samples[0], samples[1] },
+                { samples[1], samples[2] },
+        });
+        int slotId = lw.getSlot(new Address(1,2)).getId();
+        OperationType opType = entityCreator.createOpType("Clean out", null, OperationTypeFlag.IN_PLACE);
+        User user = entityCreator.createUser("user1");
+        Work work = entityCreator.createWork(null, null, null, null, null);
+        tester.setUser(user);
+
+        String mutation = tester.readGraphQL("cleanout.graphql").replace("[WORK]", work.getWorkNumber());
+
+        Object response = tester.post(mutation);
+
+        final int opId = checkResponse(response, samples, slotId);
+        entityManager.flush();
+        entityManager.refresh(lw);
+        checkOperation(opId, opType, slotId, samples);
+
+        assertThat(lw.getFirstSlot().getSamples()).containsExactlyInAnyOrder(samples[0], samples[1]);
+        assertThat(lw.getSlot(new Address(1,2)).getSamples()).isEmpty();
+        assertThat(work.getOperationIds()).containsExactly(opId);
+        assertThat(work.getSampleSlotIds()).containsExactlyInAnyOrder(new Work.SampleSlotId(samples[1].getId(), slotId),
+                new Work.SampleSlotId(samples[2].getId(), slotId));
+    }
+
+    private static int checkResponse(Object response, Sample[] samples, int slotId) {
+        Object data = chainGet(response, "data", "cleanOut");
+        assertThat(chainGetList(data, "labware")).hasSize(1);
+        assertThat(chainGetList(data, "operations")).hasSize(1);
+        List<?> actionsData = chainGet(data, "operations", 0, "actions");
+        assertThat(actionsData).hasSize(2);
+        assertThat(actionsData.stream().map(ac -> chainGet(ac, "sample", "id"))).containsExactlyInAnyOrder(
+                samples[1].getId(), samples[2].getId()
+        );
+        assertThat(actionsData.stream().map(ac -> chainGet(ac, "destination", "id"))).containsExactly(
+                slotId, slotId
+        );
+        List<Map<String,?>> slotsData = chainGet(data, "labware", 0, "slots");
+        assertThat(slotsData).hasSize(2);
+        assertThat(slotsData.stream().map(sd -> chainGet(sd, "address"))).containsExactly("A1", "A2");
+        assertThat(chainGetList(slotsData.get(0), "samples").stream().map(sam -> chainGet(sam, "id")))
+                .containsExactlyInAnyOrder(samples[0].getId(), samples[1].getId());
+        assertThat(chainGetList(slotsData.get(1), "samples")).isEmpty();
+
+        Integer opId = chainGet(data, "operations", 0, "id");
+        assertNotNull(opId);
+        return opId;
+    }
+
+    private void checkOperation(Integer opId, OperationType opType, Integer slotId, Sample[] samples) {
+        Operation op = opRepo.findById(opId).orElseThrow();
+        assertEquals(opType, op.getOperationType());
+        assertThat(op.getActions()).hasSize(2);
+        for (Action action : op.getActions()) {
+            assertEquals(action.getSource(), action.getDestination());
+            assertEquals(slotId, action.getDestination().getId());
+            assertEquals(action.getSample(), action.getSourceSample());
+        }
+        assertThat(op.getActions().stream().map(Action::getSample)).containsExactlyInAnyOrder(samples[1], samples[2]);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestCleanOutService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestCleanOutService.java
@@ -1,0 +1,258 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.SlotRepo;
+import uk.ac.sanger.sccp.stan.request.CleanOutRequest;
+import uk.ac.sanger.sccp.stan.request.OperationResult;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelper;
+import uk.ac.sanger.sccp.stan.service.validation.ValidationHelperFactory;
+import uk.ac.sanger.sccp.stan.service.work.WorkService;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.EntityFactory.objToList;
+import static uk.ac.sanger.sccp.stan.Matchers.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
+
+/** Test {@link CleanOutServiceImp} */
+class TestCleanOutService {
+    @Mock
+    private ValidationHelperFactory mockValFactory;
+    @Mock
+    private OperationService mockOpService;
+    @Mock
+    private WorkService mockWorkService;
+    @Mock
+    private SlotRepo mockSlotRepo;
+
+    @InjectMocks
+    private CleanOutServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    ValidationHelper setupVal() {
+        ValidationHelper val = mock(ValidationHelper.class);
+        Set<String> problems = new HashSet<>();
+        when(val.getProblems()).thenReturn(problems);
+        return val;
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={true, false})
+    void testPerform_noRequest(boolean hasUser) {
+        User user = hasUser ? EntityFactory.getUser() : null;
+        ValidationHelper val = setupVal();
+        when(mockValFactory.getHelper()).thenReturn(val);
+        List<String> expectedProblems = (hasUser ? List.of("No request supplied.") : List.of("No user supplied.", "No request supplied."));
+        assertValidationException(() -> service.perform(user, null), expectedProblems);
+        verify(val, never()).checkOpType(any(), any(OperationTypeFlag.class));
+        verify(service, never()).loadLabware(any(), any());
+        verify(service, never()).checkAddresses(any(), any(), any());
+        verify(service, never()).checkSlots(any(), any(), any());
+        verify(service, never()).record(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testPerform_invalid() {
+        User user = EntityFactory.getUser();
+        final ValidationHelper val = setupVal();
+        when(mockValFactory.getHelper()).thenReturn(val);
+        Labware lw = EntityFactory.getTube();
+        when(val.checkOpType(any(), any(OperationTypeFlag.class))).then(invocation -> {
+            val.getProblems().add("Bad op type.");
+            return null;
+        });
+        doAnswer(invocation -> {
+            ValidationHelper valArg = invocation.getArgument(0);
+            valArg.getProblems().add("Bad lw.");
+            return lw;
+        }).when(service).loadLabware(any(), any());
+        mayAddProblem("Bad work.", null).when(mockWorkService).validateUsableWork(any(), any());
+        mayAddProblem("Bad addresses.").when(service).checkAddresses(any(), any(), any());
+        Address A2 = new Address(1,2);
+        Address A3 = new Address(1,3);
+        List<Address> addresses = List.of(A2, A3);
+        CleanOutRequest request = new CleanOutRequest("STAN-1", addresses, "SGP1");
+
+        assertValidationException(() -> service.perform(user, request), List.of(
+                "Bad op type.", "Bad lw.", "Bad addresses.", "Bad work."
+        ));
+        verify(val).checkOpType("Clean out", OperationTypeFlag.IN_PLACE);
+        verify(mockWorkService).validateUsableWork(any(), eq("SGP1"));
+        verify(service).loadLabware(val, request.getBarcode());
+        verify(service).checkAddresses(any(), same(lw), eq(addresses));
+        verify(service, never()).record(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testPerform() {
+        User user = EntityFactory.getUser();
+        final ValidationHelper val = setupVal();
+        when(mockValFactory.getHelper()).thenReturn(val);
+        Labware lw = EntityFactory.getTube();
+        Address A2 = new Address(1,2), A3 = new Address(1,3);
+        List<Address> addresses = List.of(A2, A3);
+        Work work = EntityFactory.makeWork("SGP1");
+        CleanOutRequest request = new CleanOutRequest("STAN-1", addresses, work.getWorkNumber());
+        OperationType opType = EntityFactory.makeOperationType("Clean out", null, OperationTypeFlag.IN_PLACE);
+        doReturn(opType).when(val).checkOpType(any(), any(OperationTypeFlag.class));
+        doReturn(lw).when(service).loadLabware(any(), any());
+        doReturn(work).when(mockWorkService).validateUsableWork(any(), any());
+        doNothing().when(service).checkAddresses(any(), any(), any());
+        OperationResult opres = new OperationResult(List.of(), List.of(lw));
+        doReturn(opres).when(service).record(any(), any(), any(), any(), any());
+
+        assertSame(opres, service.perform(user, request));
+        verify(val).checkOpType("Clean out", OperationTypeFlag.IN_PLACE);
+        verify(service).loadLabware(val, "STAN-1");
+        verify(service).checkAddresses(any(), same(lw), eq(addresses));
+        verify(service).record(user, opType, work, lw, addresses);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false,true})
+    void testLoadLabware(boolean ok) {
+        ValidationHelper val = setupVal();
+        Labware lw = ok ? EntityFactory.getTube() : null;
+        String problem = ok ? null : "Bad lw.";
+        if (ok) {
+            when(val.checkLabware(any())).thenReturn(UCMap.from(Labware::getBarcode, lw));
+        } else {
+            when(val.checkLabware(any())).then(invocation -> {
+                val.getProblems().add(problem);
+                return new UCMap<>(0);
+            });
+        }
+        String bc = lw==null ? "STAN-1" : lw.getBarcode();
+        assertSame(lw, service.loadLabware(val, bc));
+        verify(val).checkLabware(List.of(bc));
+        assertProblem(val.getProblems(), problem);
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkAddressesArgs")
+    void testCheckAddresses(Labware lw, List<Address> addresses, Set<Address> expectedSlotChecks, List<String> expectedProblems) {
+        doNothing().when(service).checkSlots(any(), any(), any());
+        List<String> problems = new ArrayList<>(expectedProblems.size());
+        service.checkAddresses(problems, lw, addresses);
+        assertThat(problems).containsExactlyInAnyOrderElementsOf(expectedProblems);
+        if (nullOrEmpty(expectedSlotChecks)) {
+            verify(service, never()).checkSlots(any(), any(), any());
+        } else {
+            verify(service).checkSlots(same(problems), same(lw), eq(expectedSlotChecks));
+        }
+    }
+
+    static Stream<Arguments> checkAddressesArgs() {
+        Labware lw = EntityFactory.getTube();
+        Address A1 = new Address(1,1), A2 = new Address(1,2), A3 = new Address(1,3);
+        return Arrays.stream(new Object[][] {
+                {lw, List.of(A1, A3), Set.of(A1, A3), null},
+                {null, List.of(A1, A3), null, null},
+                {null, null, null, "No slot addresses supplied."},
+                {null, List.of(A1, A3, A1, A2, A3), null, "Repeated slot address: [A1, A3]"},
+                {null, Arrays.asList(A1, A2, null), null, "Null supplied as slot address."},
+                {lw, List.of(A1, A3, A3, A2), Set.of(A1, A2, A3), "Repeated slot address: [A3]"},
+                {lw, Arrays.asList(A1, null, A1), Set.of(A1), List.of("Null supplied as slot address.", "Repeated slot address: [A1]")},
+        }).map(arr -> {
+            arr[3] = objToList(arr[3]);
+            return Arguments.of(arr);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkSlotsArgs")
+    void testCheckSlots(Labware lw, Set<Address> addresses, List<String> expectedProblems) {
+        List<String> problems = new ArrayList<>(expectedProblems.size());
+        service.checkSlots(problems, lw, addresses);
+        assertThat(problems).containsExactlyInAnyOrderElementsOf(expectedProblems);
+    }
+
+    static Stream<Arguments> checkSlotsArgs() {
+        LabwareType lt = EntityFactory.makeLabwareType(2,2);
+        Sample sample = EntityFactory.getSample();
+        Labware lw = EntityFactory.makeLabware(lt, sample, null, sample, null);
+        lw.setBarcode("STAN-A1");
+        final Address A1 = new Address(1,1), A2 = new Address(1,2), A3 = new Address(1,3),
+                B1 = new Address(2,1), B2 = new Address(2,2), B3 = new Address(2,3);
+        return Arrays.stream(new Object[][] {
+                {A1, B1},
+                {A1, A2, B2, "Slot in labware STAN-A1 is empty: [A2, B2]"},
+                {A1, A3, B3, "No slot found in labware STAN-A1 at address: [A3, B3]"},
+                {A1, A2, A3, "Slot in labware STAN-A1 is empty: [A2]", "No slot found in labware STAN-A1 at address: [A3]"},
+        }).map(arr -> {
+            Set<Address> addresses = new LinkedHashSet<>();
+            List<String> problems = new ArrayList<>();
+            for (Object x : arr) {
+                if (x instanceof String) {
+                    problems.add((String) x);
+                } else {
+                    addresses.add((Address) x);
+                }
+            }
+            return Arguments.of(lw, addresses, problems);
+        });
+    }
+
+    @Test
+    void testRecord() {
+        LabwareType lt = EntityFactory.makeLabwareType(1,3);
+        Tissue tissue = EntityFactory.getTissue();
+        BioState bs = EntityFactory.getBioState();
+        List<Sample> samples = IntStream.range(0,3)
+                .mapToObj(i -> new Sample(10+i, 20+i, tissue, bs))
+                .toList();
+        Labware lw = EntityFactory.makeEmptyLabware(lt);
+        final Address A2 = new Address(1,2), A3 = new Address(1,3);
+        lw.getFirstSlot().setSamples(samples.subList(0,2));
+        lw.getSlot(A2).setSamples(samples.subList(1,3));
+        lw.getSlot(A3).setSamples(samples.subList(2,3));
+        Work work = EntityFactory.makeWork("SGP1");
+        Slot slot2 = lw.getSlot(A2);
+        Slot slot3 = lw.getSlot(A3);
+        List<Slot> slots = List.of(slot2, slot3);
+        User user = EntityFactory.getUser();
+        OperationType opType = EntityFactory.makeOperationType("Clean out", null, OperationTypeFlag.IN_PLACE);
+        Operation op = EntityFactory.makeOpForSlots(opType, List.of(slot2), slots, user);
+        when(mockOpService.createOperation(any(), any(), any(), any())).thenReturn(op);
+
+        OperationResult opres = service.record(user, opType, work, lw, List.of(A2, A3));
+        assertThat(opres.getOperations()).containsExactly(op);
+        assertThat(opres.getLabware()).containsExactly(lw);
+        List<Action> expectedActions = List.of(
+                new Action(null, null, slot2, slot2, samples.get(1), samples.get(1)),
+                new Action(null, null, slot2, slot2, samples.get(2), samples.get(2)),
+                new Action(null, null, slot3, slot3, samples.get(2), samples.get(2))
+        );
+        verify(mockOpService).createOperation(opType, user, expectedActions, null);
+        assertThat(lw.getFirstSlot().getSamples()).containsExactlyElementsOf(samples.subList(0,2));
+        assertThat(slot2.getSamples()).isEmpty();
+        assertThat(slot3.getSamples()).isEmpty();
+        verify(mockSlotRepo).saveAll(slots);
+        verify(mockWorkService).link(work, opres.getOperations());
+        verifyNoMoreInteractions(mockOpService);
+        verifyNoMoreInteractions(mockSlotRepo);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestCleanedOutSlotService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestCleanedOutSlotService.java
@@ -1,0 +1,78 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+import uk.ac.sanger.sccp.stan.repo.OperationTypeRepo;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/** Test {@link CleanedOutSlotServiceImp} */
+class TestCleanedOutSlotService {
+    @Mock
+    private OperationTypeRepo mockOpTypeRepo;
+    @Mock
+    private OperationRepo mockOpRepo;
+
+    @InjectMocks
+    private CleanedOutSlotServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @Test
+    void testFindCleanedOutSlots_noLw() {
+        assertThat(service.findCleanedOutSlots(null)).isEmpty();
+        assertThat(service.findCleanedOutSlots(List.of())).isEmpty();
+        verifyNoInteractions(mockOpTypeRepo);
+        verifyNoInteractions(mockOpRepo);
+    }
+
+    @Test
+    void testFindCleanedOutSlots_noOpType() {
+        when(mockOpTypeRepo.findByName(any())).thenReturn(Optional.empty());
+        assertThat(service.findCleanedOutSlots(List.of(EntityFactory.getTube()))).isEmpty();
+        verify(mockOpTypeRepo).findByName("Clean out");
+        verifyNoInteractions(mockOpRepo);
+    }
+
+    @Test
+    void testFindCleanedOutSlots() {
+        OperationType opType = EntityFactory.makeOperationType("Clean out", null, OperationTypeFlag.IN_PLACE);
+        when(mockOpTypeRepo.findByName("Clean out")).thenReturn(Optional.of(opType));
+        Sample sample = EntityFactory.getSample();
+        LabwareType lt = EntityFactory.makeLabwareType(1,2);
+        List<Labware> labware = IntStream.range(0, 3).mapToObj(i -> EntityFactory.makeLabware(lt, sample, sample)).toList();
+        final Address A1 = new Address(1,1), A2 = new Address(1,2);
+
+        List<Slot> op1slots = List.of(labware.get(0).getSlot(A1));
+        List<Slot> op2slots = List.of(labware.get(1).getSlot(A2));
+        List<Operation> ops = List.of(
+                EntityFactory.makeOpForSlots(opType, op1slots, op1slots, null),
+                EntityFactory.makeOpForSlots(opType, op2slots, op2slots, null)
+        );
+
+        when(mockOpRepo.findAllByOperationTypeAndDestinationLabwareIdIn(any(), any())).thenReturn(ops);
+
+        assertThat(service.findCleanedOutSlots(labware)).containsExactlyInAnyOrder(labware.get(0).getSlot(A1), labware.get(1).getSlot(A2));
+        Set<Integer> lwIds = labware.stream().map(Labware::getId).collect(toSet());
+        verify(mockOpRepo).findAllByOperationTypeAndDestinationLabwareIdIn(opType, lwIds);
+    }
+}

--- a/src/test/resources/graphql/cleanedoutaddresses.graphql
+++ b/src/test/resources/graphql/cleanedoutaddresses.graphql
@@ -1,0 +1,3 @@
+query {
+    cleanedOutAddresses(barcode: "STAN-A1")
+}

--- a/src/test/resources/graphql/cleanout.graphql
+++ b/src/test/resources/graphql/cleanout.graphql
@@ -1,0 +1,22 @@
+mutation {
+    cleanOut(request: {
+        barcode: "STAN-A1"
+        addresses: ["A2"]
+        workNumber: "[WORK]"
+    }) {
+        labware {
+            slots {
+                address
+                samples { id }
+            }
+        }
+        operations {
+            id
+            operationType { name }
+            actions {
+                destination { id }
+                sample { id }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Labware slots can be cleaned out, which removed the samples from them.
After they are cleaned out, they are blocked from receiving any new samples
(in SlotCopyService, which is responsible for the Transfer operation).
The query `cleanedOutAddresses` which tell you which slots in a specified
item of labware have been cleaned out.