### PR TITLE
From FS#29123: prevent grid problems in store-transfer

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/store/Size.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/store/Size.java
@@ -1,5 +1,7 @@
 package uk.ac.sanger.sccp.stan.model.store;
 
+import uk.ac.sanger.sccp.stan.model.Address;
+
 /**
  * A grid size, number of rows and columns
  * @author dr6
@@ -45,6 +47,12 @@ public class Size {
     public Size numColumns(int numColumns) {
         this.numColumns = numColumns;
         return this;
+    }
+
+    /** Does the given address fit inside this size? */
+    public boolean contains(Address address) {
+        return (address != null && address.getRow() >= 1 && address.getRow() <= this.numRows
+                && address.getColumn() >= 1 && address.getColumn() <= this.numColumns);
     }
 
     @Override


### PR DESCRIPTION
For #514 

If someone transfers stored items from a non-grid location to a grid-based location, they would be stored without a grid position, which is confusing.
Now
* If transferring to a grid-location, check that the items all have valid unoccupied positions specified
* If transferring to a non-grid-location, make sure to store them without a position
