### PR TITLE
x1231 Remove restriction on releasing cDNA and normal samples together

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
@@ -115,20 +115,20 @@ public enum ReleaseColumn implements TsvColumn<ReleaseEntry> {
         return this.name().replace('_',' ');
     }
 
-    public static List<ReleaseColumn> forModeAndOptions(ReleaseFileMode mode, @NotNull Collection<ReleaseFileOption> options) {
-        return Arrays.stream(values()).filter(rc -> rc.include(mode, options)).collect(toList());
+    public static List<ReleaseColumn> forModesAndOptions(@NotNull Collection<ReleaseFileMode> modes, @NotNull Collection<ReleaseFileOption> options) {
+        return Arrays.stream(values()).filter(rc -> rc.include(modes, options)).collect(toList());
     }
 
-    public boolean modeFilter(ReleaseFileMode mode) {
-        return (this.mode==null || this.mode==mode);
+    public boolean modeFilter(Collection<ReleaseFileMode> modes) {
+        return (this.mode==null || modes.contains(this.mode));
     }
 
     public boolean optionFilter(@NotNull Collection<ReleaseFileOption> selectedOptions) {
         return (this.options==null || selectedOptions.stream().anyMatch(this.options::contains));
     }
 
-    public boolean include(ReleaseFileMode mode, @NotNull Collection<ReleaseFileOption> selectedOptions) {
-        return this.modeFilter(mode) && this.optionFilter(selectedOptions);
+    public boolean include(Collection<ReleaseFileMode> modes, @NotNull Collection<ReleaseFileOption> selectedOptions) {
+        return this.modeFilter(modes) && this.optionFilter(selectedOptions);
     }
 
     private static class Compose {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileContent.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseFileContent.java
@@ -8,18 +8,18 @@ import java.util.*;
  * @author dr6
  */
 public class ReleaseFileContent {
-    private final ReleaseFileMode mode;
+    private final Set<ReleaseFileMode> modes;
     private final List<ReleaseEntry> entries;
     private final Set<ReleaseFileOption> options;
 
-    public ReleaseFileContent(ReleaseFileMode mode, List<ReleaseEntry> entries, Set<ReleaseFileOption> options) {
-        this.mode = mode;
+    public ReleaseFileContent(Set<ReleaseFileMode> modes, List<ReleaseEntry> entries, Set<ReleaseFileOption> options) {
+        this.modes = modes==null ? Set.of() : modes;
         this.entries = entries;
         this.options = options;
     }
 
-    public ReleaseFileMode getMode() {
-        return this.mode;
+    public Set<ReleaseFileMode> getModes() {
+        return this.modes;
     }
 
     public List<ReleaseEntry> getEntries() {
@@ -35,7 +35,7 @@ public class ReleaseFileContent {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ReleaseFileContent that = (ReleaseFileContent) o;
-        return (this.mode == that.mode
+        return (this.modes.equals(that.modes)
                 && Objects.equals(this.entries, that.entries)
                 && Objects.equals(this.options, that.options)
         );
@@ -43,6 +43,6 @@ public class ReleaseFileContent {
 
     @Override
     public int hashCode() {
-        return Objects.hash(mode, entries, options);
+        return Objects.hash(modes, entries, options);
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -225,6 +225,16 @@ public class BasicUtils {
     }
 
     /**
+     * Collector of enums into an enumset
+     * @param cls the class of the enum
+     * @return a collector
+     * @param <E> the type of enum
+     */
+    public static <E extends Enum<E>> Collector<E, ?, EnumSet<E>> toEnumSet(Class<E> cls) {
+        return Collectors.toCollection(() -> EnumSet.noneOf(cls));
+    }
+
+    /**
      * Collector to a map where the values are the input objects
      * @param keyMapper a mapping function to produce keys
      * @param mapFactory a supplier providing a new empty {@code Map}


### PR DESCRIPTION
Where we previously restricted releases and release files to one ReleaseFileMode
(cDNA or normal), we now allow multiple modes. Release file data is filled in
based on whether each given sample is cDNA or normal, rather than using
one mode for the whole file.