### PR TITLE
x1192 Stain reagent types

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -79,6 +79,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final FlagLookupService flagLookupService;
     final MeasurementService measurementService;
     final GraphService graphService;
+    final CommentRepo commentRepo;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, UserRepo userRepo,
@@ -102,7 +103,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                LabwareService labwareService, FileStoreService fileStoreService,
                                SlotRegionService slotRegionService, RecentOpService recentOpService,
                                FlagLookupService flagLookupService, MeasurementService measurementService,
-                               GraphService graphService) {
+                               GraphService graphService, CommentRepo commentRepo) {
         super(objectMapper, authComp, userRepo);
         this.sessionConfig = sessionConfig;
         this.versionInfo = versionInfo;
@@ -147,6 +148,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.flagLookupService = flagLookupService;
         this.measurementService = measurementService;
         this.graphService = graphService;
+        this.commentRepo = commentRepo;
     }
 
     public DataFetcher<User> getUser() {
@@ -472,6 +474,10 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
 
     public DataFetcher<List<StainType>> getEnabledStainTypes() {
         return dfe -> stainService.getEnabledStainTypes();
+    }
+
+    public DataFetcher<List<Comment>> getStainReagentTypes() {
+        return dfe -> commentRepo.findAllByCategoryInAndEnabled(StainType.H_AND_E_MEASUREMENTS, true);
     }
 
     public DataFetcher<VisiumPermData> getVisiumPermData() {

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -102,6 +102,7 @@ public class GraphQLProvider {
                         .dataFetcher("worksSummary", graphQLDataFetchers.worksSummary())
                         .dataFetcher("listFiles", graphQLDataFetchers.listStanFiles())
                         .dataFetcher("stainTypes", graphQLDataFetchers.getEnabledStainTypes())
+                        .dataFetcher("stainReagentTypes", graphQLDataFetchers.getStainReagentTypes())
                         .dataFetcher("visiumPermData", graphQLDataFetchers.getVisiumPermData())
                         .dataFetcher("extractResult", graphQLDataFetchers.getExtractResult())
                         .dataFetcher("passFails", graphQLDataFetchers.getPassFails())

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/CommentRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/CommentRepo.java
@@ -11,6 +11,7 @@ import java.util.*;
  */
 public interface CommentRepo extends CrudRepository<Comment, Integer> {
     List<Comment> findAllByCategory(String category);
+    List<Comment> findAllByCategoryInAndEnabled(List<String> categories, boolean enabled);
     List<Comment> findAllByCategoryAndEnabled(String category, boolean enabled);
     Optional<Comment> findByCategoryAndText(String category, String text);
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/stain/StainRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/stain/StainRequest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static uk.ac.sanger.sccp.utils.BasicUtils.describe;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullToEmpty;
 
 /**
  * A request to perform a stain operation
@@ -12,15 +13,18 @@ import static uk.ac.sanger.sccp.utils.BasicUtils.describe;
 public class StainRequest {
     private String stainType;
     private List<String> barcodes;
-    private List<TimeMeasurement> timeMeasurements;
+    private List<TimeMeasurement> timeMeasurements = List.of();
     private String workNumber;
+    private List<Integer> commentIds = List.of();
 
     public StainRequest() {}
 
-    public StainRequest(String stainType, List<String> barcodes, List<TimeMeasurement> timeMeasurements) {
+    public StainRequest(String stainType, List<String> barcodes, List<TimeMeasurement> timeMeasurements,
+                        List<Integer> commentIds) {
         this.stainType = stainType;
         this.barcodes = barcodes;
-        this.timeMeasurements = timeMeasurements;
+        setTimeMeasurements(timeMeasurements);
+        setCommentIds(commentIds);
     }
 
     public String getStainType() {
@@ -44,7 +48,7 @@ public class StainRequest {
     }
 
     public void setTimeMeasurements(List<TimeMeasurement> timeMeasurements) {
-        this.timeMeasurements = timeMeasurements;
+        this.timeMeasurements = nullToEmpty(timeMeasurements);
     }
 
     public String getWorkNumber() {
@@ -55,6 +59,14 @@ public class StainRequest {
         this.workNumber = workNumber;
     }
 
+    public List<Integer> getCommentIds() {
+        return this.commentIds;
+    }
+
+    public void setCommentIds(List<Integer> commentIds) {
+        this.commentIds = nullToEmpty(commentIds);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -63,12 +75,14 @@ public class StainRequest {
         return (Objects.equals(this.stainType, that.stainType)
                 && Objects.equals(this.barcodes, that.barcodes)
                 && Objects.equals(this.timeMeasurements, that.timeMeasurements)
-                && Objects.equals(this.workNumber, that.workNumber));
+                && Objects.equals(this.workNumber, that.workNumber)
+                && Objects.equals(this.commentIds, that.commentIds)
+        );
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(stainType, barcodes, timeMeasurements, workNumber);
+        return Objects.hash(stainType, barcodes, timeMeasurements, workNumber, commentIds);
     }
 
     @Override
@@ -78,6 +92,7 @@ public class StainRequest {
                 .add("barcodes", barcodes)
                 .add("timeMeasurements", timeMeasurements)
                 .add("workNumber", workNumber)
+                .add("commentIds", commentIds)
                 .toString();
     }
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1173,6 +1173,8 @@ input StainRequest {
     timeMeasurements: [TimeMeasurement!]!
     """An optional work number to associate with this operation."""
     workNumber: String
+    """Comment ids indicating reagent types used in stain."""
+    commentIds: [Int!]
 }
 
 """The panel used with a stain."""

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1949,6 +1949,8 @@ type Query {
     planData(barcode: String!): PlanData!
     """Get the available stain types."""
     stainTypes: [StainType!]!
+    """Get the reagent types for H&E staining."""
+    stainReagentTypes: [Comment!]!
     """Event types."""
     eventTypes: [String!]!
     """Get an item of labware and the visium permeabilisation data recorded on it, if any."""


### PR DESCRIPTION
Allow stain request to specify stain reagent types for H&E stain.
These are represented by comments in the categories of the H&E stain names.