### PR TITLE
From RT#801885 Fix possible transaction race condition

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Work.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Work.java
@@ -1,12 +1,9 @@
 package uk.ac.sanger.sccp.stan.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import uk.ac.sanger.sccp.utils.BasicUtils;
 
 import javax.persistence.*;
 import java.util.*;
-
-import static uk.ac.sanger.sccp.utils.BasicUtils.coalesce;
 
 /**
  * A work (identified by a work number) indicates a piece of requested work to be performed for some particular project and cost code
@@ -102,16 +99,16 @@ public class Work {
     @ElementCollection
     @CollectionTable(name="work_op", joinColumns=@JoinColumn(name="work_id"))
     @Column(name="operation_id")
-    private List<Integer> operationIds = List.of();
+    private Set<Integer> operationIds = new HashSet<>();
 
     @ElementCollection
     @CollectionTable(name="work_release", joinColumns=@JoinColumn(name="work_id"))
     @Column(name="release_id")
-    private List<Integer> releaseIds = List.of();
+    private Set<Integer> releaseIds = new HashSet<>();
 
     @ElementCollection
     @CollectionTable(name="work_sample", joinColumns=@JoinColumn(name="work_id"))
-    private List<SampleSlotId> sampleSlotIds = List.of();
+    private Set<SampleSlotId> sampleSlotIds = new HashSet<>();
 
     private Integer numBlocks, numSlides, numOriginalSamples;
 
@@ -210,30 +207,30 @@ public class Work {
     }
 
     /** The ids of operations linked to this work */
