### PR TITLE
x1219: run names for xenium qc

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -18,6 +18,7 @@ import uk.ac.sanger.sccp.stan.service.flag.FlagLookupService;
 import uk.ac.sanger.sccp.stan.service.graph.GraphService;
 import uk.ac.sanger.sccp.stan.service.history.HistoryService;
 import uk.ac.sanger.sccp.stan.service.label.print.LabelPrintService;
+import uk.ac.sanger.sccp.stan.service.operation.AnalyserServiceImp;
 import uk.ac.sanger.sccp.stan.service.operation.RecentOpService;
 import uk.ac.sanger.sccp.stan.service.operation.plan.PlanService;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
@@ -83,6 +84,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final GraphService graphService;
     final CommentRepo commentRepo;
     final AnalyserScanDataService analyserScanDataService;
+    final LabwareNoteService lwNoteService;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, UserRepo userRepo,
@@ -108,7 +110,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                CleanedOutSlotService cleanedOutSlotService,
                                FlagLookupService flagLookupService, MeasurementService measurementService,
                                GraphService graphService, CommentRepo commentRepo,
-                               AnalyserScanDataService analyserScanDataService) {
+                               AnalyserScanDataService analyserScanDataService, LabwareNoteService lwNoteService) {
         super(objectMapper, authComp, userRepo);
         this.sessionConfig = sessionConfig;
         this.versionInfo = versionInfo;
@@ -157,6 +159,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.graphService = graphService;
         this.commentRepo = commentRepo;
         this.analyserScanDataService = analyserScanDataService;
+        this.lwNoteService = lwNoteService;
     }
 
     public DataFetcher<User> getUser() {
@@ -487,6 +490,13 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         return dfe -> {
             String barcode = dfe.getArgument("barcode");
             return analyserScanDataService.load(barcode);
+        };
+    }
+
+    public DataFetcher<Set<String>> runNames() {
+        return dfe -> {
+            String barcode = dfe.getArgument("barcode");
+            return lwNoteService.findNoteValuesForBarcode(barcode, AnalyserServiceImp.RUN_NAME);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -131,6 +131,7 @@ public class GraphQLProvider {
                         .dataFetcher("eventTypes", graphQLDataFetchers.eventTypes())
                         .dataFetcher("workProgress", graphQLDataFetchers.workProgress())
                         .dataFetcher("analyserScanData", graphQLDataFetchers.analyserScanData())
+                        .dataFetcher("runNames", graphQLDataFetchers.runNames())
 
                         .dataFetcher("location", graphQLStore.getLocation())
                         .dataFetcher("stored", graphQLStore.getStored())

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/QCLabwareRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/QCLabwareRequest.java
@@ -22,6 +22,7 @@ public class QCLabwareRequest {
      */
     public static class QCLabware {
         private String barcode;
+        private String runName;
         private String workNumber;
         private LocalDateTime completion;
         private List<Integer> comments = List.of();
@@ -29,9 +30,10 @@ public class QCLabwareRequest {
 
         public QCLabware() {}
 
-        public QCLabware(String barcode, String workNumber, LocalDateTime completion, List<Integer> comments,
-                         List<QCSampleComment> sampleComments) {
+        public QCLabware(String barcode, String runName, String workNumber, LocalDateTime completion,
+                         List<Integer> comments, List<QCSampleComment> sampleComments) {
             setBarcode(barcode);
+            setRunName(runName);
             setWorkNumber(workNumber);
             setCompletion(completion);
             setComments(comments);
@@ -47,6 +49,15 @@ public class QCLabwareRequest {
 
         public void setBarcode(String barcode) {
             this.barcode = barcode;
+        }
+
+        /** The run name to link the operation with */
+        public String getRunName() {
+            return this.runName;
+        }
+
+        public void setRunName(String runName) {
+            this.runName = runName;
         }
 
         /**
@@ -93,7 +104,7 @@ public class QCLabwareRequest {
 
         @Override
         public String toString() {
-            return String.format("(%s, %s, %s, %s, %s)", repr(barcode), repr(workNumber), completion, comments, sampleComments);
+            return String.format("(%s, %s, %s, %s, %s, %s)", repr(barcode), repr(runName), repr(workNumber), completion, comments, sampleComments);
         }
 
         @Override
@@ -102,6 +113,7 @@ public class QCLabwareRequest {
             if (o == null || getClass() != o.getClass()) return false;
             QCLabware that = (QCLabware) o;
             return (Objects.equals(this.barcode, that.barcode)
+                    && Objects.equals(this.runName, that.runName)
                     && Objects.equals(this.workNumber, that.workNumber)
                     && Objects.equals(this.completion, that.completion)
                     && Objects.equals(this.comments, that.comments)

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteService.java
@@ -1,0 +1,39 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.*;
+
+/**
+ * Service helping with {@link uk.ac.sanger.sccp.stan.model.LabwareNote labware notes}
+ */
+public interface LabwareNoteService {
+    /**
+     * Gets the distinct values of notes for a specific labware and note name
+     * @param barcode the barcode of the labware
+     * @param name the name of the note
+     * @return the distinct values of matching notes
+     * @exception EntityNotFoundException no such labware is found
+     */
+    Set<String> findNoteValuesForBarcode(String barcode, String name) throws EntityNotFoundException;
+
+    /**
+     * Gets the values of notes for multiple labware and one note name
+     * @param labware the labware
+     * @param name the name of the note
+     * @return a map from the barcodes to the note values
+     */
+    UCMap<Set<String>> findNoteValuesForLabware(Collection<Labware> labware, String name);
+
+    /**
+     * Records specified notes
+     * @param name the name of the notes
+     * @param lwMap map to look up labware by barcode
+     * @param opMap map to look up operation by labware barcode
+     * @param values of labware barcode to note value
+     * @return the created notes
+     */
+    Iterable<LabwareNote> createNotes(String name, UCMap<Labware> lwMap, UCMap<Operation> opMap, UCMap<String> values);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteServiceImp.java
@@ -1,0 +1,71 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareNoteRepo;
+import uk.ac.sanger.sccp.stan.repo.LabwareRepo;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.*;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.inMap;
+import static uk.ac.sanger.sccp.utils.BasicUtils.toLinkedHashSet;
+
+/**
+ * @author dr6
+ */
+@Service
+public class LabwareNoteServiceImp implements LabwareNoteService {
+    private final LabwareRepo lwRepo;
+    private final LabwareNoteRepo lwNoteRepo;
+
+    @Autowired
+    public LabwareNoteServiceImp(LabwareRepo lwRepo, LabwareNoteRepo lwNoteRepo) {
+        this.lwRepo = lwRepo;
+        this.lwNoteRepo = lwNoteRepo;
+    }
+
+    @Override
+    public Set<String> findNoteValuesForBarcode(String barcode, String name) throws EntityNotFoundException {
+        Labware lw = lwRepo.getByBarcode(barcode);
+        return lwNoteRepo.findAllByLabwareIdInAndName(List.of(lw.getId()), name).stream()
+                .map(LabwareNote::getValue)
+                .collect(toLinkedHashSet());
+    }
+
+    @Override
+    public UCMap<Set<String>> findNoteValuesForLabware(Collection<Labware> labware, String name) {
+        if (labware.isEmpty()) {
+            return new UCMap<>(0);
+        }
+        Map<Integer, Labware> idToLw = labware.stream().distinct().collect(inMap(Labware::getId));
+        UCMap<Set<String>> bcNotes = new UCMap<>(labware.size());
+        lwNoteRepo.findAllByLabwareIdInAndName(idToLw.keySet(), name).stream()
+                .distinct()
+                .forEach(note -> bcNotes.computeIfAbsent(
+                        idToLw.get(note.getLabwareId()).getBarcode(), k -> new HashSet<>()
+                ).add(note.getValue()));
+        return bcNotes;
+    }
+
+    @Override
+    public Iterable<LabwareNote> createNotes(String name, UCMap<Labware> lwMap, UCMap<Operation> opMap, UCMap<String> values) {
+        List<LabwareNote> notes = new ArrayList<>(values.size());
+        for (var entry : values.entrySet()) {
+            if (entry.getValue()==null) {
+                continue;
+            }
+            String bc = entry.getKey();
+            Labware lw = lwMap.get(bc);
+            Operation op = opMap.get(bc);
+            LabwareNote note = new LabwareNote(null, lw.getId(), op.getId(), name, entry.getValue());
+            notes.add(note);
+        }
+        if (notes.isEmpty()) {
+            return List.of();
+        }
+        return lwNoteRepo.saveAll(notes);
+    }
+}

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1842,6 +1842,8 @@ input QCSampleComment {
 input QCLabware {
     """The barcode of the labware."""
     barcode: String!
+    """The run-name to record."""
+    runName: String
     """The work number to link to the operation."""
     workNumber: String!
     """The time at which the process was completed."""
@@ -2086,6 +2088,8 @@ type Query {
     rois(barcodes: [String!]!): [LabwareRoi!]!
     """Data shown when scanning in labware for analyser op."""
     analyserScanData(barcode: String!): AnalyserScanData!
+    """Run names recorded for the specified labware."""
+    runNames(barcode: String!): [String!]!
 
     """Get the specified storage location."""
     location(locationBarcode: String!): Location!

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestProbeOperationMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestProbeOperationMutation.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGetList;
 import static uk.ac.sanger.sccp.utils.BasicUtils.stream;
 
 /**
@@ -148,6 +149,9 @@ public class TestProbeOperationMutation {
         Operation op = opRepo.findById(opId).orElseThrow();
         assertEquals(op.getEquipment(), equipment);
 
+        String runNamesQuery = String.format("query { runNames(barcode: \"%s\") }", lw.getBarcode());
+        Object queryResult = tester.post(runNamesQuery);
+        assertThat(chainGetList(queryResult, "data", "runNames")).containsExactly("RUN1");
     }
 
     private void testSampleMetrics(Labware lw, Work work) throws Exception {

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestLabwareNoteService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestLabwareNoteService.java
@@ -1,0 +1,118 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareNoteRepo;
+import uk.ac.sanger.sccp.stan.repo.LabwareRepo;
+import uk.ac.sanger.sccp.utils.UCMap;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.sameElements;
+
+/** Test {@link LabwareNoteServiceImp} */
+class TestLabwareNoteService {
+    @Mock
+    LabwareRepo mockLwRepo;
+    @Mock
+    LabwareNoteRepo mockLwNoteRepo;
+
+    @InjectMocks
+    LabwareNoteServiceImp service;
+
+    AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @Test
+    void testFindNoteValuesForBarcode() {
+        Labware lw = EntityFactory.getTube();
+        String bc = lw.getBarcode();
+        String name = "Bananas";
+        List<LabwareNote> notes = List.of(
+                new LabwareNote(1, lw.getId(), 11, name, "val1"),
+                new LabwareNote(2, lw.getId(), 12, name, "val2"),
+                new LabwareNote(3, lw.getId(), 13, name, "val1")
+        );
+        when(mockLwRepo.getByBarcode(bc)).thenReturn(lw);
+        when(mockLwNoteRepo.findAllByLabwareIdInAndName(List.of(lw.getId()), name)).thenReturn(notes);
+
+        assertThat(service.findNoteValuesForBarcode(bc, name)).containsExactly("val1", "val2");
+    }
+
+    @Test
+    void testFindNoteValueForLabware_none() {
+        assertThat(service.findNoteValuesForLabware(List.of(), "Bananas")).isEmpty();
+        verifyNoInteractions(mockLwNoteRepo);
+    }
+
+    @Test
+    void testFindNoteValuesForLabware() {
+        LabwareType lt = EntityFactory.getTubeType();
+        List<Labware> lws = IntStream.range(0,3).mapToObj(i -> EntityFactory.makeEmptyLabware(lt)).toList();
+        Labware lw0 = lws.get(0);
+        Labware lw1 = lws.get(1);
+        Labware lw2 = lws.get(2);
+        Set<Integer> lwIds = lws.stream().map(Labware::getId).collect(toSet());
+        String name = "Bananas";
+
+        List<LabwareNote> notes = List.of(
+                new LabwareNote(1, lw0.getId(), 11, name, "val1"),
+                new LabwareNote(2, lw0.getId(), 12, name, "val2"),
+                new LabwareNote(3, lw0.getId(), 13, name, "val1"),
+                new LabwareNote(4, lw1.getId(), 14, name, "val1")
+        );
+        when(mockLwNoteRepo.findAllByLabwareIdInAndName(lwIds, name)).thenReturn(notes);
+
+        var map = service.findNoteValuesForLabware(lws, name);
+        assertThat(map.get(lw0.getBarcode())).containsExactlyInAnyOrder("val1", "val2");
+        assertThat(map.get(lw1.getBarcode())).containsExactly("val1");
+        assertThat(map.get(lw2.getBarcode())).isNullOrEmpty();
+    }
+
+    @Test
+    void testCreateNotes() {
+        String name = "Bananas";
+        LabwareType lt = EntityFactory.getTubeType();
+        Labware[] lws = IntStream.range(0,3).mapToObj(i -> EntityFactory.makeEmptyLabware(lt)).toArray(Labware[]::new);
+        UCMap<Labware> lwMap = UCMap.from(Labware::getBarcode, lws);
+        Operation[] ops = IntStream.range(10,13).mapToObj(i -> {
+            Operation op = new Operation();
+            op.setId(i);
+            return op;
+        }).toArray(Operation[]::new);
+        UCMap<Operation> opMap = new UCMap<>(3);
+        IntStream.range(0, lws.length).forEach(i -> opMap.put(lws[i].getBarcode(), ops[i]));
+        UCMap<String> valueMap = new UCMap<>(2);
+        valueMap.put(lws[0].getBarcode(), "val0");
+        valueMap.put(lws[1].getBarcode(), "val1");
+
+        service.createNotes(name, lwMap, opMap, valueMap);
+
+        verify(mockLwNoteRepo).saveAll(sameElements(IntStream.range(0,2).mapToObj(
+                i -> new LabwareNote(null, lws[i].getId(), ops[i].getId(), name, "val"+i)).toList(),
+                true
+        ));
+    }
+
+    @Test
+    void testCreateNotes_none() {
+        service.createNotes("Bananas", new UCMap<>(), new UCMap<>(), new UCMap<>());
+        verifyNoInteractions(mockLwNoteRepo);
+    }
+}


### PR DESCRIPTION
Support run name parameter for qc request.
Support query to get run names for labware barcode.

For #426

See also [x1219_xenium_qc_run.sql](https://github.com/sanger/stan-sql/blob/devel/views/x1219_xenium_qc_run.sql)