### PR TITLE
x1285 Support op type flag any_open_work

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/OperationType.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/OperationType.java
@@ -121,6 +121,11 @@ public class OperationType implements HasName, HasIntId {
     public boolean supportsActiveDest() {
         return this.has(OperationTypeFlag.ACTIVE_DEST);
     }
+
+    /** Can this operation be recorded against a paused or unstarted work? */
+    public boolean supportsAnyOpenWork() {
+        return this.has(OperationTypeFlag.ANY_OPEN_WORK);
+    }
     //endregion
 
     @Override

--- a/src/main/java/uk/ac/sanger/sccp/stan/model/OperationTypeFlag.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/OperationTypeFlag.java
@@ -22,6 +22,8 @@ public enum OperationTypeFlag {
     PROBES,
     /** The destination of the op can be an active piece of labware (i.e. not empty) */
     ACTIVE_DEST,
+    /** This op can be recorded against a paused or unstarted work number */
+    ANY_OPEN_WORK,
 
     // Current limit: 32 flags
     ;

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/InPlaceOpServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/InPlaceOpServiceImp.java
@@ -53,7 +53,7 @@ public class InPlaceOpServiceImp implements InPlaceOpService {
         ValidationHelper val = valFactory.getHelper();
         Equipment eq = val.checkEquipment(request.getEquipmentId(), null);
         problems.addAll(val.getProblems());
-        Work work = workService.validateUsableWork(problems, request.getWorkNumber());
+        Work work = workService.validateWorkForOpType(problems, request.getWorkNumber(), opType);
 
         if (!problems.isEmpty()) {
             throw new ValidationException("The request could not be validated.", problems);

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkService.java
@@ -185,10 +185,32 @@ public interface WorkService {
      * Adds a problem and returns null if the given string is null.
      * @param problems a receptacle for any problems found
      * @param workNumber the string representing an existing work number
-     * @return the active work corresponding to the given string
+     * @return the work corresponding to the given work number
      * @see Work#isUsable
      */
     Work validateUsableWork(Collection<String> problems, String workNumber);
+
+    /**
+     * Validates the specified work as open.
+     * If the work doesn't exist or is closed, adds a problem to the given problems receptacle.
+     * Adds a problem and returns null if the given string is null.
+     * @param problems a receptacle for any problems found
+     * @param workNumber the string representing an existing work number
+     * @return the work corresponding to the given work number
+     * @see Work#isOpen
+     */
+    Work validateOpenWork(Collection<String> problems, String workNumber);
+
+    /**
+     * Validates the specified work for the given operation type.
+     * If the op type is given and supports any open work, then the work should be open.
+     * Otherwise, the work should be active.
+     * @param problems receptacle for any problems found
+     * @param workNumber the string representing an existing work number
+     * @param opType the type operation being requested
+     * @return the work corresponding to the given work number
+     */
+    Work validateWorkForOpType(Collection<String> problems, String workNumber, OperationType opType);
 
     /**
      * Validates the specified work as usable.

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestInPlaceOpService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestInPlaceOpService.java
@@ -74,10 +74,10 @@ public class TestInPlaceOpService {
         doReturn(equipment).when(mockVal).checkEquipment(any(), any());
         final String problem = "Everything is bad.";
         if (successful) {
-            when(mockWorkService.validateUsableWork(any(), any())).thenReturn(work);
+            when(mockWorkService.validateWorkForOpType(any(), any(), any())).thenReturn(work);
             doReturn(Set.of()).when(mockVal).getProblems();
         } else {
-            when(mockWorkService.validateUsableWork(any(), any())).then(invocation -> {
+            when(mockWorkService.validateWorkForOpType(any(), any(), any())).then(invocation -> {
                 Collection<String> problems = invocation.getArgument(0);
                 problems.add(problem);
                 return work;
@@ -98,7 +98,7 @@ public class TestInPlaceOpService {
 
         verify(service).validateLabware(any(), eq(request.getBarcodes()));
         verify(service).validateOpType(any(), eq(request.getOperationType()), eq(labware));
-        verify(mockWorkService).validateUsableWork(any(), eq(request.getWorkNumber()));
+        verify(mockWorkService).validateWorkForOpType(any(), eq(request.getWorkNumber()), same(opType));
         verify(mockVal).checkEquipment(request.getEquipmentId(), null);
         verify(service, times(successful ? 1 : 0)).createOperations(user, labware, opType, equipment, work);
     }


### PR DESCRIPTION
Support the "assign to work" op type that can be recorded against any open (i.e. active, unstarted, paused) work.

For #531 