### PR TITLE
x1206 Label printing for strip-tube labels

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelData.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/label/LabwareLabelData.java
@@ -4,6 +4,8 @@ import uk.ac.sanger.sccp.utils.BasicUtils;
 
 import java.util.*;
 
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullToEmpty;
+
 /**
  * A collection of information that may be printed onto a labware label.
  * @author dr6
@@ -13,16 +15,22 @@ public class LabwareLabelData {
     private final String externalBarcode;
     private final String medium;
     private final String date;
-
     private final List<LabelContent> contents;
+    private final Map<String, String> extraFields;
 
     public LabwareLabelData(String barcode, String externalBarcode, String medium, String date,
-                            List<LabelContent> contents) {
+                            List<LabelContent> contents, Map<String, String> extraFields) {
         this.barcode = barcode;
         this.externalBarcode = externalBarcode;
         this.medium = medium;
         this.date = date;
-        this.contents = List.copyOf(contents);
+        this.contents = nullToEmpty(contents);
+        this.extraFields = nullToEmpty(extraFields);
+    }
+
+    public LabwareLabelData(String barcode, String externalBarcode, String medium, String date,
+                            List<LabelContent> contents) {
+        this(barcode, externalBarcode, medium, date, contents, null);
     }
 
     public String getBarcode() {
@@ -45,6 +53,10 @@ public class LabwareLabelData {
         return this.contents;
     }
 
+    public Map<String, String> getExtraFields() {
+        return this.extraFields;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -54,7 +66,9 @@ public class LabwareLabelData {
                 && Objects.equals(this.externalBarcode, that.externalBarcode)
                 && Objects.equals(this.medium, that.medium)
                 && Objects.equals(this.date, that.date)
-                && Objects.equals(this.contents, that.contents));
+                && Objects.equals(this.contents, that.contents)
+                && Objects.equals(this.extraFields, that.extraFields)
+        );
     }
 
     @Override
@@ -70,6 +84,7 @@ public class LabwareLabelData {
                 .add("medium", medium)
                 .add("date", date)
                 .add("contents", contents)
+                .add("extraFields", extraFields)
                 .omitNullValues()
                 .reprStringValues()
                 .toString();
@@ -81,6 +96,7 @@ public class LabwareLabelData {
         fields.put("medium", getMedium());
         fields.put("date", getDate());
         fields.put("external", getExternalBarcode());
+        fields.putAll(getExtraFields());
         int index = 0;
         for (LabelContent content : contents) {
             addField(fields, "donor", index, content.donorName());

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkService.java
@@ -6,8 +6,7 @@ import uk.ac.sanger.sccp.stan.request.SuggestedWorkResponse;
 import uk.ac.sanger.sccp.stan.request.WorkWithComment;
 import uk.ac.sanger.sccp.utils.UCMap;
 
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Stream;
 
 /**
@@ -221,6 +220,13 @@ public interface WorkService {
      * @return the works created by the user
      */
     List<Work> getWorksCreatedBy(User user);
