### PR TITLE
x1240: accept "lp number" in slot copy request

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/request/SlotCopyRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/SlotCopyRequest.java
@@ -36,7 +36,7 @@ public class SlotCopyRequest {
     public SlotCopyRequest(String operationType, String labwareTypeName, List<SlotCopyContent> contents, String workNumber,
                            String preBarcode) {
         this(operationType, workNumber, null, null, List.of(new SlotCopyDestination(labwareTypeName, preBarcode,
-                null, null, null, contents, null)));
+                null, null, null, contents, null, null)));
     }
 
     public void setOperationType(String operationType) {
@@ -169,20 +169,23 @@ public class SlotCopyRequest {
         private String lotNumber;
         private String probeLotNumber;
         private String preBarcode;
+        private String lpNumber;
         private List<SlotCopyContent> contents;
 
         public SlotCopyDestination() {
-            this(null, null, null, null, null, null, null);
+            this(null, null, null, null, null, null, null, null);
         }
 
         public SlotCopyDestination(String labwareTypeName, String preBarcode, SlideCosting costing,
-                                   String lotNumber, String probeLotNumber, List<SlotCopyContent> contents, String bioState) {
+                                   String lotNumber, String probeLotNumber, List<SlotCopyContent> contents,
+                                   String bioState, String lpNumber) {
             this.labwareType = labwareTypeName;
             this.preBarcode = preBarcode;
             this.costing = costing;
             this.lotNumber = lotNumber;
             this.bioState = bioState;
             this.probeLotNumber = probeLotNumber;
+            this.lpNumber = lpNumber;
             setContents(contents);
         }
 
@@ -263,6 +266,15 @@ public class SlotCopyRequest {
             this.preBarcode = preBarcode;
         }
 
+        /** The LP number of this labware. **/
+        public String getLpNumber() {
+            return this.lpNumber;
+        }
+
+        public void setLpNumber(String lpNumber) {
+            this.lpNumber = lpNumber;
+        }
+
         /**
          * The specifications of which source slots are being copied into what addresses in the destination labware.
          */
@@ -285,14 +297,15 @@ public class SlotCopyRequest {
                     && Objects.equals(this.lotNumber, that.lotNumber)
                     && Objects.equals(this.probeLotNumber, that.probeLotNumber)
                     && Objects.equals(this.preBarcode, that.preBarcode)
-                    && Objects.equals(this.contents, that.contents)
                     && Objects.equals(this.barcode, that.barcode)
+                    && Objects.equals(this.lpNumber, that.lpNumber)
+                    && Objects.equals(this.contents, that.contents)
             );
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(labwareType, bioState, costing, lotNumber, probeLotNumber, preBarcode, contents, barcode);
+            return (barcode==null ? 0 : barcode.hashCode());
         }
 
         @Override
@@ -305,6 +318,7 @@ public class SlotCopyRequest {
                     .add("lotNumber", lotNumber)
                     .add("probeLotNumber", probeLotNumber)
                     .add("preBarcode", preBarcode)
+                    .add("lpNumber", lpNumber)
                     .add("contents", contents)
                     .reprStringValues()
                     .toString();

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyServiceImp.java
@@ -111,8 +111,8 @@ public class SlotCopyServiceImp implements SlotCopyService {
         updateSources(data.request.getSources(), data.sourceLabware.values(), newSourceState, barcodesToUnstore);
         return opres;
     }
-    // region Executing
 
+    // region Executing
     public OperationResult executeOps(User user, Collection<SlotCopyDestination> dests,
                                       OperationType opType, UCMap<LabwareType> lwTypes, UCMap<BioState> bioStates,
                                       UCMap<Labware> sources, Work work, UCMap<Labware> existingDests,
@@ -122,7 +122,8 @@ public class SlotCopyServiceImp implements SlotCopyService {
         for (SlotCopyDestination dest : dests) {
             OperationResult opres = executeOp(user, dest.getContents(), opType, lwTypes.get(dest.getLabwareType()),
                     dest.getPreBarcode(), sources, dest.getCosting(), dest.getLotNumber(), dest.getProbeLotNumber(),
-                    bioStates.get(dest.getBioState()), existingDests.get(dest.getBarcode()), executionType);
+                    bioStates.get(dest.getBioState()), dest.getLpNumber(), existingDests.get(dest.getBarcode()),
+                    executionType);
             ops.addAll(opres.getOperations());
             destLabware.addAll(opres.getLabware());
         }
@@ -146,6 +147,7 @@ public class SlotCopyServiceImp implements SlotCopyService {
      * @param lotNumber the lot number of the new labware, if specified
      * @param probeLotNumber the transcriptome probe lot number, if specified
      * @param bioState the new bio state of the labware, if given
+     * @param lpNumber the lp number for the labware, if given
      * @param destLw existing destination labware, if applicable
      * @param executionType the execution type of the operation, if given
      * @return the result of the operation
@@ -153,7 +155,7 @@ public class SlotCopyServiceImp implements SlotCopyService {
     public OperationResult executeOp(User user, Collection<SlotCopyContent> contents,
                                      OperationType opType, LabwareType lwType, String preBarcode,
                                      UCMap<Labware> labwareMap, SlideCosting costing, String lotNumber,
-                                     String probeLotNumber, BioState bioState, Labware destLw,
+                                     String probeLotNumber, BioState bioState, String lpNumber, Labware destLw,
                                      ExecutionType executionType) {
         if (destLw==null) {
             destLw = lwService.create(lwType, preBarcode, preBarcode);
@@ -172,6 +174,9 @@ public class SlotCopyServiceImp implements SlotCopyService {
         }
         if (!nullOrEmpty(probeLotNumber)) {
             lwNoteRepo.save(new LabwareNote(null, filledLabware.getId(), op.getId(), "probe lot", probeLotNumber.toUpperCase()));
+        }
+        if (!nullOrEmpty(lpNumber)) {
+            lwNoteRepo.save(new LabwareNote(null, filledLabware.getId(), op.getId(), "LP number", lpNumber.toUpperCase()));
         }
         if (executionType!=null) {
             lwNoteRepo.save(new LabwareNote(null, filledLabware.getId(), op.getId(), EXECUTION_NOTE_NAME, executionType.toString()));

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -590,6 +590,8 @@ input SlotCopyDestination {
     probeLotNumber: String
     """The barcode of the new labware, if it is prebarcoded."""
     preBarcode: String
+    """The LP number of the new labware, if it has one."""
+    lpNumber: String
     """The specifications of which source slots are being copied into what addresses in the destination labware."""
     contents: [SlotCopyContent!]!
 }


### PR DESCRIPTION
Add lp number field to SlotCopyRequest for use in CytAssist.
It is expected to be of the form "LP#" where # is a series of digits.
Stored as a labware note.

For #457 