-    public List<Integer> getOperationIds() {
+    public Set<Integer> getOperationIds() {
         return this.operationIds;
     }
 
-    public void setOperationIds(List<Integer> operationIds) {
-        this.operationIds = (operationIds instanceof ArrayList ? operationIds : BasicUtils.newArrayList(operationIds));
+    public void setOperationIds(Set<Integer> operationIds) {
+        this.operationIds = operationIds==null ? new HashSet<>() : operationIds;
     }
 
     /** The ids of releases linked to this work */
-    public List<Integer> getReleaseIds() {
+    public Set<Integer> getReleaseIds() {
         return this.releaseIds;
     }
 
-    public void setReleaseIds(List<Integer> releaseIds) {
-        this.releaseIds = coalesce(releaseIds, List.of());
+    public void setReleaseIds(Set<Integer> releaseIds) {
+        this.releaseIds = releaseIds==null ? new HashSet<>() : releaseIds;
     }
 
     /** The ids of samples and slots that are in combination linked to this work */
-    public List<SampleSlotId> getSampleSlotIds() {
+    public Set<SampleSlotId> getSampleSlotIds() {
         return this.sampleSlotIds;
     }
 
-    public void setSampleSlotIds(List<SampleSlotId> sampleSlotIds) {
-        this.sampleSlotIds = (sampleSlotIds instanceof ArrayList ? sampleSlotIds : BasicUtils.newArrayList(sampleSlotIds));
+    public void setSampleSlotIds(Set<SampleSlotId> sampleSlotIds) {
+        this.sampleSlotIds = sampleSlotIds==null ? new HashSet<>() : sampleSlotIds;
     }
 
     public Integer getNumBlocks() {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/history/HistoryServiceImp.java
@@ -333,8 +333,8 @@ public class HistoryServiceImp implements HistoryService {
 
     public History getHistoryForWorkNumber(String workNumber, @NotNull EventTypeFilter etFilter) {
         Work work = workRepo.getByWorkNumber(workNumber);
-        List<Integer> opIds = etFilter.ops ? work.getOperationIds() : List.of();
-        List<Integer> releaseIds = etFilter.releases ? work.getReleaseIds() : List.of();
+        Set<Integer> opIds = etFilter.ops ? work.getOperationIds() : Set.of();
+        Set<Integer> releaseIds = etFilter.releases ? work.getReleaseIds() : Set.of();
         if (opIds.isEmpty() && releaseIds.isEmpty()) {
             return new History();
         }

--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -534,6 +534,40 @@ public class BasicUtils {
     }
 
     /**
+     * Creates a new empty hashset
+     * @return a new empty hashset
+     * @param <E> type of contents of the hashset
+     */
+    public static <E> HashSet<E> hashSetOf() {
+        return new HashSet<>();
+    }
+
+    /**
+     * Creates a new empty hashset initially containing one element
+     * @param element single initial contents
+     * @return a new hashset
+     * @param <E> type of contents of the hashset
+     */
+    public static <E> HashSet<E> hashSetOf(E element) {
+        HashSet<E> set = new HashSet<>();
+        set.add(element);
+        return set;
+    }
+
+    /**
+     * Creates a new hashset with the given inital contents
+     * @param elements initial contents
+     * @return a new hashset
+     * @param <E> type of contents of the hashset
+     */
+    @SafeVarargs
+    public static <E> HashSet<E> hashSetOf(E... elements) {
+        HashSet<E> set = new HashSet<>();
+        Collections.addAll(set, elements);
+        return set;
+    }
+
+    /**
      * Returns a stream of the given iterable
      * @param iterable an iterable
      * @return a stream

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestFindQuery.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestFindQuery.java
@@ -74,10 +74,10 @@ public class TestFindQuery {
         ReleaseRecipient workRequester = new ReleaseRecipient(1, "test1");
         Work work = entityCreator.createWork(workType, pr, null, cc,workRequester);
         List<String> workNumbers = List.of(work.getWorkNumber());
-        work.setSampleSlotIds(List.of(
-                new Work.SampleSlotId(samples[0].getId(), labware[0].getSlots().get(0).getId()),
-                new Work.SampleSlotId(samples[1].getId(), labware[1].getSlots().get(0).getId()),
-                new Work.SampleSlotId(samples[2].getId(), labware[2].getSlots().get(0).getId())
+        work.setSampleSlotIds(Set.of(
+                new Work.SampleSlotId(samples[0].getId(), labware[0].getSlots().getFirst().getId()),
+                new Work.SampleSlotId(samples[1].getId(), labware[1].getSlots().getFirst().getId()),
+                new Work.SampleSlotId(samples[2].getId(), labware[2].getSlots().getFirst().getId())
         ));
 
         Location[] locations = {

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestHistoryQuery.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestHistoryQuery.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGetList;
+import static uk.ac.sanger.sccp.utils.BasicUtils.hashSetOf;
 
 /**
  * Tests the history queries
@@ -117,7 +118,7 @@ public class TestHistoryQuery {
         Operation op = opRepo.save(new Operation(null, opType, null, null, user));
         actionRepo.save(new Action(null, op.getId(), slot, slot, sample, sample));
         entityManager.refresh(op);
-        work.setOperationIds(List.of(op.getId()));
+        work.setOperationIds(hashSetOf(op.getId()));
         workRepo.save(work);
 
         String baseQuery = tester.readGraphQL("history.graphql");

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLibraryPrepMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestLibraryPrepMutation.java
@@ -128,7 +128,7 @@ public class TestLibraryPrepMutation {
             verifyStorelightQuery(mockStorelightClient, List.of("unstoreBarcodes", sourceLw.getBarcode()), user.getUsername());
         }
         entityManager.refresh(work);
-        assertThat(work.getOperationIds()).containsExactlyElementsOf(Arrays.stream(opIds).boxed()::iterator);
+        assertThat(work.getOperationIds()).containsExactlyInAnyOrderElementsOf(Arrays.stream(opIds).boxed()::iterator);
     }
 
     @NotNull

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterMutation.java
@@ -71,14 +71,14 @@ public class TestRegisterMutation {
         entityManager.flush();
         entityManager.refresh(work);
         assertThat(work.getOperationIds()).hasSize(1);
-        Integer opId = work.getOperationIds().get(0);
+        Integer opId = work.getOperationIds().iterator().next();
         Operation op = opRepo.findById(opId).orElseThrow();
         assertEquals("Register", op.getOperationType().getName());
         Slot slot = lwRepo.getByBarcode(barcode).getFirstSlot();
         assertThat(work.getSampleSlotIds()).hasSize(1);
-        Work.SampleSlotId ss = work.getSampleSlotIds().get(0);
+        Work.SampleSlotId ss = work.getSampleSlotIds().iterator().next();
         assertEquals(slot.getId(), ss.getSlotId());
-        assertEquals(slot.getSamples().get(0).getId(), ss.getSampleId());
+        assertEquals(slot.getSamples().getFirst().getId(), ss.getSampleId());
     }
 
     @Test

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestSuggestedWorkForLabwareQuery.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestSuggestedWorkForLabwareQuery.java
@@ -13,7 +13,8 @@ import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
 
 import javax.transaction.Transactional;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
@@ -51,7 +52,7 @@ public class TestSuggestedWorkForLabwareQuery {
         Operation op = opRepo.save(new Operation(null, opType, null, null, entityCreator.createUser("user1")));
         Action ac = new Action(null, op.getId(), slot, slot, sample, sample);
         Work work = entityCreator.createWork(null, null, null, null, null);
-        work.setOperationIds(new ArrayList<>(List.of(op.getId())));
+        work.getOperationIds().add(op.getId());
         workRepo.save(work);
         actionRepo.save(ac);
         String query = tester.readGraphQL("suggestedwork.graphql");

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestTransactionSafety.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestTransactionSafety.java
@@ -1,0 +1,138 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.Transactor;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+
+import java.util.*;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests thread safety adding op ids to a work in two simultaneous transactions in separate threads
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import(EntityCreator.class)
+public class TestTransactionSafety {
+    @Autowired
+    private EntityCreator entityCreator;
+
+    @Autowired
+    private OperationRepo opRepo;
+    @Autowired
+    private OperationTypeRepo opTypeRepo;
+    @Autowired
+    private ProjectRepo projectRepo;
+    @Autowired
+    private ProgramRepo programRepo;
+    @Autowired
+    private WorkRepo workRepo;
+    @Autowired
+    private CostCodeRepo costCodeRepo;
+    @Autowired
+    private WorkTypeRepo workTypeRepo;
+    @Autowired
+    private UserRepo userRepo;
+
+    private Program newProgram;
+    private Operation[] ops;
+
+    @Autowired
+    private Transactor transactor;
+
+    private void setup() {
+        Optional<Work> optWork = workRepo.findByWorkNumber("SGPX");
+        if (optWork.isPresent()) {
+            Work work = optWork.get();
+            work.getOperationIds().clear();
+            workRepo.save(work);
+        } else {
+            WorkType workType = entityCreator.getAny(workTypeRepo);
+            Project project = entityCreator.getAny(projectRepo);
+            newProgram = entityCreator.createProgram("prog1");
+            CostCode costCode = entityCreator.getAny(costCodeRepo);
+            Work work = new Work(null, "SGPX", workType, null, project, newProgram, costCode, Work.Status.active);
+            workRepo.save(work);
+        }
+        OperationType opType = entityCreator.getAny(opTypeRepo);
+        User user = entityCreator.getAny(userRepo);
+        ops = new Operation[]{opRepo.save(new Operation(null, opType, null, List.of(), user)),
+                opRepo.save(new Operation(null, opType, null, List.of(), user))};
+    }
+
+    @Test
+    public void testWork() throws Exception {
+        try {
+            transact(this::setup);
+
+            TestThread thread1 = new TestThread(ops[0].getId());
+            TestThread thread2 = new TestThread(ops[1].getId());
+            thread1.start();
+            thread2.start();
+            thread1.join();
+            thread2.join();
+
+            transact(this::checkOpIds);
+        } finally {
+            transact(this::cleanup);
+        }
+    }
+
+    private void checkOpIds() {
+        Work work = workRepo.getByWorkNumber("SGPX");
+        assertThat(work.getOperationIds()).containsExactlyInAnyOrder(ops[0].getId(), ops[1].getId());
+    }
+
+    private void cleanup() {
+        Work work = workRepo.findByWorkNumber("SGPX").orElse(null);
+        if (work!=null) {
+            work.getOperationIds().clear();
+            workRepo.delete(work);
+        }
+        if (ops!=null) {
+            for (Operation op : ops) {
+                if (op!=null) {
+                    opRepo.delete(op);
+                }
+            }
+        }
+        if (newProgram!=null) {
+            programRepo.delete(newProgram);
+        }
+    }
+
+    class TestThread extends Thread {
+        private final int opId;
+        public TestThread(int opId) {
+            this.opId = opId;
+        }
+
+        @Override
+        public void run() {
+            transact(this::execute);
+        }
+
+        public void execute() {
+            Work work = workRepo.getByWorkNumber("SGPX");
+            Set<Integer> opIds = work.getOperationIds();
+            opIds.add(this.opId);
+            workRepo.save(work);
+        }
+    }
+
+    private void transact(final Runnable runnable) {
+        Supplier<Void> supplier = () -> { runnable.run(); return null; };
+        transactor.transact("transaction safety test", supplier);
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestWorkProgressQuery.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestWorkProgressQuery.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.IntFunction;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
@@ -109,7 +109,7 @@ public class TestWorkProgressQuery {
         releaseRepo.save(release);
 
         Work work = entityCreator.createWork(null, null, null, null, null);
-        work.setOperationIds(Arrays.stream(ops).map(Operation::getId).collect(toList()));
+        work.setOperationIds(Arrays.stream(ops).map(Operation::getId).collect(toSet()));
         work.setStatus(Work.Status.paused);
         work = workRepo.save(work);
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestWorkRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestWorkRepo.java
@@ -22,9 +22,11 @@ import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.hashSetOf;
 
 /**
  * Tests {@link WorkRepo}
@@ -199,16 +201,16 @@ public class TestWorkRepo {
         Program prog = entityCreator.createProgram("Hello");
         Work work = workRepo.save(new Work(null, "SGP123", workType, workRequester, project, prog, cc, Status.active));
         assertNotNull(work.getId());
-        List<Integer> opIds;
+        Set<Integer> opIds;
         if (problem==1) {
-            opIds = List.of(404);
+            opIds = hashSetOf(404);
         } else {
-            opIds = IntStream.range(0,2).mapToObj(i -> createOpId()).collect(toList());
+            opIds = IntStream.range(0,2).mapToObj(i -> createOpId()).collect(toCollection(HashSet::new));
         }
         work.setOperationIds(opIds);
         List<Integer> sampleIds = (problem==2 ? List.of(404, 405) : createSampleIds(2));
         List<Integer> slotIds = (problem==3 ? List.of(404, 405) : createSlotIds(2));
-        List<SampleSlotId> sampleSlotIds = List.of(
+        Set<SampleSlotId> sampleSlotIds = hashSetOf(
                 new SampleSlotId(sampleIds.get(0), slotIds.get(0)),
                 new SampleSlotId(sampleIds.get(0), slotIds.get(1)),
                 new SampleSlotId(sampleIds.get(1), slotIds.get(1))
@@ -259,11 +261,11 @@ public class TestWorkRepo {
         LabwareType lt = entityCreator.createLabwareType("lt", 1, 2);
         Labware lw1 = entityCreator.createLabware("STAN-A1", lt, sample, sample);
         Labware lw2 = entityCreator.createLabware("STAN-A2", lt, sample, sample);
-        work1.setSampleSlotIds(List.of(new SampleSlotId(sampleId, lw1.getSlot(A1).getId()),
+        work1.setSampleSlotIds(hashSetOf(new SampleSlotId(sampleId, lw1.getSlot(A1).getId()),
                 new SampleSlotId(sampleId, lw1.getSlot(A2).getId()),
                 new SampleSlotId(sampleId, lw2.getSlot(A1).getId())));
         workRepo.save(work1);
-        work2.setSampleSlotIds(List.of(new SampleSlotId(sampleId, lw2.getSlot(A2).getId())));
+        work2.setSampleSlotIds(hashSetOf(new SampleSlotId(sampleId, lw2.getSlot(A2).getId())));
         workRepo.save(work2);
 
         labwareIds = workRepo.findLabwareIdsForWorkIds(List.of(work1.getId(), -1));
@@ -300,8 +302,8 @@ public class TestWorkRepo {
         Work work1 = entityCreator.createWork(null, null, null, null, null);
         Work work2 = entityCreator.createWork(work1.getWorkType(), work1.getProject(), work1.getProgram(), work1.getCostCode(), work1.getWorkRequester());
 
-        work1.setSampleSlotIds(List.of(new Work.SampleSlotId(samples[0].getId(), labware[0].getSlots().get(0).getId())));
-        work2.setSampleSlotIds(List.of(
+        work1.setSampleSlotIds(Set.of(new Work.SampleSlotId(samples[0].getId(), labware[0].getSlots().get(0).getId())));
+        work2.setSampleSlotIds(Set.of(
                 new Work.SampleSlotId(samples[0].getId(), labware[0].getSlots().get(0).getId()),
                 new Work.SampleSlotId(samples[1].getId(), labware[1].getSlots().get(0).getId())
         ));
@@ -329,7 +331,7 @@ public class TestWorkRepo {
         Map<Integer, String> workMap = workRepo.findWorkNumbersForReleaseIds(ridList);
         assertNull(workMap.get(rids[0]));
         assertNull(workMap.get(rids[1]));
-        work1.setReleaseIds(ridList.subList(0,2));
+        work1.setReleaseIds(new HashSet<>(ridList.subList(0,2)));
         workRepo.saveAll(List.of(work1, work2));
         workMap = workRepo.findWorkNumbersForReleaseIds(ridList);
         assertEquals(wn1, workMap.get(rids[0]));
@@ -351,8 +353,8 @@ public class TestWorkRepo {
         for (int opId : opIds) {
             assertThat(workMap.get(opId)).isEmpty();
         }
-        work1.setOperationIds(List.of(opIds[0], opIds[1]));
-        work2.setOperationIds(List.of(opIds[1], opIds[2]));
+        work1.setOperationIds(hashSetOf(opIds[0], opIds[1]));
+        work2.setOperationIds(hashSetOf(opIds[1], opIds[2]));
         workRepo.saveAll(List.of(work1, work2));
 
         workMap = workRepo.findWorkNumbersForOpIds(List.of(opIds[3]));
@@ -379,9 +381,9 @@ public class TestWorkRepo {
         Work work3 = entityCreator.createWorkLike(work1);
 
         Operation[] ops = IntStream.rangeClosed(1,3).mapToObj(d -> saveOp(lw, day(d))).toArray(Operation[]::new);
-        work1.setOperationIds(List.of(ops[0].getId()));
-        work2.setOperationIds(List.of(ops[1].getId()));
-        work3.setOperationIds(List.of(ops[2].getId()));
+        work1.setOperationIds(hashSetOf(ops[0].getId()));
+        work2.setOperationIds(hashSetOf(ops[1].getId()));
+        work3.setOperationIds(hashSetOf(ops[2].getId()));
         if (!exists) {
             work1.setStatus(Status.completed);
             work2.setStatus(Status.failed);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestFindService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestFindService.java
@@ -346,9 +346,7 @@ public class TestFindService {
         WorkType workType = new WorkType(1, "worktype", true);
         ReleaseRecipient workRequester = new ReleaseRecipient(1, "test1");
         Work work = new Work(1, "SGP404", workType, workRequester, pr, null, cc, Work.Status.active);
-        work.setSampleSlotIds(List.of(
-                new Work.SampleSlotId(sample.getId(), lw.getSlots().getFirst().getId())
-        ));
+        work.getSampleSlotIds().add(new Work.SampleSlotId(sample.getId(), lw.getSlots().getFirst().getId()));
 
         when(mockWorkRepo.getByWorkNumber(work.getWorkNumber())).thenReturn(work);
         when(mockSlotRepo.findAllByIdIn(List.of(lw.getSlots().getFirst().getId()))).thenReturn(List.of(lw.getSlots().getFirst()));

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestWorkProgressService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestWorkProgressService.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -392,7 +393,7 @@ public class TestWorkProgressService {
         }
 
         when(mockStainTypeRepo.loadOperationStainTypes(any())).thenReturn(opStainTypes);
-        List<Integer> opIds = ops.stream().map(Operation::getId).collect(toList());
+        Set<Integer> opIds = ops.stream().map(Operation::getId).collect(toSet());
         Work work = workWithId(17);
         work.setOperationIds(opIds);
         when(mockOpRepo.findAllById(opIds)).thenReturn(ops);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/history/TestHistoryService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/history/TestHistoryService.java
@@ -186,9 +186,9 @@ public class TestHistoryService {
                 new Operation(20, null, null, null, null),
                 new Operation(21, null, null, null, null)
         );
-        final List<Integer> opIds = List.of(20, 21);
+        final Set<Integer> opIds = Set.of(20, 21);
         work.setOperationIds(opIds);
-        final List<Integer> releaseIds = List.of(30,31);
+        final Set<Integer> releaseIds = Set.of(30,31);
         Labware rlw1 = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType());
         Labware rlw2 = EntityFactory.makeEmptyLabware(EntityFactory.getTubeType());
         List<Release> releases = List.of(
@@ -244,7 +244,7 @@ public class TestHistoryService {
         String workNumber = "SGP1";
         Work work = EntityFactory.makeWork(workNumber);
         when(mockWorkRepo.getByWorkNumber(workNumber)).thenReturn(work);
-        work.setOperationIds(includeOps ? List.of(2, 3, 4) : List.of());
+        work.setOperationIds(includeOps ? Set.of(2, 3, 4) : Set.of());
         Set<Integer> opLwIds = includeOps ? Set.of(10,11) : Set.of();
         doReturn(opLwIds).when(service).labwareIdsFromOps(any());
         LabwareType lt = EntityFactory.getTubeType();
@@ -267,7 +267,7 @@ public class TestHistoryService {
         List<Labware> opLw = (includeOps ? List.of(new Labware(2, "STAN-2", lt, null)) : List.of());
         doReturn(opLw).when(mockLwRepo).findAllByIdIn(opLwIds);
 
-        work.setReleaseIds(includeReleases ? List.of(5,6,7) : List.of());
+        work.setReleaseIds(includeReleases ? Set.of(5,6,7) : Set.of());
         List<Release> releases;
         List<Labware> releaseLw;
         if (includeReleases) {
@@ -317,7 +317,7 @@ public class TestHistoryService {
     @Test
     public void testGetHistoryForWorkNumber_noOps() {
         Work work = new Work(10, "SGP10", null, null, null, null, null, Work.Status.active);
-        work.setOperationIds(List.of());
+        work.setOperationIds(Set.of());
         final String workNumber = "sgp10";
         when(mockWorkRepo.getByWorkNumber(workNumber)).thenReturn(work);
         History history = service.getHistoryForWorkNumber(workNumber);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/work/TestWorkService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/work/TestWorkService.java
@@ -26,6 +26,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.utils.BasicUtils.hashSetOf;
 import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
 
 /**
@@ -631,8 +632,8 @@ public class TestWorkService {
         Work work = new Work(50, "SGP5000", null, null, null, null, null, Status.active);
 
         when(mockWorkRepo.getByWorkNumber(work.getWorkNumber())).thenReturn(work);
-        work.setOperationIds(List.of(1,2,3));
-        work.setSampleSlotIds(List.of(new SampleSlotId(sam1.getId(), 2)));
+        work.setOperationIds(hashSetOf(1,2,3));
+        work.setSampleSlotIds(hashSetOf(new SampleSlotId(sam1.getId(), 2)));
 
         when(mockWorkRepo.save(any())).then(Matchers.returnArgument());
 
@@ -715,19 +716,19 @@ public class TestWorkService {
             w.setId(i);
             w.setWorkNumber("SGP"+i);
             w.setStatus(Status.active);
-            w.setOperationIds(i==51 ? List.of(existingOpId) : List.of());
-            w.setSampleSlotIds(i==51 ? List.of(existingSsid) : List.of());
+            w.setOperationIds(i==51 ? hashSetOf(existingOpId) : hashSetOf());
+            w.setSampleSlotIds(i==51 ? hashSetOf(existingSsid) : hashSetOf());
             return w;
         }).collect(toList());
         workService.link(works, List.of(op1, op2));
-        assertThat(works.get(0).getOperationIds()).containsExactly(existingOpId, 10, 11);
-        assertThat(works.get(1).getOperationIds()).containsExactly(10, 11);
-        assertThat(works.get(0).getSampleSlotIds()).containsExactly(
+        assertThat(works.get(0).getOperationIds()).containsExactlyInAnyOrder(existingOpId, 10, 11);
+        assertThat(works.get(1).getOperationIds()).containsExactlyInAnyOrder(10, 11);
+        assertThat(works.get(0).getSampleSlotIds()).containsExactlyInAnyOrder(
                 Stream.concat(Stream.of(existingSsid),
                         Stream.concat(opSsids(op1), opSsids(op2)))
                         .toArray(SampleSlotId[]::new)
         );
-        assertThat(works.get(1).getSampleSlotIds()).containsExactly(
+        assertThat(works.get(1).getSampleSlotIds()).containsExactlyInAnyOrder(
                 Stream.concat(opSsids(op1), opSsids(op2)).toArray(SampleSlotId[]::new)
         );
 
@@ -767,8 +768,8 @@ public class TestWorkService {
         Release rel2 = quickRelease(101, lw2);
         when(mockWorkRepo.save(any())).then(Matchers.returnArgument());
         Work work = quickWork(Status.active);
-        work.setReleaseIds(List.of(1));
-        work.setSampleSlotIds(List.of(new SampleSlotId(2,3)));
+        work.setReleaseIds(hashSetOf(1));
+        work.setSampleSlotIds(hashSetOf(new SampleSlotId(2,3)));
         assertSame(work, workService.linkReleases(work, List.of(rel1, rel2)));
         verify(mockWorkRepo).save(work);
         assertThat(work.getReleaseIds()).containsExactlyInAnyOrder(1, 100, 101);


### PR DESCRIPTION
What seems to have happened is that two requests were executed at nearly the same time (in separate transactions) and they tried to set the same work's operation-ids. The second overwrote the changes in the first. I believe that the way the code was written (in particular, loading the contents of the field into a new arraylist, modifying it, and then setting it back in the object) allowed this to happen (though I don't think it should).

To avoid this, don't read the list contents into a new list and then set it back; update it in place. To avoid dupes, change it to a set instead of a list. It makes more sense as a set anyway. Avoid using immutable collection objects so that we can always mutate the collections instead of overwriting them.
