### PR TITLE
x1223: Save location names as well as addresses for release files

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/Release.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/Release.java
@@ -47,19 +47,19 @@ public class Release {
     private Integer snapshotId;
 
     private String locationBarcode;
-
+    private String locationName;
     private String storageAddress;
 
     public Release() {}
 
     public Release(Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient, Integer snapshotId) {
-        this(null, labware, user, destination, recipient, snapshotId, null, null, null, null);
+        this(null, labware, user, destination, recipient, snapshotId, null, null, null, null, null);
     }
     public Release(Integer id, Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient, Integer snapshotId, LocalDateTime released) {
-        this(id, labware, user, destination, recipient, snapshotId, released, null, null, null);
+        this(id, labware, user, destination, recipient, snapshotId, released, null, null, null, null);
     }
     public Release(Integer id, Labware labware, User user, ReleaseDestination destination, ReleaseRecipient recipient,
-                   Integer snapshotId, LocalDateTime released, String locationBarcode, String storageAddress,
+                   Integer snapshotId, LocalDateTime released, String locationBarcode, String locationName, String storageAddress,
                    List<ReleaseRecipient> otherRecipients) {
         this.id = id;
         this.labware = labware;
@@ -69,6 +69,7 @@ public class Release {
         this.released = released;
         this.snapshotId = snapshotId;
         this.locationBarcode = locationBarcode;
+        this.locationName = locationName;
         this.storageAddress = storageAddress;
         setOtherRecipients(otherRecipients);
     }
@@ -140,6 +141,14 @@ public class Release {
         this.locationBarcode = locationBarcode;
     }
 
+    public String getLocationName() {
+        return this.locationName;
+    }
+
+    public void setLocationName(String locationName) {
+        this.locationName = locationName;
+    }
+
     public String getStorageAddress() {
         return this.storageAddress;
     }
@@ -170,6 +179,7 @@ public class Release {
                 && Objects.equals(this.user, that.user)
                 && Objects.equals(this.snapshotId, that.snapshotId)
                 && Objects.equals(this.locationBarcode, that.locationBarcode)
+                && Objects.equals(this.locationName, that.locationName)
                 && Objects.equals(this.storageAddress, that.storageAddress)
                 && Objects.equals(this.otherRecipients, that.otherRecipients)
         );
@@ -192,6 +202,7 @@ public class Release {
                 .add("released", released)
                 .add("snapshotId", snapshotId)
                 .addReprIfNotNull("locationBarcode", locationBarcode)
+                .addReprIfNotNull("locationName", locationName)
                 .addIfNotNull("storageAddress", storageAddress)
                 .toString();
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/store/BasicLocation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/store/BasicLocation.java
@@ -4,23 +4,27 @@ import uk.ac.sanger.sccp.stan.model.Address;
 
 import java.util.Objects;
 
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
 /**
  * The location barcode and item address (if any) of an item in storage.
  * @author dr6
  */
 public class BasicLocation {
     private String barcode;
+    private String name;
     private Address address;
     private Integer addressIndex;
 
     public BasicLocation() {}
 
     public BasicLocation(String barcode, Address address) {
-        this(barcode, address, null);
+        this(barcode, null, address, null);
     }
 
-    public BasicLocation(String barcode, Address address, Integer addressIndex) {
+    public BasicLocation(String barcode, String name, Address address, Integer addressIndex) {
         this.barcode = barcode;
+        this.name = name;
         this.address = address;
         this.addressIndex = addressIndex;
     }
@@ -31,6 +35,14 @@ public class BasicLocation {
 
     public void setBarcode(String barcode) {
         this.barcode = barcode;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public Address getAddress() {
@@ -55,17 +67,18 @@ public class BasicLocation {
         if (o == null || getClass() != o.getClass()) return false;
         BasicLocation that = (BasicLocation) o;
         return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.name, that.name)
                 && Objects.equals(this.address, that.address)
                 && Objects.equals(this.addressIndex, that.addressIndex));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(barcode, address, addressIndex);
+        return Objects.hash(barcode, address);
     }
 
     @Override
     public String toString() {
-        return String.format("(%s:%s:%s)", barcode, address, addressIndex);
+        return String.format("(%s:%s:%s:%s)", barcode, repr(name), address, addressIndex);
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/ReleaseServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/ReleaseServiceImp.java
@@ -391,6 +391,7 @@ public class ReleaseServiceImp implements ReleaseService {
         final Release newRelease = new Release(labware, user, destination, recipient, snapshot.getId());
         if (location!=null) {
             newRelease.setLocationBarcode(location.getBarcode());
+            newRelease.setLocationName(location.getName());
             if (location.getAddressIndex()!=null) {
                 newRelease.setStorageAddress(location.getAddressIndex().toString());
             } else if (location.getAddress()!=null) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import static java.util.stream.Collectors.toList;
 
 public enum ReleaseColumn implements TsvColumn<ReleaseEntry> {
+    Released_from_box_name(ReleaseEntry::getLocationName),
     Released_from_box_location(ReleaseEntry::getStorageAddress),
     Released_labware_barcode(Compose.labware, Labware::getBarcode),
     Biological_state(Compose.sample, Sample::getBioState),

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
@@ -22,6 +22,7 @@ public class ReleaseEntry {
     private String sourceBarcode;
     private String sectionThickness;
     private Address sourceAddress;
+    private String locationName;
     private String storageAddress;
     private String stainType;
     private String bondBarcode;
@@ -54,14 +55,15 @@ public class ReleaseEntry {
     private String equipment;
 
     public ReleaseEntry(Labware labware, Slot slot, Sample sample) {
-        this(labware, slot, sample, null);
+        this(labware, slot, sample, null, null);
     }
 
-    public ReleaseEntry(Labware labware, Slot slot, Sample sample, String storageAddress) {
+    public ReleaseEntry(Labware labware, Slot slot, Sample sample, String storageAddress, String locationName) {
         this.labware = labware;
         this.slot = slot;
         this.sample = sample;
         this.storageAddress = storageAddress;
+        this.locationName = locationName;
     }
 
     public Labware getLabware() {
@@ -106,6 +108,14 @@ public class ReleaseEntry {
 
     public void setSourceAddress(Address sourceAddress) {
         this.sourceAddress = sourceAddress;
+    }
+
+    public String getLocationName() {
+        return this.locationName;
+    }
+
+    public void setLocationName(String locationName) {
+        this.locationName = locationName;
     }
 
     public String getStorageAddress() {
@@ -410,6 +420,7 @@ public class ReleaseEntry {
                 && Objects.equals(this.sourceBarcode, that.sourceBarcode)
                 && Objects.equals(this.sectionThickness, that.sectionThickness)
                 && Objects.equals(this.sourceAddress, that.sourceAddress)
+                && Objects.equals(this.locationName, that.locationName)
                 && Objects.equals(this.storageAddress, that.storageAddress)
                 && Objects.equals(this.stainType, that.stainType)
                 && Objects.equals(this.bondBarcode, that.bondBarcode)
@@ -463,6 +474,7 @@ public class ReleaseEntry {
                 .add("lastSection", lastSection)
                 .add("sourceBarcode", sourceBarcode)
                 .add("sectionThickness", sectionThickness)
+                .add("locationName", locationName)
                 .add("sourceAddress", sourceAddress)
                 .add("storageAddress", storageAddress)
                 .add("stainType", stainType)

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/store/StoreService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/store/StoreService.java
@@ -298,13 +298,14 @@ public class StoreService {
             if (locationBarcode==null) {
                 continue;
             }
+            String locationName = locationData.get("name").textValue();
             String addressString = sd.get("address").textValue();
             Address address = null;
             if (addressString!=null && !addressString.isEmpty()) {
                 address = Address.valueOf(addressString);
             }
             Integer addressIndex = integerFromNode(sd.get("addressIndex"));
-            map.put(itemBarcode, new BasicLocation(locationBarcode, address, addressIndex));
+            map.put(itemBarcode, new BasicLocation(locationBarcode, locationName, address, addressIndex));
         }
         return map;
     }

--- a/src/main/resources/db/changelog/changelog-2.45.xml
+++ b/src/main/resources/db/changelog/changelog-2.45.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="2.45.0" author="dr6">
+        <addColumn tableName="labware_release">
+            <column name="location_name" type="VARCHAR(64)" afterColumn="location_barcode">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -29,4 +29,5 @@
     <include relativeToChangelogFile="true" file="changelog-2.31.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.32.xml"/>
     <include relativeToChangelogFile="true" file="changelog-2.43.xml"/>
+    <include relativeToChangelogFile="true" file="changelog-2.45.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/storelight/storedBasicLocation.graphql
+++ b/src/main/resources/storelight/storedBasicLocation.graphql
@@ -3,6 +3,6 @@
         barcode
         address
         addressIndex
-        location { barcode }
+        location { barcode name }
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/IntegrationTestUtils.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/IntegrationTestUtils.java
@@ -101,7 +101,11 @@ public class IntegrationTestUtils {
                 ObjectNode node = objectMapper.createObjectNode()
                         .put("barcode", entry.getKey())
                         .put("address", loc.getAddress()!=null ? loc.getAddress().toString() : null)
-                        .set("location", objectMapper.createObjectNode().put("barcode", loc.getBarcode()));
+                        .put("addressIndex", loc.getAddressIndex()!=null ? loc.getAddressIndex().toString() : null)
+                        .set("location", objectMapper.createObjectNode()
+                                .put("barcode", loc.getBarcode())
+                                .put("name", loc.getName())
+                        );
                 itemArrayNode.add(node);
             }
             storelightDataNode = objectMapper.createObjectNode().set("stored", itemArrayNode);

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestReleaseMutation.java
@@ -109,8 +109,8 @@ public class TestReleaseMutation {
 
         stubStorelightUnstore(mockStorelightClient);
         UCMap<BasicLocation> basicLocationMap = new UCMap<>(2);
-        basicLocationMap.put("STAN-001", new BasicLocation("STO-1", new Address(1,2)));
-        basicLocationMap.put("STAN-002", new BasicLocation("STO-1", new Address(3,4)));
+        basicLocationMap.put("STAN-001", new BasicLocation("STO-1", "Box 1", new Address(1,2), 4));
+        basicLocationMap.put("STAN-002", new BasicLocation("STO-1", "Box 1", new Address(3,4), null));
         stubStorelightBasicLocation(mockStorelightClient, basicLocationMap);
 
         Object result = tester.post(mutation);
@@ -155,7 +155,11 @@ public class TestReleaseMutation {
         assertMapValue(row0, ReleaseColumn.Released_labware_barcode, block.getBarcode());
         assertMapValue(row0, ReleaseColumn.Labware_type, block.getLabwareType().getName());
         assertMapValue(row0, ReleaseColumn.Last_section_number, "6");
-        assertMapValue(row0, ReleaseColumn.Released_from_box_location, "A2");
+        assertMapValue(row0, ReleaseColumn.Released_from_box_name, "Box 1");
+        assertMapValue(row0, ReleaseColumn.Released_from_box_location, "4");
+        var row1 = tsvMaps.get(1);
+        assertMapValue(row1, ReleaseColumn.Released_from_box_name, "Box 1");
+        assertMapValue(row1, ReleaseColumn.Released_from_box_location, "C4");
         String bsName = sample.getBioState().getName();
         for (int i = 1; i < 4; ++i) {
             var row = tsvMaps.get(i);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestReleaseService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestReleaseService.java
@@ -216,8 +216,7 @@ public class TestReleaseService {
                                         Object repoResult,
                                         boolean anyRepeats,
                                         String expectedError) {
-        if (repoResult instanceof Exception) {
-            Exception dbException = (Exception) repoResult;
+        if (repoResult instanceof Exception dbException) {
             when(mockRecipientRepo.getAllByUsernameIn(any())).thenThrow(dbException);
             assertSame(dbException, assertThrows(Exception.class, () -> service.loadOtherRecipients(usernames)));
             verify(mockRecipientRepo).getAllByUsernameIn(usernames);
@@ -542,16 +541,16 @@ public class TestReleaseService {
         lw.getSlots().get(0).getSamples().add(sample1);
         lw.getSlots().get(1).getSamples().add(sample1);
         BasicLocation loc;
+        String expectedName = locBarcode==null ? null : "Name "+locBarcode;
         if (locBarcode==null) {
             loc = null;
         } else {
-            loc = new BasicLocation(locBarcode, address);
-            loc.setAddressIndex(addressIndex);
+            loc = new BasicLocation(locBarcode, expectedName, address, addressIndex);
         }
 
         final int releaseId = 10;
         Release release = new Release(releaseId, lw, user, destination, recipient, 1, LocalDateTime.now(),
-                locBarcode, expectedAddressDesc, otherRecs);
+                locBarcode, expectedName, expectedAddressDesc, otherRecs);
 
         when(mockReleaseRepo.save(any())).thenReturn(release);
 
@@ -564,6 +563,7 @@ public class TestReleaseService {
         final Release expectedNewRelease = new Release(lw, user, destination, recipient, snap.getId());
         if (loc!=null) {
             expectedNewRelease.setLocationBarcode(loc.getBarcode());
+            expectedNewRelease.setLocationName(loc.getName());
             expectedNewRelease.setStorageAddress(expectedAddressDesc);
         }
         expectedNewRelease.setOtherRecipients(otherRecs);


### PR DESCRIPTION
When any released labware has a storage address,
also include the location name. If the location name isn't
sufficient to identify the location, append the location barcode.

For #424