### PR TITLE
RT#804644: Use extra decoding step for work numbers in file controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>uk.ac.sanger.sccp</groupId>
 	<artifactId>stan</artifactId>
-	<version>2.43.2</version>
+	<version>2.43.3</version>
 	<name>stan</name>
 	<description>Spatial Genomics LIMS</description>
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/FileStoreController.java
@@ -16,8 +16,8 @@ import uk.ac.sanger.sccp.stan.model.StanFile;
 import uk.ac.sanger.sccp.stan.model.User;
 import uk.ac.sanger.sccp.stan.service.FileStoreService;
 
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.*;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.List;
 
@@ -55,6 +55,10 @@ public class FileStoreController {
     public ResponseEntity<?> receiveFile(@RequestParam("file") MultipartFile file,
                                          @RequestParam("workNumber") List<String> workNumbers) throws URISyntaxException {
         User user = checkUserForUpload();
+        final Charset cs = Charset.defaultCharset();
+        workNumbers = workNumbers.stream()
+                .map(s -> URLDecoder.decode(s, cs))
+                .toList();
         Collection<StanFile> sfs = asCollection(fileService.save(user, file, workNumbers));
         log.info("Saved files "+sfs);
         StanFile firstSf = sfs.iterator().next();


### PR DESCRIPTION
Due to some quirk between the client and the core, the work numbers in the URL parameter for storing a file are received in a URL- encoded state, which makes them not valid work numbers. Go through a step of decoding them to make sure that they are correctly formed.
