### PR TITLE
x1257: SlotCopySave

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -87,6 +87,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final CommentRepo commentRepo;
     final AnalyserScanDataService analyserScanDataService;
     final LabwareNoteService lwNoteService;
+    final SlotCopyRecordService slotCopyRecordService;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, UserRepo userRepo,
@@ -112,7 +113,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                CleanedOutSlotService cleanedOutSlotService,
                                FlagLookupService flagLookupService, MeasurementService measurementService,
                                GraphService graphService, CommentRepo commentRepo,
-                               AnalyserScanDataService analyserScanDataService, LabwareNoteService lwNoteService) {
+                               AnalyserScanDataService analyserScanDataService, LabwareNoteService lwNoteService, SlotCopyRecordService slotCopyRecordService) {
         super(objectMapper, authComp, userRepo);
         this.sessionConfig = sessionConfig;
         this.versionInfo = versionInfo;
@@ -163,6 +164,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.commentRepo = commentRepo;
         this.analyserScanDataService = analyserScanDataService;
         this.lwNoteService = lwNoteService;
+        this.slotCopyRecordService = slotCopyRecordService;
     }
 
     public DataFetcher<User> getUser() {
@@ -519,6 +521,15 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         return dfe -> {
             String barcode = dfe.getArgument("barcode");
             return labwareService.getSampleBioRisks(barcode);
+        };
+    }
+
+    public DataFetcher<SlotCopySave> reloadSlotCopy() {
+        return dfe -> {
+            String opname = dfe.getArgument("operationType");
+            String workNumber = dfe.getArgument("workNumber");
+            String lpNumber = dfe.getArgument("lpNumber");
+            return slotCopyRecordService.load(opname, workNumber, lpNumber);
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLMutation.java
@@ -103,6 +103,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
     final CleanOutService cleanOutService;
     final RoiMetricService roiMetricService;
     final UserAdminService userAdminService;
+    final SlotCopyRecordService slotCopyRecordService;
 
     @Autowired
     public GraphQLMutation(ObjectMapper objectMapper, AuthenticationComponent authComp,
@@ -136,7 +137,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
                            QCLabwareService qcLabwareService, OrientationService orientationService, SSStudyService ssStudyService,
                            ReactivateService reactivateService, LibraryPrepService libraryPrepService,
                            SegmentationService segmentationService, CleanOutService cleanOutService, RoiMetricService roiMetricService,
-                           UserAdminService userAdminService) {
+                           UserAdminService userAdminService, SlotCopyRecordService slotCopyRecordService) {
         super(objectMapper, authComp, userRepo);
         this.authService = authService;
         this.registerService = registerService;
@@ -200,6 +201,7 @@ public class GraphQLMutation extends BaseGraphQLResource {
         this.cleanOutService = cleanOutService;
         this.roiMetricService = roiMetricService;
         this.userAdminService = userAdminService;
+        this.slotCopyRecordService = slotCopyRecordService;
     }
 
     private void logRequest(String name, User user, Object request) {
@@ -915,6 +917,16 @@ public class GraphQLMutation extends BaseGraphQLResource {
             SampleMetricsRequest request = arg(dfe, "request", SampleMetricsRequest.class);
             logRequest("recordSampleMetrics", user, request);
             return roiMetricService.perform(user, request);
+        };
+    }
+
+    public DataFetcher<SlotCopySave> saveSlotCopy() {
+        return dfe -> {
+            User user = checkUser(dfe, User.Role.normal);
+            SlotCopySave request = arg(dfe, "request", SlotCopySave.class);
+            logRequest("slotCopySave", user, request);
+            slotCopyRecordService.save(request);
+            return request;
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -135,6 +135,7 @@ public class GraphQLProvider {
                         .dataFetcher("analyserScanData", graphQLDataFetchers.analyserScanData())
                         .dataFetcher("runNames", graphQLDataFetchers.runNames())
                         .dataFetcher("labwareBioRiskCodes", graphQLDataFetchers.labwareBioRiskCodes())
+                        .dataFetcher("reloadSlotCopy", graphQLDataFetchers.reloadSlotCopy())
 
                         .dataFetcher("location", graphQLStore.getLocation())
                         .dataFetcher("stored", graphQLStore.getStored())
@@ -235,6 +236,7 @@ public class GraphQLProvider {
                         .dataFetcher("segmentation", transact(graphQLMutation.segmentation()))
                         .dataFetcher("cleanOut", transact(graphQLMutation.cleanOut()))
                         .dataFetcher("recordSampleMetrics", transact(graphQLMutation.recordSampleMetrics()))
+                        .dataFetcher("saveSlotCopy", transact(graphQLMutation.saveSlotCopy()))
 
                         .dataFetcher("addUser", transact(graphQLMutation.addUser()))
                         .dataFetcher("setUserRole", transact(graphQLMutation.setUserRole()))

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/slotcopyrecord/SlotCopyRecord.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/slotcopyrecord/SlotCopyRecord.java
@@ -1,0 +1,108 @@
+package uk.ac.sanger.sccp.stan.model.slotcopyrecord;
+
+import uk.ac.sanger.sccp.stan.model.OperationType;
+import uk.ac.sanger.sccp.stan.model.Work;
+import uk.ac.sanger.sccp.utils.BasicUtils;
+
+import javax.persistence.*;
+import java.util.*;
+
+/**
+ * A record of a saved slot copy request
+ * @author dr6
+ */
+@Entity
+public class SlotCopyRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    @ManyToOne
+    private OperationType operationType;
+    @ManyToOne
+    private Work work;
+    private String lpNumber;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "slot_copy_record_id", nullable = false)
+    private Set<SlotCopyRecordNote> notes = new HashSet<>();
+
+    // Required no-arg constructor
+    public SlotCopyRecord() {}
+
+    public SlotCopyRecord(OperationType operationType, Work work, String lpNumber) {
+        this.operationType = operationType;
+        this.work = work;
+        this.lpNumber = lpNumber;
+    }
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public OperationType getOperationType() {
+        return this.operationType;
+    }
+
+    public void setOperationType(OperationType operationType) {
+        this.operationType = operationType;
+    }
+
+    public Work getWork() {
+        return this.work;
+    }
+
+    public void setWork(Work work) {
+        this.work = work;
+    }
+    public String getLpNumber() {
+        return this.lpNumber;
+    }
+
+    public void setLpNumber(String lpNumber) {
+        this.lpNumber = lpNumber;
+    }
+
+    public Set<SlotCopyRecordNote> getNotes() {
+        return this.notes;
+    }
+
+    public void setNotes(Collection<SlotCopyRecordNote> notes) {
+        this.notes.clear();
+        if (notes != null) {
+            this.notes.addAll(notes);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SlotCopyRecord that = (SlotCopyRecord) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.operationType, that.operationType)
+                && Objects.equals(this.work, that.work)
+                && Objects.equals(this.lpNumber, that.lpNumber)
+                && Objects.equals(this.notes, that.notes)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return (id!=null ? id.hashCode() : Objects.hash(work, lpNumber));
+    }
+
+    @Override
+    public String toString() {
+        return BasicUtils.describe(this)
+                .add("id", id)
+                .add("operationType", operationType)
+                .add("work", work)
+                .add("lpNumber", lpNumber)
+                .add("notes", notes)
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/slotcopyrecord/SlotCopyRecordNote.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/slotcopyrecord/SlotCopyRecordNote.java
@@ -1,0 +1,98 @@
+package uk.ac.sanger.sccp.stan.model.slotcopyrecord;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
+
+/**
+ * A key/value with an index, linked to a slot copy record
+ * @author dr6
+ */
+@Entity
+@Table(name="slot_copy_record_note")
+public class SlotCopyRecordNote implements Comparable<SlotCopyRecordNote> {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+    private int valueIndex = 0;
+    private String value;
+
+    public SlotCopyRecordNote() {} // required
+
+    public SlotCopyRecordNote(String name, int valueIndex, String value) {
+        this.name = name;
+        this.valueIndex = valueIndex;
+        this.value = value;
+    }
+
+    public SlotCopyRecordNote(String name, String value) {
+        this(name, 0, value);
+    }
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getValueIndex() {
+        return this.valueIndex;
+    }
+
+    public void setValueIndex(int index) {
+        this.valueIndex = index;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SlotCopyRecordNote that = (SlotCopyRecordNote) o;
+        return (Objects.equals(this.id, that.id)
+                && Objects.equals(this.name, that.name)
+                && this.valueIndex == that.valueIndex
+                && Objects.equals(this.value, that.value));
+    }
+
+    @Override
+    public int hashCode() {
+        return id!=null ? id.hashCode() : Objects.hash(name, valueIndex, value);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[%s:%s=%s]", name, valueIndex, repr(value));
+    }
+
+    @Override
+    public int compareTo(@NotNull SlotCopyRecordNote o) {
+        int n = this.name.compareTo(o.name);
+        if (n != 0) {
+            return n;
+        }
+        return Integer.compare(this.valueIndex, o.valueIndex);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/SlotCopyRecordRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/SlotCopyRecordRepo.java
@@ -1,0 +1,12 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.springframework.data.repository.CrudRepository;
+import uk.ac.sanger.sccp.stan.model.OperationType;
+import uk.ac.sanger.sccp.stan.model.Work;
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecord;
+
+import java.util.Optional;
+
+public interface SlotCopyRecordRepo extends CrudRepository<SlotCopyRecord, Integer> {
+    Optional<SlotCopyRecord> findByOperationTypeAndWorkAndLpNumber(OperationType opType, Work work, String lpNumber);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/SlotCopyRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/SlotCopyRequest.java
@@ -155,6 +155,20 @@ public class SlotCopyRequest {
         public String toString() {
             return repr(barcode)+": "+labwareState;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SlotCopySource that = (SlotCopySource) o;
+            return (Objects.equals(this.barcode, that.barcode)
+                    && this.labwareState == that.labwareState);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(barcode, labwareState);
+        }
     }
 
     /**

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/SlotCopySave.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/SlotCopySave.java
@@ -1,0 +1,195 @@
+package uk.ac.sanger.sccp.stan.request;
+
+import uk.ac.sanger.sccp.stan.model.ExecutionType;
+import uk.ac.sanger.sccp.stan.model.SlideCosting;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyContent;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopySource;
+
+import java.util.List;
+import java.util.Objects;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.describe;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullToEmpty;
+
+/**
+ * Saved data for an incomplete slot copy operation
+ * @author dr6
+ */
+public class SlotCopySave {
+    private List<SlotCopySource> sources = List.of();
+    private String operationType;
+    private String workNumber;
+    private String lpNumber;
+    private ExecutionType executionType;
+    private String labwareType;
+    private String barcode;
+    private String bioState;
+    private SlideCosting costing;
+    private String lotNumber;
+    private String probeLotNumber;
+    private String preBarcode;
+    private List<SlotCopyContent> contents = List.of();
+
+    /** The source labware and their new labware states (if specified). */
+    public List<SlotCopySource> getSources() {
+        return this.sources;
+    }
+
+    public void setSources(List<SlotCopySource> sources) {
+        this.sources = nullToEmpty(sources);
+    }
+
+    /** The name of the type of operation being recorded to describe the contents being copied. */
+    public String getOperationType() {
+        return this.operationType;
+    }
+
+    public void setOperationType(String operationType) {
+        this.operationType = operationType;
+    }
+
+    /** An optional work number to associate with this operation. */
+    public String getWorkNumber() {
+        return this.workNumber;
+    }
+
+    public void setWorkNumber(String workNumber) {
+        this.workNumber = workNumber;
+    }
+
+    /** The LP number of the new labware, required. */
+    public String getLpNumber() {
+        return this.lpNumber;
+    }
+
+    public void setLpNumber(String lpNumber) {
+        this.lpNumber = lpNumber;
+    }
+
+    /** Whether the execution was automated or manual. */
+    public ExecutionType getExecutionType() {
+        return this.executionType;
+    }
+
+    public void setExecutionType(ExecutionType executionType) {
+        this.executionType = executionType;
+    }
+
+    /** The name of the type of the destination labware (if it is new labware). */
+    public String getLabwareType() {
+        return this.labwareType;
+    }
+
+    public void setLabwareType(String labwareType) {
+        this.labwareType = labwareType;
+    }
+
+    /** The barcode of the existing piece of labware. */
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    /** The bio state for samples in the destination (if specified). */
+    public String getBioState() {
+        return this.bioState;
+    }
+
+    public void setBioState(String bioState) {
+        this.bioState = bioState;
+    }
+
+    /** The costing of the slide, if specified. */
+    public SlideCosting getCosting() {
+        return this.costing;
+    }
+
+    public void setCosting(SlideCosting costing) {
+        this.costing = costing;
+    }
+
+    /** The lot number of the slide, if specified. */
+    public String getLotNumber() {
+        return this.lotNumber;
+    }
+
+    public void setLotNumber(String lotNumber) {
+        this.lotNumber = lotNumber;
+    }
+
+    /** The probe lot number of the slide, if specified. */
+    public String getProbeLotNumber() {
+        return this.probeLotNumber;
+    }
+
+    public void setProbeLotNumber(String probeLotNumber) {
+        this.probeLotNumber = probeLotNumber;
+    }
+
+    /** The barcode of the new labware, if it is prebarcoded. */
+    public String getPreBarcode() {
+        return this.preBarcode;
+    }
+
+    public void setPreBarcode(String preBarcode) {
+        this.preBarcode = preBarcode;
+    }
+
+    /** The specifications of which source slots are being copied into what addresses in the destination labware. */
+    public List<SlotCopyContent> getContents() {
+        return this.contents;
+    }
+
+    public void setContents(List<SlotCopyContent> contents) {
+        this.contents = nullToEmpty(contents);
+    }
+
+    @Override
+    public String toString() {
+        return describe(this)
+                .add("sources", sources)
+                .add("operationType", operationType)
+                .add("workNumber", workNumber)
+                .add("lpNumber", lpNumber)
+                .add("executionType", executionType)
+                .add("labwareType", labwareType)
+                .add("barcode", barcode)
+                .add("bioState", bioState)
+                .add("costing", costing)
+                .add("lotNumber", lotNumber)
+                .add("probeLotNumber", probeLotNumber)
+                .add("preBarcode", preBarcode)
+                .add("contents", contents)
+                .reprStringValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || o.getClass() != this.getClass()) return false;
+        SlotCopySave that = (SlotCopySave) o;
+        return (Objects.equals(this.sources, that.sources)
+                && Objects.equals(this.operationType, that.operationType)
+                && Objects.equals(this.workNumber, that.workNumber)
+                && Objects.equals(this.lpNumber, that.lpNumber)
+                && Objects.equals(this.executionType, that.executionType)
+                && Objects.equals(this.labwareType, that.labwareType)
+                && Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.bioState, that.bioState)
+                && Objects.equals(this.costing, that.costing)
+                && Objects.equals(this.lotNumber, that.lotNumber)
+                && Objects.equals(this.probeLotNumber, that.probeLotNumber)
+                && Objects.equals(this.preBarcode, that.preBarcode)
+                && Objects.equals(this.contents, that.contents)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(workNumber, lpNumber);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyRecordService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyRecordService.java
@@ -1,0 +1,15 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecord;
+import uk.ac.sanger.sccp.stan.request.SlotCopySave;
+
+import javax.persistence.EntityNotFoundException;
+
+/** Loads and saves {@link SlotCopyRecord}s */
+public interface SlotCopyRecordService {
+    /** Converts the given slot copy info to a record saved in the database */
+    SlotCopyRecord save(SlotCopySave request) throws ValidationException;
+
+    /** Looks up the indicated slot copy data from the database */
+    SlotCopySave load(String opname, String workNumber, String lpNumber) throws EntityNotFoundException;
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyRecordServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyRecordServiceImp.java
@@ -1,0 +1,259 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecord;
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecordNote;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyContent;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopySource;
+import uk.ac.sanger.sccp.stan.request.SlotCopySave;
+import uk.ac.sanger.sccp.utils.Zip;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.*;
+
+/**
+ * @author dr6
+ */
+@Service
+public class SlotCopyRecordServiceImp implements SlotCopyRecordService {
+    public static final String
+            NOTE_BARCODE = "barcode",
+            NOTE_LWTYPE = "labware type",
+            NOTE_PREBARCODE = "prebarcode",
+            NOTE_BIOSTATE = "bio state",
+            NOTE_COSTING = "costing",
+            NOTE_LOT = "lot",
+            NOTE_PROBELOT = "probe lot",
+            NOTE_EXECUTION = "execution",
+            NOTE_CON_SRCBC = "con source barcode",
+            NOTE_CON_SRCADDRESS = "con source address",
+            NOTE_CON_DESTADDRESS = "con dest address",
+            NOTE_SRC_BARCODE = "source barcode",
+            NOTE_SRC_STATE = "source state";
+
+    private final SlotCopyRecordRepo recordRepo;
+    private final OperationTypeRepo opTypeRepo;
+    private final WorkRepo workRepo;
+    private final EntityManager entityManager;
+
+    @Autowired
+    public SlotCopyRecordServiceImp(SlotCopyRecordRepo recordRepo, OperationTypeRepo opTypeRepo, WorkRepo workRepo, EntityManager entityManager) {
+        this.recordRepo = recordRepo;
+        this.opTypeRepo = opTypeRepo;
+        this.workRepo = workRepo;
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    public SlotCopyRecord save(SlotCopySave request) throws ValidationException {
+        Set<String> problems = new LinkedHashSet<>();
+        checkRequiredFields(problems, request);
+        if (!problems.isEmpty()) {
+            throw new ValidationException(problems);
+        }
+        Work work = workRepo.getByWorkNumber(request.getWorkNumber());
+        OperationType opType = opTypeRepo.getByName(request.getOperationType());
+        Optional<SlotCopyRecord> oldRecordOpt = recordRepo.findByOperationTypeAndWorkAndLpNumber(opType, work, request.getLpNumber());
+        if (oldRecordOpt.isPresent()) {
+            recordRepo.delete(oldRecordOpt.get());
+            entityManager.flush();
+        }
+
+        SlotCopyRecord record = new SlotCopyRecord();
+        record.setOperationType(opType);
+        record.setWork(work);
+        record.setLpNumber(request.getLpNumber());
+        record.setNotes(createNotes(request));
+
+        return recordRepo.save(record);
+    }
+
+    @Override
+    public SlotCopySave load(String opname, String workNumber, String lpNumber) throws EntityNotFoundException {
+        OperationType opType = opTypeRepo.getByName(opname);
+        Work work = workRepo.getByWorkNumber(workNumber);
+        lpNumber = trimAndRequire(lpNumber, "LP number not supplied.");
+        SlotCopyRecord record = recordRepo.findByOperationTypeAndWorkAndLpNumber(opType, work, lpNumber).orElse(null);
+        if (record==null) {
+            throw new EntityNotFoundException("No such record found.");
+        }
+        return reassembleSave(record);
+    }
+
+    /** Constructs slot copy save data from a slot copy record */
+    SlotCopySave reassembleSave(SlotCopyRecord record) {
+        Map<String, List<String>> noteMap = loadNoteMap(record.getNotes());
+        SlotCopySave save = new SlotCopySave();
+        save.setLpNumber(record.getLpNumber());
+        save.setWorkNumber(record.getWork().getWorkNumber());
+        save.setOperationType(record.getOperationType().getName());
+        save.setBarcode(singleNoteValue(noteMap, NOTE_BARCODE));
+        save.setLabwareType(singleNoteValue(noteMap, NOTE_LWTYPE));
+        save.setPreBarcode(singleNoteValue(noteMap, NOTE_PREBARCODE));
+        save.setBioState(singleNoteValue(noteMap, NOTE_BIOSTATE));
+        save.setCosting(nullableValueOf(singleNoteValue(noteMap, NOTE_COSTING), SlideCosting::valueOf));
+        save.setLotNumber(singleNoteValue(noteMap, NOTE_LOT));
+        save.setProbeLotNumber(singleNoteValue(noteMap, NOTE_PROBELOT));
+        save.setExecutionType(nullableValueOf(singleNoteValue(noteMap, NOTE_EXECUTION), ExecutionType::valueOf));
+        List<String> sourceBarcodes = noteMap.get(NOTE_SRC_BARCODE);
+        List<String> sourceStates = noteMap.get(NOTE_SRC_STATE);
+        save.setSources(Zip.map(sourceBarcodes.stream(), sourceStates.stream(),
+                (bc, state) -> new SlotCopySource(bc, nullableValueOf(state, Labware.State::valueOf))
+        ).toList());
+        List<String> contentSourceBarcodes = noteMap.get(NOTE_CON_SRCBC);
+        List<String> contentSourceAddress = noteMap.get(NOTE_CON_SRCADDRESS);
+        List<String> contentDestAddress = noteMap.get(NOTE_CON_DESTADDRESS);
+        save.setContents(IntStream.range(0, contentSourceBarcodes.size()).mapToObj(
+                i -> new SlotCopyContent(contentSourceBarcodes.get(i),
+                        nullableValueOf(contentSourceAddress.get(i), Address::valueOf),
+                        nullableValueOf(contentDestAddress.get(i), Address::valueOf))
+        ).toList());
+        return save;
+    }
+
+    /**
+     * Returns null of the given string is null or empty; otherwise uses the given function to convert it.
+     * @param string string value
+     * @param function function to convert the string
+     * @return the value converted into; or null if the string is null or empty
+     * @param <E> the type of value the string is converted into
+     */
+    static <E> E nullableValueOf(String string, Function<String, E> function) {
+        if (nullOrEmpty(string)) {
+            return null;
+        }
+        return function.apply(string);
+    }
+
+    /**
+     * Trims the given string; adds a problem if it is null or empty
+     * @param problems receptacle for problems
+     * @param name the name of the field
+     * @param value the value of the field
+     * @return the trimmed value of the string; null if the string is empty
+     */
+    String trimAndCheck(Collection<String> problems, String name, String value) {
+        value = trimToNull(value);
+        if (value==null) {
+            problems.add("Missing "+name+".");
+        }
+        return value;
+    }
+
+    /**
+     * Checks required fields are present
+     * @param problems receptacle for problems
+     * @param request request to validate
+     */
+    void checkRequiredFields(Collection<String> problems, SlotCopySave request) {
+        request.setOperationType(trimAndCheck(problems, "operation type", request.getOperationType()));
+        request.setWorkNumber(trimAndCheck(problems, "work number", request.getWorkNumber()));
+        request.setLpNumber(trimAndCheck(problems, "LP number", request.getLpNumber()));
+    }
+
+    /**
+     * Adds a note to the given list of notes, if the given value is non-null and nonempty
+     * @param notes list to add note
+     * @param name name of note
+     * @param value value of note
+     */
+    void mayAddNote(List<SlotCopyRecordNote> notes, String name, String value) {
+        mayAddNote(notes, name, 0, value);
+    }
+
+    /**
+     * Adds a note to the given list of notes, if the given value is non-null and nonempty
+     * @param notes list to add note
+     * @param name name of note
+     * @param index index of note to add
+     * @param value value of note
+     */
+    void mayAddNote(List<SlotCopyRecordNote> notes, String name, int index, String value) {
+        value = trimToNull(value);
+        if (value != null) {
+            notes.add(new SlotCopyRecordNote(name, index, value));
+        }
+    }
+
+    /**
+     * Compiles a list of notes for the details of the request
+     * @param request the request to describe
+     * @return a list of notes describing details of the request
+     */
+    List<SlotCopyRecordNote> createNotes(SlotCopySave request) {
+        List<SlotCopyRecordNote> notes = new ArrayList<>();
+        mayAddNote(notes, NOTE_BARCODE, request.getBarcode());
+        mayAddNote(notes, NOTE_LWTYPE, request.getLabwareType());
+        mayAddNote(notes, NOTE_PREBARCODE, request.getPreBarcode());
+        mayAddNote(notes, NOTE_BIOSTATE, request.getBioState());
+        mayAddNote(notes, NOTE_LOT, request.getLotNumber());
+        mayAddNote(notes, NOTE_PROBELOT, request.getProbeLotNumber());
+        if (request.getExecutionType()!=null) {
+            notes.add(new SlotCopyRecordNote(NOTE_EXECUTION, request.getExecutionType().name()));
+        }
+        if (request.getCosting()!=null) {
+            notes.add(new SlotCopyRecordNote(NOTE_COSTING, request.getCosting().name()));
+        }
+
+        for (int i = 0; i < request.getSources().size(); ++i) {
+            SlotCopySource source = request.getSources().get(i);
+            mayAddNote(notes, NOTE_SRC_BARCODE, i, source.getBarcode());
+            if (source.getLabwareState()!=null) {
+                notes.add(new SlotCopyRecordNote(NOTE_SRC_STATE, i, source.getLabwareState().name()));
+            }
+        }
+        for (int i = 0; i < request.getContents().size(); ++i) {
+            SlotCopyContent content = request.getContents().get(i);
+            mayAddNote(notes, NOTE_CON_SRCBC, i, content.getSourceBarcode());
+            if (content.getSourceAddress()!=null) {
+                notes.add(new SlotCopyRecordNote(NOTE_CON_SRCADDRESS, i, content.getSourceAddress().toString()));
+            }
+            if (content.getDestinationAddress()!=null) {
+                notes.add(new SlotCopyRecordNote(NOTE_CON_DESTADDRESS, i, content.getDestinationAddress().toString()));
+            }
+        }
+        return notes;
+    }
+
+    /**
+     * Loads given note values into a map
+     * @param notes notes to load
+     * @return a map of note name to list of values
+     */
+    Map<String, List<String>> loadNoteMap(Collection<SlotCopyRecordNote> notes) {
+        Map<String, List<String>> map = new HashMap<>();
+        notes = notes.stream()
+                .sorted(Comparator.naturalOrder())
+                .toList();
+        for (SlotCopyRecordNote note : notes) {
+            List<String> list = map.computeIfAbsent(note.getName(), k -> new ArrayList<>());
+            while (list.size() <= note.getValueIndex()) {
+                list.add(null);
+            }
+            list.set(note.getValueIndex(), note.getValue());
+        }
+        return map;
+    }
+
+    /**
+     * Gets the single named value from the given map of notes
+     * @param noteMap map of names to note values
+     * @param key name of the note
+     * @return the value of the note; or null of it is missing or empty
+     */
+    String singleNoteValue(Map<String, List<String>> noteMap, String key) {
+        List<String> values = noteMap.get(key);
+        if (nullOrEmpty(values)) {
+            return null;
+        }
+        return values.getFirst();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyRecordServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/SlotCopyRecordServiceImp.java
@@ -105,17 +105,21 @@ public class SlotCopyRecordServiceImp implements SlotCopyRecordService {
         save.setExecutionType(nullableValueOf(singleNoteValue(noteMap, NOTE_EXECUTION), ExecutionType::valueOf));
         List<String> sourceBarcodes = noteMap.get(NOTE_SRC_BARCODE);
         List<String> sourceStates = noteMap.get(NOTE_SRC_STATE);
-        save.setSources(Zip.map(sourceBarcodes.stream(), sourceStates.stream(),
-                (bc, state) -> new SlotCopySource(bc, nullableValueOf(state, Labware.State::valueOf))
-        ).toList());
+        if (!nullOrEmpty(sourceBarcodes) && !nullOrEmpty(sourceStates)) {
+            save.setSources(Zip.map(sourceBarcodes.stream(), sourceStates.stream(),
+                    (bc, state) -> new SlotCopySource(bc, nullableValueOf(state, Labware.State::valueOf))
+            ).toList());
+        }
         List<String> contentSourceBarcodes = noteMap.get(NOTE_CON_SRCBC);
         List<String> contentSourceAddress = noteMap.get(NOTE_CON_SRCADDRESS);
         List<String> contentDestAddress = noteMap.get(NOTE_CON_DESTADDRESS);
-        save.setContents(IntStream.range(0, contentSourceBarcodes.size()).mapToObj(
-                i -> new SlotCopyContent(contentSourceBarcodes.get(i),
-                        nullableValueOf(contentSourceAddress.get(i), Address::valueOf),
-                        nullableValueOf(contentDestAddress.get(i), Address::valueOf))
-        ).toList());
+        if (!nullOrEmpty(contentSourceBarcodes)) {
+            save.setContents(IntStream.range(0, contentSourceBarcodes.size()).mapToObj(
+                    i -> new SlotCopyContent(contentSourceBarcodes.get(i),
+                            nullableValueOf(contentSourceAddress.get(i), Address::valueOf),
+                            nullableValueOf(contentDestAddress.get(i), Address::valueOf))
+            ).toList());
+        }
         return save;
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -531,6 +531,15 @@ public class BasicUtils {
     }
 
     /**
+     * Returns the given string trimmed, and null if the trimmed string is empty
+     * @param string the given string, or null
+     * @return the trimmed non-empty string, or null
+     */
+    public static String trimToNull(String string) {
+        return (string==null ? null : emptyToNull(string.trim()));
+    }
+
+    /**
      * If the given list is non-null, it is returned. Otherwise, returns the immutable empty list.
      * @param list list or null
      * @return a non-null list

--- a/src/main/resources/db/changelog/changelog-3.30.xml
+++ b/src/main/resources/db/changelog/changelog-3.30.xml
@@ -49,7 +49,7 @@
             <column name="value_index" type="INT UNSIGNED" defaultValueNumeric="0">
                 <constraints nullable="false"/>
             </column>
-            <column name="value" type="VARCHAR(20)">
+            <column name="value" type="VARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
             <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">

--- a/src/main/resources/db/changelog/changelog-3.30.xml
+++ b/src/main/resources/db/changelog/changelog-3.30.xml
@@ -1,0 +1,68 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="3.3.0" author="dr6">
+        <createTable tableName="slot_copy_record">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="operation_type_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_slot_copy_record_operation_type" referencedTableName="operation_type" referencedColumnNames="id"/>
+            </column>
+            <column name="work_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_slot_copy_record_work" referencedTableName="work" referencedColumnNames="id"/>
+            </column>
+            <column name="lp_number" type="VARCHAR(10)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="slot_copy_record" indexName="uk_slot_copy_record_operation_type_work_lp" unique="true">
+            <column name="operation_type_id"/>
+            <column name="work_id"/>
+            <column name="lp_number"/>
+        </createIndex>
+        <rollback>
+            <dropAllForeignKeyConstraints baseTableName="slot_copy_record"/>
+            <dropTable tableName="slot_copy_record"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="3.3.1" author="dr6">
+        <createTable tableName="slot_copy_record_note">
+            <column name="id" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="slot_copy_record_id" type="INT">
+                <constraints nullable="false" foreignKeyName="fk_slot_copy_record_note_slot_copy_record" referencedTableName="slot_copy_record" referencedColumnNames="id"/>
+            </column>
+            <column name="name" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_index" type="INT UNSIGNED" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated" type="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <rollback>
+            <dropAllForeignKeyConstraints baseTableName="slot_copy_record_note"/>
+            <dropTable tableName="slot_copy_record_note"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -32,4 +32,5 @@
     <include relativeToChangelogFile="true" file="changelog-2.45.xml"/>
     <include relativeToChangelogFile="true" file="changelog-3.00.xml"/>
     <include relativeToChangelogFile="true" file="changelog-3.01.xml"/>
+    <include relativeToChangelogFile="true" file="changelog-3.30.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -637,6 +637,84 @@ input SlotCopyRequest {
     executionType: ExecutionType
 }
 
+"""Saved data for an incomplete slot copy operation."""
+input SlotCopySave {
+    """The source labware and their new labware states (if specified)."""
+    sources: [SlotCopySource!]!
+    """The name of the type of operation being recorded to describe the contents being copied."""
+    operationType: String!
+    """An optional work number to associate with this operation."""
+    workNumber: String!
+    """The LP number of the new labware, required."""
+    lpNumber: String!
+    """Whether the execution was automated or manual."""
+    executionType: ExecutionType
+    """The name of the type of the destination labware (if it is new labware)."""
+    labwareType: String
+    """The barcode of the existing piece of labware."""
+    barcode: String
+    """The bio state for samples in the destination (if specified)."""
+    bioState: String
+    """The costing of the slide, if specified."""
+    costing: SlideCosting
+    """The lot number of the slide, if specified."""
+    lotNumber: String
+    """The probe lot number of the slide, if specified."""
+    probeLotNumber: String
+    """The barcode of the new labware, if it is prebarcoded."""
+    preBarcode: String
+    """The specifications of which source slots are being copied into what addresses in the destination labware."""
+    contents: [SlotCopyContent!]!
+}
+
+"""Loaded data about a source labware for an incomplete slot copy operation."""
+type SlotCopyLoadSource {
+    """The barcode of the source."""
+    barcode: String!
+    """The new labware state of the source."""
+    labwareState: LabwareState!
+}
+
+"""Loaded data about a transfer in an incomplete slot copy operation."""
+type SlotCopyLoadContent {
+    """The barcode of the source labware."""
+    sourceBarcode: String!
+    """The address of the source slot in its labware."""
+    sourceAddress: Address!
+    """The address of the destination slot."""
+    destinationAddress: Address!
+}
+
+"""Loaded data for an incomplete slot copy operation."""
+type SlotCopyLoad {
+    """The source labware and their new labware states (if specified)."""
+    sources: [SlotCopyLoadSource!]!
+    """The name of the type of operation being recorded to describe the contents being copied."""
+    operationType: String!
+    """An optional work number to associate with this operation."""
+    workNumber: String!
+    """The LP number of the new labware, required."""
+    lpNumber: String!
+    """Whether the execution was automated or manual."""
+    executionType: ExecutionType
+    """The name of the type of the destination labware (if it is new labware)."""
+    labwareType: String
+    """The barcode of the existing piece of labware."""
+    barcode: String
+    """The bio state for samples in the destination (if specified)."""
+    bioState: String
+    """The costing of the slide, if specified."""
+    costing: SlideCosting
+    """The lot number of the slide, if specified."""
+    lotNumber: String
+    """The probe lot number of the slide, if specified."""
+    probeLotNumber: String
+    """The barcode of the new labware, if it is prebarcoded."""
+    preBarcode: String
+    """The specifications of which source slots are being copied into what addresses in the destination labware."""
+    contents: [SlotCopyLoadContent!]!
+}
+
 """A request to record an operation in place."""
 input InPlaceOpRequest {
     """The name of the type of operation being recorded."""
@@ -2143,6 +2221,8 @@ type Query {
     runNames(barcode: String!): [String!]!
     """Bio risk codes for samples in the specified labware."""
     labwareBioRiskCodes(barcode: String!): [SampleBioRisk!]!
+    """Reloads saved slot copy information."""
+    reloadSlotCopy(operationType: String!, workNumber: String!, lpNumber: String!): SlotCopyLoad
 
     """Get the specified storage location."""
     location(locationBarcode: String!): Location!
@@ -2343,6 +2423,8 @@ type Mutation {
     cleanOut(request: CleanOutRequest!) : OperationResult!
     """Record metrics."""
     recordSampleMetrics(request: SampleMetricsRequest!): OperationResult!
+    """Save slot copy information for a future operation."""
+    saveSlotCopy(request: SlotCopySave!): SlotCopyLoad!
 
     """Create a new user for the application."""
     addUser(username: String!): User!

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestSaveSlotCopyMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestSaveSlotCopyMutation.java
@@ -1,0 +1,86 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.model.*;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+
+/**
+ * Tests save/resume slot copy
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestSaveSlotCopyMutation {
+    @Autowired
+    private GraphQLTester tester;
+    @Autowired
+    private EntityCreator entityCreator;
+
+    @Test
+    @Transactional
+    public void testSlotCopySave() throws Exception {
+        User user = entityCreator.createUser("user1");
+        Work work = entityCreator.createWork(null, null, null, null, null);
+        OperationType opType = entityCreator.createOpType("opname", null);
+        tester.setUser(user);
+        String mutation = tester.readGraphQL("saveslotcopy.graphql").replace("[WORK]", work.getWorkNumber());
+
+        Object response = tester.post(mutation);
+        Map<String, String> data = chainGet(response, "data", "saveSlotCopy");
+        assertEquals("STAN-A", data.get("barcode"));
+        assertEquals(opType.getName(), data.get("operationType"));
+        assertEquals(work.getWorkNumber(), data.get("workNumber"));
+        assertEquals("LP1", data.get("lpNumber"));
+
+        String query = tester.readGraphQL("reloadslotcopy.graphql").replace("[WORK]", work.getWorkNumber());
+
+        response = tester.post(query);
+        data = chainGet(response, "data", "reloadSlotCopy");
+        assertEquals(opType.getName(), data.get("operationType"));
+        assertEquals("STAN-A", data.get("barcode"));
+        assertEquals(work.getWorkNumber(), data.get("workNumber"));
+        assertEquals("LP1", data.get("lpNumber"));
+        assertEquals("manual", data.get("executionType"));
+        assertEquals("pb1", data.get("preBarcode"));
+        assertEquals("lt1", data.get("labwareType"));
+        assertEquals("lot1", data.get("lotNumber"));
+        assertEquals("probe1", data.get("probeLotNumber"));
+        assertEquals("bs", data.get("bioState"));
+        assertEquals("SGP", data.get("costing"));
+        List<Map<String, ?>> sourceData = chainGet(data, "sources");
+        List<Map<String, ?>> contentData = chainGet(data, "contents");
+        assertThat(sourceData).containsExactly(Map.of("barcode", "STAN-0", "labwareState", "active"));
+        assertThat(contentData).containsExactly(
+                Map.of("sourceBarcode", "STAN-0", "sourceAddress", "A2", "destinationAddress", "A1"),
+                Map.of("sourceBarcode", "STAN-1", "sourceAddress", "A1", "destinationAddress", "A2")
+        );
+
+        // Replace the save with a new save
+        mutation = mutation.replace("pb1", "pb2").replace("costing: SGP", "costing: Faculty")
+                .replace("manual", "automated");
+        response = tester.post(mutation);
+        assertEquals("STAN-A", chainGet(response, "data", "saveSlotCopy", "barcode"));
+        response = tester.post(query);
+
+        data = chainGet(response, "data", "reloadSlotCopy");
+        assertEquals("pb2", data.get("preBarcode"));
+        assertEquals("automated", data.get("executionType"));
+        assertEquals("Faculty", data.get("costing"));
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestSlotCopyRecordRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestSlotCopyRecordRepo.java
@@ -1,0 +1,117 @@
+package uk.ac.sanger.sccp.stan.repo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.model.OperationType;
+import uk.ac.sanger.sccp.stan.model.Work;
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecord;
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecordNote;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests {@link SlotCopyRecordRepo}
+ * @author dr6
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@Import(EntityCreator.class)
+class TestSlotCopyRecordRepo {
+    @Autowired
+    private SlotCopyRecordRepo repo;
+    @Autowired
+    private EntityCreator entityCreator;
+    @Autowired
+    private EntityManager entityManager;
+
+    private OperationType opType;
+    private Work work;
+
+    @BeforeEach
+    void setup() {
+        opType = entityCreator.createOpType("opname", null);
+        work = entityCreator.createWork(null, null, null, null, null);
+    }
+
+    @Test
+    @Transactional
+    void testSlotCopyRecord_minimal() {
+        SlotCopyRecord record = new SlotCopyRecord(opType, work, "LP1");
+        record = repo.save(record);
+        assertNotNull(record);
+        assertNotNull(record.getId());
+        SlotCopyRecord loaded = repo.findByOperationTypeAndWorkAndLpNumber(opType, work, record.getLpNumber()).orElseThrow();
+        assertNotNull(loaded);
+        assertEquals(opType, loaded.getOperationType());
+        assertEquals(work, loaded.getWork());
+        assertEquals(loaded.getId(), record.getId());
+        assertThat(loaded.getNotes()).isEmpty();
+    }
+
+    @Transactional
+    @Test
+    void testSlotCopyRecord_maximal() {
+        SlotCopyRecord record = new SlotCopyRecord(opType, work, "LP1");
+        record.setNotes(List.of(new SlotCopyRecordNote("Alpha", "Alabama"),
+                new SlotCopyRecordNote("Beta", 3, "Banana")));
+
+        record = repo.save(record);
+        SlotCopyRecord loaded = repo.findByOperationTypeAndWorkAndLpNumber(opType, work, record.getLpNumber()).orElseThrow();
+        entityManager.refresh(loaded);
+        assertNotNull(loaded);
+        assertEquals(opType, loaded.getOperationType());
+        assertEquals(work, loaded.getWork());
+        assertEquals("LP1", loaded.getLpNumber());
+
+        assertThat(loaded.getNotes()).hasSize(2);
+        List<SlotCopyRecordNote> notes = loaded.getNotes().stream()
+                .sorted(Comparator.naturalOrder())
+                .toList();
+        for (int i = 0; i < notes.size(); i++) {
+            SlotCopyRecordNote note = notes.get(i);
+            assertEquals(i==0 ? "Alpha" : "Beta", note.getName());
+            assertEquals(i==0 ? "Alabama" : "Banana", note.getValue());
+            assertEquals(i==0 ? 0 : 3, note.getValueIndex());
+        }
+    }
+
+    @Transactional
+    @Test
+    void testUpdate() {
+        SlotCopyRecord record = new SlotCopyRecord(opType, work, "LP1");
+        record.setNotes(List.of(new SlotCopyRecordNote("Alpha", 0, "Alpha0"),
+                new SlotCopyRecordNote("Alpha", 1, "Alpha1"),
+                new SlotCopyRecordNote("Beta", "Banana")));
+        record = repo.save(record);
+
+        entityManager.flush();
+
+        Integer id = record.getId();
+
+        record = repo.findById(id).orElseThrow();
+        record.setNotes(List.of(new SlotCopyRecordNote("Alpha", 0, "Alabama")));
+
+        repo.save(record);
+
+        entityManager.flush();
+        entityManager.refresh(record);
+        assertThat(record.getNotes()).hasSize(1);
+        SlotCopyRecordNote note = record.getNotes().iterator().next();
+        assertNotNull(note.getId());
+        assertEquals("Alpha", note.getName());
+        assertEquals(0, note.getValueIndex());
+        assertEquals("Alabama", note.getValue());
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestTagLayoutRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestTagLayoutRepo.java
@@ -5,10 +5,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
-import uk.ac.sanger.sccp.stan.EntityCreator;
 import uk.ac.sanger.sccp.stan.model.Address;
 import uk.ac.sanger.sccp.stan.model.reagentplate.ReagentPlate;
 import uk.ac.sanger.sccp.stan.model.taglayout.TagHeading;
@@ -30,18 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @Sql("/testdata/tag_layout_test.sql")
-@Import(EntityCreator.class)
 public class TestTagLayoutRepo {
     @Autowired
     TagLayoutRepo tagLayoutRepo;
-    @Autowired
-    LabwareTypeRepo lwTypeRepo;
-    @Autowired
-    OperationRepo opRepo;
-    @Autowired
-    ReagentPlateRepo reagentPlateRepo;
-    @Autowired
-    EntityCreator entityCreator;
 
     @Test
     @Transactional

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestSlotCopyRecordService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestSlotCopyRecordService.java
@@ -1,0 +1,324 @@
+package uk.ac.sanger.sccp.stan.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecord;
+import uk.ac.sanger.sccp.stan.model.slotcopyrecord.SlotCopyRecordNote;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopyContent;
+import uk.ac.sanger.sccp.stan.request.SlotCopyRequest.SlotCopySource;
+import uk.ac.sanger.sccp.stan.request.SlotCopySave;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static uk.ac.sanger.sccp.stan.Matchers.addProblem;
+import static uk.ac.sanger.sccp.stan.Matchers.assertValidationException;
+import static uk.ac.sanger.sccp.stan.service.SlotCopyRecordServiceImp.*;
+
+/**
+ * Test {@link SlotCopyRecordServiceImp}
+ */
+class TestSlotCopyRecordService {
+    @Mock
+    private SlotCopyRecordRepo mockRecordRepo;
+    @Mock
+    private OperationTypeRepo mockOpTypeRepo;
+    @Mock
+    private WorkRepo mockWorkRepo;
+    @Mock
+    private EntityManager mockEntityManager;
+
+    @InjectMocks
+    private SlotCopyRecordServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={true, false})
+    void testSave(boolean exists) {
+        Work work = EntityFactory.makeWork("SGP1");
+        when(mockWorkRepo.getByWorkNumber(work.getWorkNumber())).thenReturn(work);
+        OperationType opType = EntityFactory.makeOperationType("opname", null);
+        when(mockOpTypeRepo.getByName(opType.getName())).thenReturn(opType);
+        SlotCopySave save = new SlotCopySave();
+        save.setOperationType(opType.getName());
+        save.setWorkNumber(work.getWorkNumber());
+        final String LP = "LP1";
+        save.setLpNumber(LP);
+
+        doNothing().when(service).checkRequiredFields(any(), any());
+
+        SlotCopyRecord existing;
+        if (exists) {
+            existing = new SlotCopyRecord();
+            existing.setLpNumber(LP);
+            existing.setOperationType(opType);
+            existing.setWork(work);
+            existing.setId(700);
+            when(mockRecordRepo.findByOperationTypeAndWorkAndLpNumber(any(), any(), any())).thenReturn(Optional.of(existing));
+        } else {
+            existing = null;
+            when(mockRecordRepo.findByOperationTypeAndWorkAndLpNumber(any(), any(), any())).thenReturn(Optional.empty());
+        }
+        List<SlotCopyRecordNote> notes = List.of(new SlotCopyRecordNote("Alpha", "Beta"));
+        doReturn(notes).when(service).createNotes(any());
+        when(mockRecordRepo.save(any())).then(invocation -> {
+            SlotCopyRecord record = invocation.getArgument(0);
+            record.setId(800);
+            return record;
+        });
+
+        SlotCopyRecord record = service.save(save);
+
+        verify(service).checkRequiredFields(any(), same(save));
+        verify(mockWorkRepo).getByWorkNumber(work.getWorkNumber());
+        verify(mockOpTypeRepo).getByName(opType.getName());
+        verify(mockRecordRepo).findByOperationTypeAndWorkAndLpNumber(opType, work, LP);
+
+        if (exists) {
+            verify(mockRecordRepo).delete(existing);
+            verify(mockEntityManager).flush();
+        } else {
+            verify(mockRecordRepo, never()).delete(any());
+        }
+
+        assertNotNull(record.getId());
+        assertEquals(opType, record.getOperationType());
+        assertEquals(work, record.getWork());
+        assertEquals(LP, record.getLpNumber());
+        assertThat(record.getNotes()).containsExactlyInAnyOrderElementsOf(notes);
+        verify(mockRecordRepo).save(record);
+    }
+
+    @Test
+    void testSave_invalid() {
+        SlotCopySave save = new SlotCopySave();
+        doAnswer(addProblem("Bad stuff")).when(service).checkRequiredFields(any(), any());
+        assertValidationException(() -> service.save(save), List.of("Bad stuff"));
+        verifyNoMoreInteractions(mockRecordRepo);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans={true, false})
+    void testLoad(boolean found) {
+        Work work = EntityFactory.makeWork("SGP1");
+        when(mockWorkRepo.getByWorkNumber(work.getWorkNumber())).thenReturn(work);
+        OperationType opType = EntityFactory.makeOperationType("opname", null);
+        when(mockOpTypeRepo.getByName(opType.getName())).thenReturn(opType);
+        String LP = "LP1";
+        SlotCopyRecord record;
+        SlotCopySave save;
+        if (found) {
+            record = new SlotCopyRecord();
+            record.setId(500);
+            save = new SlotCopySave();
+            save.setOperationType(opType.getName());
+            doReturn(save).when(service).reassembleSave(any());
+        } else {
+            record = null;
+            save = null;
+        }
+        when(mockRecordRepo.findByOperationTypeAndWorkAndLpNumber(any(), any(), any())).thenReturn(Optional.ofNullable(record));
+
+        if (found) {
+            assertSame(save, service.load(opType.getName(), work.getWorkNumber(), LP));
+            verify(service).reassembleSave(record);
+        } else {
+            assertThrows(EntityNotFoundException.class, () -> service.load(opType.getName(), work.getWorkNumber(), LP));
+            verify(service, never()).reassembleSave(any());
+        }
+        verify(mockRecordRepo).findByOperationTypeAndWorkAndLpNumber(opType, work, LP);
+    }
+
+    @Test
+    void testReassembleSave() {
+        SlotCopyRecord record = new SlotCopyRecord();
+        Work work = EntityFactory.makeWork("SGP1");
+        OperationType opType = EntityFactory.makeOperationType("opname", null);
+        record.setWork(work);
+        record.setOperationType(opType);
+        record.setLpNumber("LP1");
+        record.setNotes(List.of(
+                new SlotCopyRecordNote(NOTE_BARCODE, "STAN-A"),
+                new SlotCopyRecordNote(NOTE_LWTYPE, "lwtype"),
+                new SlotCopyRecordNote(NOTE_PREBARCODE, "pb"),
+                new SlotCopyRecordNote(NOTE_BIOSTATE, "bs"),
+                new SlotCopyRecordNote(NOTE_COSTING, "SGP"),
+                new SlotCopyRecordNote(NOTE_LOT, "lot1"),
+                new SlotCopyRecordNote(NOTE_PROBELOT, "probe1"),
+                new SlotCopyRecordNote(NOTE_EXECUTION, "manual"),
+                new SlotCopyRecordNote(NOTE_SRC_BARCODE, 0, "STAN-0"),
+                new SlotCopyRecordNote(NOTE_SRC_STATE, 0, "discarded"),
+                new SlotCopyRecordNote(NOTE_SRC_BARCODE, 1, "STAN-1"),
+                new SlotCopyRecordNote(NOTE_SRC_STATE, 1, "active"),
+                new SlotCopyRecordNote(NOTE_CON_SRCBC, 0,"STAN-0"),
+                new SlotCopyRecordNote(NOTE_CON_SRCADDRESS, 0, "A1"),
+                new SlotCopyRecordNote(NOTE_CON_DESTADDRESS, 0, "A2"),
+                new SlotCopyRecordNote(NOTE_CON_SRCBC, 1, "STAN-1"),
+                new SlotCopyRecordNote(NOTE_CON_SRCADDRESS, 1, "B1"),
+                new SlotCopyRecordNote(NOTE_CON_DESTADDRESS, 1, "B2")
+        ));
+        SlotCopySave save = service.reassembleSave(record);
+
+        assertEquals("SGP1", save.getWorkNumber());
+        assertEquals("opname", save.getOperationType());
+        assertEquals("LP1", save.getLpNumber());
+        assertEquals("STAN-A", save.getBarcode());
+        assertEquals("lwtype", save.getLabwareType());
+        assertEquals("pb", save.getPreBarcode());
+        assertEquals("bs", save.getBioState());
+        assertEquals(SlideCosting.SGP, save.getCosting());
+        assertEquals("lot1", save.getLotNumber());
+        assertEquals("probe1", save.getProbeLotNumber());
+        assertEquals(ExecutionType.manual, save.getExecutionType());
+        assertThat(save.getSources()).containsExactlyInAnyOrder(new SlotCopySource("STAN-0", Labware.State.discarded),
+                new SlotCopySource("STAN-1", Labware.State.active));
+        assertThat(save.getContents()).containsExactlyInAnyOrder(new SlotCopyContent("STAN-0", new Address(1,1), new Address(1,2)),
+                new SlotCopyContent("STAN-1", new Address(2,1), new Address(2,2)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({",","'',", "'1',1"})
+    void testNullableValueOf(String string, Integer expected) {
+        assertEquals(expected, nullableValueOf(string, Integer::valueOf));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"'  Alpha  ',Alpha", "Beta,Beta", ",", "'   ',"})
+    void testTrimAndCheck(String string, String expected) {
+        List<String> problems = new ArrayList<>(expected==null ? 1 : 0);
+        assertEquals(expected, service.trimAndCheck(problems, "thing", string));
+        if (expected==null) {
+            assertThat(problems).containsExactly("Missing thing.");
+        } else {
+            assertThat(problems).isEmpty();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true,true,true", "false,true,true", "true,false,true", "true,true,false", "false,false,false"})
+    void testCheckRequiredFields(boolean workPresent, boolean opTypePresent, boolean lpPresent) {
+        SlotCopySave request = new SlotCopySave();
+        request.setWorkNumber(workPresent ? "  SGP1 " : null);
+        request.setOperationType(opTypePresent ? "  opname " : "");
+        request.setLpNumber(lpPresent ? "  LP1 " : "   ");
+        List<String> problems = new ArrayList<>();
+        service.checkRequiredFields(problems, request);
+        assertEquals(workPresent ? "SGP1":null, request.getWorkNumber());
+        assertEquals(opTypePresent ? "opname" : null, request.getOperationType());
+        assertEquals(lpPresent ? "LP1" : null, request.getLpNumber());
+
+        if (workPresent && opTypePresent && lpPresent) {
+            assertThat(problems).isEmpty();
+        }
+        if (!workPresent) {
+            assertThat(problems).contains("Missing work number.");
+        }
+        if (!opTypePresent) {
+            assertThat(problems).contains("Missing operation type.");
+        }
+        if (!lpPresent) {
+            assertThat(problems).contains("Missing LP number.");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false,true})
+    void testMayAddNote(boolean valuePresent) {
+        List<SlotCopyRecordNote> notes = new ArrayList<>();
+        service.mayAddNote(notes, "name", valuePresent ? "value" : null);
+        if (valuePresent) {
+            assertThat(notes).containsExactly(new SlotCopyRecordNote("name", "value"));
+        } else {
+            assertThat(notes).isEmpty();
+        }
+    }
+
+    @Test
+    void testCreateNotes() {
+        SlotCopySave request = new SlotCopySave();
+        request.setOperationType("opname");
+        request.setWorkNumber("SGP1");
+        request.setLpNumber("LP1");
+        request.setCosting(SlideCosting.Faculty);
+        request.setExecutionType(ExecutionType.automated);
+        request.setBarcode("STAN-A");
+        request.setBioState("bs");
+        request.setLabwareType("lwtype");
+        request.setPreBarcode("pb");
+        request.setLotNumber("lot1");
+        request.setProbeLotNumber("probe1");
+        request.setSources(List.of(new SlotCopySource("STAN-0", Labware.State.discarded),
+                new SlotCopySource("STAN-1", Labware.State.active)));
+        request.setContents(List.of(
+                new SlotCopyContent("STAN-0", new Address(1, 1), new Address(1, 2)),
+                new SlotCopyContent("STAN-1", new Address(2, 1), new Address(2, 2))
+        ));
+        List<SlotCopyRecordNote> notes = service.createNotes(request);
+        assertThat(notes).containsExactlyInAnyOrder(
+                new SlotCopyRecordNote(NOTE_COSTING, "Faculty"),
+                new SlotCopyRecordNote(NOTE_EXECUTION, "automated"),
+                new SlotCopyRecordNote(NOTE_BARCODE, "STAN-A"),
+                new SlotCopyRecordNote(NOTE_BIOSTATE, "bs"),
+                new SlotCopyRecordNote(NOTE_LWTYPE, "lwtype"),
+                new SlotCopyRecordNote(NOTE_PREBARCODE, "pb"),
+                new SlotCopyRecordNote(NOTE_LOT, "lot1"),
+                new SlotCopyRecordNote(NOTE_PROBELOT, "probe1"),
+                new SlotCopyRecordNote(NOTE_SRC_BARCODE, 0, "STAN-0"),
+                new SlotCopyRecordNote(NOTE_SRC_STATE, 0, "discarded"),
+                new SlotCopyRecordNote(NOTE_SRC_BARCODE, 1, "STAN-1"),
+                new SlotCopyRecordNote(NOTE_SRC_STATE, 1, "active"),
+                new SlotCopyRecordNote(NOTE_CON_SRCBC, 0, "STAN-0"),
+                new SlotCopyRecordNote(NOTE_CON_SRCADDRESS, 0, "A1"),
+                new SlotCopyRecordNote(NOTE_CON_DESTADDRESS, 0, "A2"),
+                new SlotCopyRecordNote(NOTE_CON_SRCBC, 1, "STAN-1"),
+                new SlotCopyRecordNote(NOTE_CON_SRCADDRESS, 1, "B1"),
+                new SlotCopyRecordNote(NOTE_CON_DESTADDRESS, 1, "B2")
+        );
+    }
+
+    @Test
+    void testLoadNoteMap() {
+        List<SlotCopyRecordNote> notes = List.of(
+                new SlotCopyRecordNote("Alpha", "Alabama"),
+                new SlotCopyRecordNote("Beta", "Banana"),
+                new SlotCopyRecordNote("Gamma", 2, "G2"),
+                new SlotCopyRecordNote("Gamma", 0, "G0")
+        );
+        Map<String, List<String>> map = service.loadNoteMap(notes);
+        assertThat(map).hasSize(3);
+        assertThat(map.get("Alpha")).containsExactly("Alabama");
+        assertThat(map.get("Beta")).containsExactly("Banana");
+        assertThat(map.get("Gamma")).containsExactly("G0", null, "G2");
+    }
+
+    @Test
+    void testSingleNoteValue() {
+        Map<String, List<String>> map = Map.of("Alpha", List.of("Alabama"), "Beta", List.of());
+        assertEquals("Alabama", service.singleNoteValue(map, "Alpha"));
+        assertNull(service.singleNoteValue(map, "Beta"));
+        assertNull(service.singleNoteValue(map, "Gamma"));
+    }
+}

--- a/src/test/resources/graphql/reloadslotcopy.graphql
+++ b/src/test/resources/graphql/reloadslotcopy.graphql
@@ -1,0 +1,17 @@
+query {
+    reloadSlotCopy(operationType: "opname", workNumber: "[WORK]", lpNumber: "LP1") {
+        operationType
+        barcode
+        workNumber
+        lpNumber
+        costing
+        executionType
+        preBarcode
+        labwareType
+        lotNumber
+        probeLotNumber
+        bioState
+        sources { barcode labwareState }
+        contents { sourceBarcode sourceAddress destinationAddress }
+    }
+}

--- a/src/test/resources/graphql/saveslotcopy.graphql
+++ b/src/test/resources/graphql/saveslotcopy.graphql
@@ -1,0 +1,25 @@
+mutation {
+    saveSlotCopy(request: {
+        barcode: "STAN-A"
+        bioState: "bs"
+        costing: SGP
+        lotNumber: "lot1"
+        probeLotNumber: "probe1"
+        labwareType: "lt1"
+        operationType: "opname"
+        preBarcode: "pb1"
+        workNumber: "[WORK]"
+        lpNumber: "LP1"
+        executionType: manual
+        sources: [{barcode: "STAN-0", labwareState: active}]
+        contents: [
+            {sourceBarcode: "STAN-0", sourceAddress: "A2", destinationAddress: "A1"}
+            {sourceBarcode: "STAN-1", sourceAddress: "A1", destinationAddress: "A2"}
+        ]
+    }) {
+        barcode
+        workNumber
+        lpNumber
+        operationType
+    }
+}


### PR DESCRIPTION
Support saving and reloading a bunch of info related to a planned slot copy operation without recording the op itself.

For #492 