### PR TITLE
x1262: support thickness (formerly int) to one decimal place

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/config/FieldValidation.java
@@ -250,6 +250,11 @@ public class FieldValidation {
     }
 
     @Bean
+    public Sanitiser<String> thicknessSanitiser() {
+        return new DecimalSanitiser("thickness", 1, BigDecimal.ZERO, null);
+    }
+
+    @Bean
     public Sanitiser<String> concentrationSanitiser() {
         return new DecimalSanitiser("concentration", 2, null, null);
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementType.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/MeasurementType.java
@@ -5,7 +5,7 @@ package uk.ac.sanger.sccp.stan.model;
  * @author dr6
  */
 public enum MeasurementType {
-    Thickness(MeasurementValueType.INT, "μm"),
+    Thickness(MeasurementValueType.DECIMAL, "μm"),
     Haematoxylin(MeasurementValueType.TIME),
     Eosin(MeasurementValueType.TIME),
     Blueing(MeasurementValueType.TIME),

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/PlanAction.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/PlanAction.java
@@ -27,7 +27,7 @@ public class PlanAction {
     @ManyToOne
     private Sample sample;
     private Integer newSection;
-    private Integer sampleThickness;
+    private String sampleThickness;
     @ManyToOne
     private BioState newBioState;
 
@@ -38,7 +38,7 @@ public class PlanAction {
     }
 
     public PlanAction(Integer id, Integer planOperationId, Slot source, Slot destination, Sample sample,
-                      Integer newSection, Integer sampleThickness, BioState newBioState) {
+                      Integer newSection, String sampleThickness, BioState newBioState) {
         this.id = id;
         this.planOperationId = planOperationId;
         this.source = source;
@@ -97,11 +97,11 @@ public class PlanAction {
         this.newSection = section;
     }
 
-    public Integer getSampleThickness() {
+    public String getSampleThickness() {
         return this.sampleThickness;
     }
 
-    public void setSampleThickness(Integer sampleThickness) {
+    public void setSampleThickness(String sampleThickness) {
         this.sampleThickness = sampleThickness;
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/plan/PlanRequestAction.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/plan/PlanRequestAction.java
@@ -13,11 +13,11 @@ public class PlanRequestAction {
     private Address address;
     private int sampleId;
     private PlanRequestSource source;
-    private Integer sampleThickness;
+    private String sampleThickness;
 
     public PlanRequestAction() {}
 
-    public PlanRequestAction(Address address, int sampleId, PlanRequestSource source, Integer sampleThickness) {
+    public PlanRequestAction(Address address, int sampleId, PlanRequestSource source, String sampleThickness) {
         this.address = address;
         this.sampleId = sampleId;
         this.source = source;
@@ -48,11 +48,11 @@ public class PlanRequestAction {
         this.source = source;
     }
 
-    public Integer getSampleThickness() {
+    public String getSampleThickness() {
         return this.sampleThickness;
     }
 
-    public void setSampleThickness(Integer sampleThickness) {
+    public void setSampleThickness(String sampleThickness) {
         this.sampleThickness = sampleThickness;
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/register/SectionRegisterContent.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/register/SectionRegisterContent.java
@@ -24,7 +24,7 @@ public class SectionRegisterContent {
     private String fixative;
     private String medium;
     private Integer sectionNumber;
-    private Integer sectionThickness;
+    private String sectionThickness;
     private String region;
     private LocalDate dateSectioned;
     private String bioRiskCode;
@@ -133,11 +133,11 @@ public class SectionRegisterContent {
         this.sectionNumber = sectionNumber;
     }
 
-    public Integer getSectionThickness() {
+    public String getSectionThickness() {
         return this.sectionThickness;
     }
 
-    public void setSectionThickness(Integer sectionThickness) {
+    public void setSectionThickness(String sectionThickness) {
         this.sectionThickness = sectionThickness;
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationFactory.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/plan/PlanValidationFactory.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.plan.PlanRequest;
 import uk.ac.sanger.sccp.stan.service.Validator;
+import uk.ac.sanger.sccp.stan.service.sanitiser.Sanitiser;
 
 /**
  * @author dr6
@@ -18,22 +19,26 @@ public class PlanValidationFactory {
     private final Validator<String> visiumBarcodeValidator;
     private final Validator<String> xeniumBarcodeValidator;
     private final Validator<String> lotNumberValidator;
+    private final Sanitiser<String> thicknessSanitiser;
 
     @Autowired
     public PlanValidationFactory(LabwareRepo lwRepo, LabwareTypeRepo ltRepo, OperationTypeRepo opTypeRepo,
                                  @Qualifier("visiumLPBarcodeValidator") Validator<String> visiumBarcodeValidator,
                                  @Qualifier("xeniumBarcodeValidator") Validator<String> xeniumBarcodeValidator,
-                                 @Qualifier("lotNumberValidator") Validator<String> lotNumberValidator) {
+                                 @Qualifier("lotNumberValidator") Validator<String> lotNumberValidator,
+                                 @Qualifier("thicknessSanitiser") Sanitiser<String> thicknessSanitiser) {
         this.lwRepo = lwRepo;
         this.ltRepo = ltRepo;
         this.opTypeRepo = opTypeRepo;
         this.visiumBarcodeValidator = visiumBarcodeValidator;
         this.xeniumBarcodeValidator = xeniumBarcodeValidator;
         this.lotNumberValidator = lotNumberValidator;
+        this.thicknessSanitiser = thicknessSanitiser;
     }
 
     public PlanValidation createPlanValidation(PlanRequest request) {
         return new PlanValidationImp(request, lwRepo, ltRepo, opTypeRepo,
-                visiumBarcodeValidator, xeniumBarcodeValidator, lotNumberValidator);
+                visiumBarcodeValidator, xeniumBarcodeValidator, lotNumberValidator,
+                thicknessSanitiser);
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationFactory.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/RegisterValidationFactory.java
@@ -7,6 +7,7 @@ import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.register.RegisterRequest;
 import uk.ac.sanger.sccp.stan.request.register.SectionRegisterRequest;
 import uk.ac.sanger.sccp.stan.service.*;
+import uk.ac.sanger.sccp.stan.service.sanitiser.Sanitiser;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 
 /**
@@ -31,6 +32,7 @@ public class RegisterValidationFactory {
     private final Validator<String> visiumLpSlideBarcodeValidation;
     private final Validator<String> xeniumBarcodeValidator;
     private final Validator<String> replicateValidator;
+    private final Sanitiser<String> thicknessSanitiser;
     private final TissueFieldChecker tissueFieldChecker;
     private final SlotRegionService slotRegionService;
     private final BioRiskService bioRiskService;
@@ -46,6 +48,7 @@ public class RegisterValidationFactory {
                                      @Qualifier("externalBarcodeValidator") Validator<String> externalBarcodeValidation,
                                      @Qualifier("visiumLPBarcodeValidator") Validator<String> visiumLpSlideBarcodeValidation,
                                      @Qualifier("xeniumBarcodeValidator") Validator<String> xeniumBarcodeValidator,
+                                     @Qualifier("thicknessSanitiser") Sanitiser<String> thicknessSanitiser,
                                      @Qualifier("replicateValidator") Validator<String> replicateValidator,
                                      TissueFieldChecker tissueFieldChecker,
                                      SlotRegionService slotRegionService, BioRiskService bioRiskService, WorkService workService) {
@@ -65,6 +68,7 @@ public class RegisterValidationFactory {
         this.visiumLpSlideBarcodeValidation = visiumLpSlideBarcodeValidation;
         this.xeniumBarcodeValidator = xeniumBarcodeValidator;
         this.replicateValidator = replicateValidator;
+        this.thicknessSanitiser = thicknessSanitiser;
         this.tissueFieldChecker = tissueFieldChecker;
         this.slotRegionService = slotRegionService;
         this.workService = workService;
@@ -82,6 +86,6 @@ public class RegisterValidationFactory {
                 hmdmcRepo, ttRepo, fixativeRepo, mediumRepo, tissueRepo, bioStateRepo,
                 slotRegionService, bioRiskService, workService,
                 externalBarcodeValidation, donorNameValidation, externalNameValidation, replicateValidator,
-                visiumLpSlideBarcodeValidation, xeniumBarcodeValidator);
+                visiumLpSlideBarcodeValidation, xeniumBarcodeValidator, thicknessSanitiser);
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/filereader/SectionRegisterFileReader.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/filereader/SectionRegisterFileReader.java
@@ -35,7 +35,7 @@ public interface SectionRegisterFileReader extends MultipartFileReader<SectionRe
         Replicate_number,
         Section_external_ID,
         Section_number(Integer.class),
-        Section_thickness(Integer.class),
+        Section_thickness(String.class),
         Date_sectioned(LocalDate.class, Pattern.compile("date.*sectioned|section.*date", Pattern.CASE_INSENSITIVE), false),
         Section_position(Pattern.compile("(if.+)?(section\\s+)?position", Pattern.CASE_INSENSITIVE)),
         ;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/register/filereader/SectionRegisterFileReaderImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/register/filereader/SectionRegisterFileReaderImp.java
@@ -111,7 +111,7 @@ public class SectionRegisterFileReaderImp extends BaseRegisterFileReader<Section
         content.setDonorIdentifier((String) row.get(Column.Donor_ID));
         content.setLifeStage(valueToLifeStage(problems, (String) row.get(Column.Life_stage)));
         content.setReplicateNumber((String) row.get(Column.Replicate_number));
-        content.setSectionThickness((Integer) row.get(Column.Section_thickness));
+        content.setSectionThickness((String) row.get(Column.Section_thickness));
         content.setSpecies((String) row.get(Column.Species));
         content.setTissueType((String) row.get(Column.Tissue_type));
         content.setSpatialLocation((Integer) row.get(Column.Spatial_location));

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/sanitiser/DecimalSanitiser.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/sanitiser/DecimalSanitiser.java
@@ -4,8 +4,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.regex.Pattern;
 
-import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
-
 /**
  * Sanitiser for numbers including a decimal point, e.g. 12.345
  * @author dr6
@@ -33,7 +31,7 @@ public class DecimalSanitiser extends NumberSanitiser<BigDecimal> {
                 case 1 -> ", expected only 1 decimal place: ";
                 default -> ", expected up to "+ numDecimalPlaces +" decimal places: ";
             };
-            return "Invalid value for " + fieldName + expectation + repr(value);
+            return "Invalid value for " + fieldName + expectation + value;
         }
         return super.errorMessage(value);
     }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/sanitiser/NumberSanitiser.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/sanitiser/NumberSanitiser.java
@@ -62,7 +62,7 @@ public abstract class NumberSanitiser<N extends Comparable<N>> implements Saniti
         if (lowerBound!=null && number.compareTo(lowerBound) < 0
                 || upperBound!=null && number.compareTo(upperBound) > 0) {
             if (problems!=null) {
-                problems.add("Value outside the expected bounds for "+fieldName+": "+repr(value));
+                problems.add("Value outside the expected bounds for "+fieldName+": "+value);
             }
             return null;
         }

--- a/src/main/resources/db/changelog/changelog-0.1.xml
+++ b/src/main/resources/db/changelog/changelog-0.1.xml
@@ -630,7 +630,7 @@
             <column name="new_section" type="INT">
                 <constraints nullable="true"/>
             </column>
-            <column name="sample_thickness" type="INT">
+            <column name="sample_thickness" type="VARCHAR(16)">
                 <constraints nullable="true"/>
             </column>
             <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -348,7 +348,7 @@ input SectionRegisterContent {
     """The section number of this particular section from its original tissue block."""
     sectionNumber: Int!
     """The thickness, if known, of this section."""
-    sectionThickness: Int
+    sectionThickness: String
     """The region of this sample in this slot, if any."""
     region: String
     """The date the sample was sectioned."""
@@ -481,7 +481,7 @@ input PlanRequestAction {
     """The id of the existing sample."""
     sampleId: Int!
     """The thickness (if specified) of the new sample."""
-    sampleThickness: Int
+    sampleThickness: String
     """The source of the sample (describing a slot in some existing labware)."""
     source: PlanRequestSource!
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestExtractMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestExtractMutation.java
@@ -222,7 +222,6 @@ public class TestExtractMutation {
             assertEquals(dests[1].getFirstSlot().getId(), opCom.getSlotId());
         }
 
-
         result = tester.post(tester.readGraphQL("extractresult.graphql").replace("$BARCODE", dests[0].getBarcode()));
         extractData = chainGet(result, "data", "extractResult");
         assertEquals(dests[0].getBarcode(), chainGet(extractData, "labware", "barcode"));
@@ -245,7 +244,7 @@ public class TestExtractMutation {
         meas = measurements.get(0);
         assertEquals(dests[0].getFirstSlot().getId(), meas.getSlotId());
         assertEquals("RIN", meas.getName());
-        assertEquals("55.0", meas.getValue());
+        assertEquals("55.5", meas.getValue());
         Operation op = opRepo.findById(opId).orElseThrow();
         assertEquals(analysisEquipment, op.getEquipment());
     }

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestRegisterMutation.java
@@ -158,7 +158,7 @@ public class TestRegisterMutation {
         Measurement measurement = measurements.get(0);
         assertNotNull(measurement.getId());
         assertEquals("Thickness", measurement.getName());
-        assertEquals("14", measurement.getValue());
+        assertEquals("14.5", measurement.getValue());
         assertEquals(sample.getId(), measurement.getSampleId());
         assertNotNull(measurement.getOperationId());
         Operation op = opRepo.findById(measurement.getOperationId()).orElseThrow();

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmOperationService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmOperationService.java
@@ -259,9 +259,9 @@ public class TestConfirmOperationService {
 
         List<?>[] planActions = Arrays.stream(dests)
                 .map(dest -> List.of(
-                        new PlanAction(20, 10, srcSlot, dest.getSlot(A1), sample, 1, 4, null),
+                        new PlanAction(20, 10, srcSlot, dest.getSlot(A1), sample, 1, "4", null),
                         new PlanAction(21, 10, srcSlot, dest.getSlot(A1), sample, 2, null, null),
-                        new PlanAction(22, 10, srcSlot, dest.getSlot(A2), sample, 3, 7, null),
+                        new PlanAction(22, 10, srcSlot, dest.getSlot(A2), sample, 3, "7", null),
                         new PlanAction(23, 10, srcSlot, otherSlot, sample, 4, null, null)
                 ))
                 .toArray(List[]::new);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmSectionService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/confirm/TestConfirmSectionService.java
@@ -292,7 +292,7 @@ public class TestConfirmSectionService {
         ConfirmSectionLabware csl = new ConfirmSectionLabware(lw1.getBarcode(), false, csecs, List.of());
         Map<PlanActionKey, PlanAction> planActionMap = Stream.of(
                 new PlanAction(1, 1, source, lw1.getSlot(A1), sample),
-                new PlanAction(2, 1, source, lw1.getSlot(B3), sample, 12, 50, null)
+                new PlanAction(2, 1, source, lw1.getSlot(B3), sample, 12, "50", null)
         ).collect(BasicUtils.inMap(PlanActionKey::new, HashMap::new));
         plan.setPlanActions(new ArrayList<>(planActionMap.values()));
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanService.java
@@ -305,8 +305,8 @@ public class TestPlanService {
                     lw.getSlot(A2).getSamples().add(nonSectionSample);
                     return lw;
                 })
-                .collect(toList());
-        List<String> sourceBarcodes = sources.stream().map(Labware::getBarcode).collect(toList());
+                .toList();
+        List<String> sourceBarcodes = sources.stream().map(Labware::getBarcode).toList();
         UCMap<Labware> sourceMap = UCMap.from(sources, Labware::getBarcode);
         Labware destination = EntityFactory.makeEmptyLabware(lt);
         int planId = 99;
@@ -315,12 +315,12 @@ public class TestPlanService {
                         new PlanRequestAction(A1, samples.get(0).getId(),
                                 new PlanRequestSource(sourceBarcodes.get(0), A1), null),
                         new PlanRequestAction(A2, samples.get(0).getId(),
-                                new PlanRequestSource(sourceBarcodes.get(0), null), 1)
+                                new PlanRequestSource(sourceBarcodes.get(0), null), "1")
                 ));
 
         List<PlanAction> expectedActions = List.of(
                 new PlanAction(21, planId, sources.get(0).getFirstSlot(), destination.getFirstSlot(), samples.get(0), null, null, bioState),
-                new PlanAction(22, planId, sources.get(0).getFirstSlot(), destination.getSlot(A2), samples.get(0), null, 1, bioState)
+                new PlanAction(22, planId, sources.get(0).getFirstSlot(), destination.getSlot(A2), samples.get(0), null, "1", bioState)
         );
 
         final int[] planActionIdCounter = {20};

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidationFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/plan/TestPlanValidationFactory.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.plan.PlanRequest;
 import uk.ac.sanger.sccp.stan.service.Validator;
+import uk.ac.sanger.sccp.stan.service.sanitiser.Sanitiser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -24,8 +25,9 @@ public class TestPlanValidationFactory {
         Validator<String> mockVisiumValidator = genericMock(Validator.class);
         Validator<String> mockLotValidator = genericMock(Validator.class);
         Validator<String> mockXeniumValidator = genericMock(Validator.class);
+        Sanitiser<String> mockThicknessSanitiser = genericMock(Sanitiser.class);
         PlanValidationFactory factory = new PlanValidationFactory(lwRepo, ltRepo, opTypeRepo,
-                mockVisiumValidator, mockXeniumValidator, mockLotValidator);
+                mockVisiumValidator, mockXeniumValidator, mockLotValidator, mockThicknessSanitiser);
         PlanRequest request = new PlanRequest();
         PlanValidation validation = factory.createPlanValidation(request);
         assertThat(validation).isInstanceOf(PlanValidationImp.class);
@@ -38,5 +40,6 @@ public class TestPlanValidationFactory {
         assertSame(validationImp.visiumBarcodeValidator, mockVisiumValidator);
         assertSame(validationImp.xeniumBarcodeValidator, mockXeniumValidator);
         assertSame(validationImp.lotValidator, mockLotValidator);
+        assertSame(validationImp.thicknessSanitiser, mockThicknessSanitiser);
     }
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidationFactory.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestRegisterValidationFactory.java
@@ -6,6 +6,7 @@ import uk.ac.sanger.sccp.stan.repo.*;
 import uk.ac.sanger.sccp.stan.request.register.RegisterRequest;
 import uk.ac.sanger.sccp.stan.request.register.SectionRegisterRequest;
 import uk.ac.sanger.sccp.stan.service.*;
+import uk.ac.sanger.sccp.stan.service.sanitiser.Sanitiser;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,16 +18,17 @@ import static org.mockito.Mockito.mock;
  */
 public class TestRegisterValidationFactory {
     RegisterValidationFactory registerValidationFactory;
+    @SuppressWarnings("unchecked")
     @BeforeEach
     void setup() {
-        //noinspection unchecked
         Validator<String> mockStringValidator = mock(Validator.class);
+        Sanitiser<String> mockSanitiser = mock(Sanitiser.class);
         registerValidationFactory = new RegisterValidationFactory(
                 mock(DonorRepo.class), mock(HmdmcRepo.class), mock(TissueTypeRepo.class),
                 mock(LabwareTypeRepo.class), mock(MediumRepo.class),
                 mock(FixativeRepo.class), mock(TissueRepo.class), mock(SpeciesRepo.class), mock(LabwareRepo.class),
                 mock(BioStateRepo.class), mockStringValidator, mockStringValidator, mockStringValidator,
-                mockStringValidator, mockStringValidator, mockStringValidator,
+                mockStringValidator, mockStringValidator, mockSanitiser, mockStringValidator,
                 mock(TissueFieldChecker.class), mock(SlotRegionService.class), mock(BioRiskService.class),
                 mock(WorkService.class));
     }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/TestSectionRegisterService.java
@@ -319,7 +319,7 @@ public class TestSectionRegisterService {
         SectionRegisterContent content = new SectionRegisterContent();
         content.setAddress(address);
         content.setExternalIdentifier(extName);
-        content.setSectionThickness(thickness);
+        content.setSectionThickness(thickness==null ? null : thickness.toString());
         return content;
     }
 

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/register/filereader/TestSectionRegisterFileReader.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/register/filereader/TestSectionRegisterFileReader.java
@@ -415,10 +415,10 @@ class TestSectionRegisterFileReader extends BaseTestFileReader {
         List<String> problems = new ArrayList<>(0);
         Map<Column, Object> row = new EnumMap<>(Column.class);
         row.put(Column.Donor_ID, "Donor1");
-        row.put(Column.Section_thickness, 41);
+        row.put(Column.Section_thickness, "41");
         SectionRegisterContent src = reader.createRequestContent(problems, row);
         assertEquals("Donor1", src.getDonorIdentifier());
-        assertEquals(41, src.getSectionThickness());
+        assertEquals("41", src.getSectionThickness());
         assertNull(src.getAddress());
         assertNull(src.getLifeStage());
         assertNull(src.getSpatialLocation());
@@ -431,7 +431,7 @@ class TestSectionRegisterFileReader extends BaseTestFileReader {
         List<String> problems = new ArrayList<>(0);
         Map<Column, Object> row = new EnumMap<>(Column.class);
         row.put(Column.Donor_ID, "Donor1");
-        row.put(Column.Section_thickness, 41);
+        row.put(Column.Section_thickness, "41");
         row.put(Column.Section_address, "A4");
         row.put(Column.Section_external_ID, "X1");
         row.put(Column.HuMFre, "12/234");
@@ -446,7 +446,7 @@ class TestSectionRegisterFileReader extends BaseTestFileReader {
         row.put(Column.Section_position, "Middle");
         SectionRegisterContent src = reader.createRequestContent(problems, row);
         assertEquals("Donor1", src.getDonorIdentifier());
-        assertEquals(41, src.getSectionThickness());
+        assertEquals("41", src.getSectionThickness());
         assertEquals(new Address(1,4), src.getAddress());
         assertEquals("X1", src.getExternalIdentifier());
         assertEquals("12/234", src.getHmdmc());

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/sanitiser/TestDecimalSanitiser.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/sanitiser/TestDecimalSanitiser.java
@@ -59,11 +59,11 @@ public class TestDecimalSanitiser {
     @ParameterizedTest
     @CsvSource(value={
             "2;bananas;Invalid value for X: \"bananas\"",
-            "2;-0.1;Value outside the expected bounds for X: \"-0.1\"",
-            "2;10.1;Value outside the expected bounds for X: \"10.1\"",
-            "2;1.251;Invalid value for X, expected up to 2 decimal places: \"1.251\"",
-            "1;1.35;Invalid value for X, expected only 1 decimal place: \"1.35\"",
-            "0;5.2;Invalid value for X, expected no decimal places: \"5.2\"",
+            "2;-0.1;Value outside the expected bounds for X: -0.1",
+            "2;10.1;Value outside the expected bounds for X: 10.1",
+            "2;1.251;Invalid value for X, expected up to 2 decimal places: 1.251",
+            "1;1.35;Invalid value for X, expected only 1 decimal place: 1.35",
+            "0;5.2;Invalid value for X, expected no decimal places: 5.2",
     }, delimiter=';')
     public void testBoundedSanitiseInvalid(int numDecimalPlaces, String input, String expectedProblem) {
         List<String> problems = new ArrayList<>(1);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/sanitiser/TestIntSanitiser.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/sanitiser/TestIntSanitiser.java
@@ -59,8 +59,8 @@ public class TestIntSanitiser {
             "-,Invalid value for X: \"-\"",
             "bananas,Invalid value for X: \"bananas\"",
             "999999999999,Invalid value for X: \"999999999999\"",
-            "-1,Value outside the expected bounds for X: \"-1\"",
-            "101,Value outside the expected bounds for X: \"101\"",
+            "-1,Value outside the expected bounds for X: -1",
+            "101,Value outside the expected bounds for X: 101",
     })
     public void testBoundedSanitiseInvalid(String input, String expectedProblem) {
         List<String> problems = new ArrayList<>(1);

--- a/src/test/resources/graphql/analysis.graphql
+++ b/src/test/resources/graphql/analysis.graphql
@@ -6,7 +6,7 @@ mutation {
             barcode: "$BARCODE"
             commentId: 1
             workNumber: "SGP4000"
-            measurements: [{name:"RIN", value:"55"}]
+            measurements: [{name:"RIN", value:"55.5"}]
         }]
     }) {
         operations {

--- a/src/test/resources/graphql/registersections.graphql
+++ b/src/test/resources/graphql/registersections.graphql
@@ -14,7 +14,7 @@ mutation {
                         medium: "None"
                         replicateNumber: "7"
                         sectionNumber: 8
-                        sectionThickness: 12
+                        sectionThickness: "12"
                         lifeStage: adult
                         externalIdentifier: "TISSUE1"
                         spatialLocation: 1
@@ -30,7 +30,7 @@ mutation {
                         medium: "None"
                         replicateNumber: "9a"
                         sectionNumber: 10
-                        sectionThickness: 13
+                        sectionThickness: "13"
                         lifeStage: adult
                         externalIdentifier: "TISSUE2"
                         spatialLocation: 1
@@ -47,7 +47,7 @@ mutation {
                         medium: "None"
                         replicateNumber: "8"
                         sectionNumber: 11
-                        sectionThickness: 14
+                        sectionThickness: "14.5"
                         lifeStage: adult
                         externalIdentifier: "TISSUE3"
                         spatialLocation: 1


### PR DESCRIPTION
Requests accepting thickness measurements are now strings rather than ints.
See also [schema patch](https://github.com/sanger/stan-sql/blob/devel/schema/x1262_thickness_string.sql)
For #485 