+
+    /**
+     * Loads works linked to the slots in the given labware
+     * @param labware labware
+     * @return map of slot/sample ids to works
+     */
+    Map<SlotIdSampleId, Set<Work>> loadWorksForSlotsIn(Collection<Labware> labware);
 
     /**
      * struct-like container for a work and an operation

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkServiceImp.java
@@ -507,6 +507,17 @@ public class WorkServiceImp implements WorkService {
                 .collect(toList());
     }
 
+    @Override
+    public Map<SlotIdSampleId, Set<Work>> loadWorksForSlotsIn(Collection<Labware> labware) {
+        return loadWorksForSlots(labware.stream()
+                .flatMap(lw -> lw.getSlots().stream()));
+    }
+
+    public Map<SlotIdSampleId, Set<Work>> loadWorksForSlots(Stream<Slot> slots) {
+        List<Integer> slotIds = slots.map(Slot::getId).toList();
+        return workRepo.slotSampleWorksForSlotIds(slotIds);
+    }
+
     public void fillInComments(Collection<WorkWithComment> wcs, Map<Integer, WorkEvent> workEvents) {
         for (WorkWithComment wc : wcs) {
             Work work = wc.getWork();

--- a/src/main/resources/sprint.properties
+++ b/src/main/resources/sprint.properties
@@ -3,6 +3,7 @@ sprint.host = http://sprint.psd.sanger.ac.uk/graphql
 sprint.template_dir = sprint
 
 sprint.templates = {\
+  'strip' : 'strip.json',\
   'adh' : 'adh.json',\
   'slide@3' : 'slide3.json',\
   'slide@6' : 'slide6.json',\

--- a/src/main/resources/sprint/strip.json
+++ b/src/main/resources/sprint/strip.json
@@ -1,0 +1,61 @@
+{
+  "labelSize": {
+    "width": 39,
+    "height": 8,
+    "displacement": 8
+  },
+  "barcodeFields": [
+    {
+      "x": 8,
+      "y": 1,
+      "value": "#barcode#",
+      "barcodeType": "datamatrix",
+      "cellWidth": 0.25
+    },
+    {
+      "x": 32,
+      "y": 1,
+      "value": "#barcode#",
+      "barcodeType": "datamatrix",
+      "cellWidth": 0.25
+    }
+  ],
+  "textFields": [
+    {
+      "x": 20,
+      "y": 2,
+      "value": "#work#",
+      "fontSize": 1.7
+    },
+    {
+      "x": 27,
+      "y": 2,
+      "value": "#lp#",
+      "fontSize": 1.7
+    },
+    {
+      "x": 12,
+      "y": 4,
+      "value": "#address#",
+      "fontSize": 1.8
+    },
+    {
+      "x": 20,
+      "y": 4,
+      "value": "#state[0]#",
+      "fontSize": 1.8
+    },
+    {
+      "x": 20,
+      "y": 6,
+      "value": "#tissue[0]#",
+      "fontSize": 1.5
+    },
+    {
+      "x": 8,
+      "y": 7,
+      "value": "#barcode#",
+      "fontSize": 1.5
+    }
+  ]
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestWorkRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestWorkRepo.java
@@ -323,6 +323,15 @@ public class TestWorkRepo {
         assertThat(workIds).containsExactlyInAnyOrder(work1.getId(), work2.getId());
         workIds = workRepo.findWorkIdsForLabwareId(labware[1].getId());
         assertThat(workIds).containsExactly(work2.getId());
+
+        List<Integer> slotIds = labware[0].getSlots().stream()
+                .map(Slot::getId)
+                .toList();
+
+        Map<SlotIdSampleId, Set<Work>> slotWorks = workRepo.slotSampleWorksForSlotIds(slotIds);
+        assertThat(slotWorks).hasSize(1);
+        assertThat(slotWorks.get(new SlotIdSampleId(labware[0].getFirstSlot(), samples[0])))
+                .containsExactlyInAnyOrder(work1, work2);
     }
 
     @Transactional

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/label/TestLabwareLabelDataService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/label/TestLabwareLabelDataService.java
@@ -502,6 +502,33 @@ public class TestLabwareLabelDataService {
     }
 
     @ParameterizedTest
+    @ValueSource(booleans={false,true})
+    public void testGetSplitLabelData(boolean hasLp) {
+        String lp = (hasLp ? "LP1" : null);
+        LabwareType lt = EntityFactory.makeLabwareType(3,1);
+        Sample[] samples = EntityFactory.makeSamples(2);
+        Tissue tissue = samples[0].getTissue();
+        Donor donor = tissue.getDonor();
+        Labware lw = EntityFactory.makeLabware(lt, samples);
+        String state = samples[0].getBioState().getName();
+        Map<SlotIdSampleId, String> slotWork = Map.of(
+                new SlotIdSampleId(lw.getFirstSlot(), samples[0]), "SGP1",
+                new SlotIdSampleId(lw.getFirstSlot(), samples[1]), "SGP2"
+        );
+        List<LabwareLabelData> expectedLds = List.of(
+                new LabwareLabelData(lw.getBarcode(), lw.getExternalBarcode(), null, null,
+                        List.of(new LabelContent(donor.getDonorName(), tissue.getExternalName(), null, state)),
+                        hasLp ? Map.of("lp", "LP1", "address", "B1")
+                                : Map.of("address", "B1")),
+                new LabwareLabelData(lw.getBarcode(), lw.getExternalBarcode(), null, null,
+                        List.of(new LabelContent(donor.getDonorName(), tissue.getExternalName(), null, state)),
+                        hasLp ? Map.of("lp", "LP1", "address", "A1", "work", "SGP1")
+                                : Map.of("address", "A1", "work", "SGP1"))
+        );
+        assertThat(service.getSplitLabelData(lw, slotWork, lp)).containsExactlyElementsOf(expectedLds);
+    }
+
+    @ParameterizedTest
     @EnumSource(LifeStage.class)
     public void testGetTissueDesc(LifeStage lifeStage) {
         Donor donor = new Donor(null, "DONOR", lifeStage, species);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/work/TestWorkService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/work/TestWorkService.java
@@ -1138,6 +1138,19 @@ public class TestWorkService {
                 workService.suggestLabwareForWorkNumber(work.getWorkNumber(), forRelease));
     }
 
+    @Test
+    public void testLoadWorksForSlotsIn() {
+        Sample sample = EntityFactory.getSample();
+        LabwareType lt = EntityFactory.makeLabwareType(3,1);
+        Labware lw = EntityFactory.makeLabware(lt, sample);
+        Map<SlotIdSampleId, Set<Work>> slotWorks = Map.of(new SlotIdSampleId(lw.getFirstSlot(), sample),
+                Set.of(EntityFactory.makeWork("SGP1")));
+        when(mockWorkRepo.slotSampleWorksForSlotIds(any())).thenReturn(slotWorks);
+        assertSame(slotWorks, workService.loadWorksForSlotsIn(List.of(lw)));
+        List<Integer> slotIds = lw.getSlots().stream().map(Slot::getId).toList();
+        verify(mockWorkRepo).slotSampleWorksForSlotIds(slotIds);
+    }
+
     private Operation makeOp(OperationType opType, int opId, Labware srcLw, Labware dstLw) {
         List<Action> actions = new ArrayList<>();
         int acId = 100*opId;


### PR DESCRIPTION
For #475 

These strip tubes require one label per nonempty slot. They also need a bunch of new fields (LP, address, work).
Also, the labels for slots in a labware are printed in reverse order, as requested by x1251.
