### PR TITLE
x1279 Change SlotMeasurementRequest to allow multiple comment ids

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationCommentRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/OperationCommentRepo.java
@@ -14,4 +14,8 @@ public interface OperationCommentRepo extends CrudRepository<OperationComment, I
     @Query("select oc from OperationComment oc join Operation op on (oc.operationId=op.id) " +
             "where oc.slotId in (?1) and op.operationType=?2")
     List<OperationComment> findAllBySlotAndOpType(Collection<Integer> slotIds, OperationType opType);
+
+    @Query("select oc from OperationComment oc join Comment com on (oc.comment=com) " +
+            "where oc.slotId in (?1) and com.category=?2")
+    List<OperationComment> findAllBySlotIdInAndCommentCategory(Collection<Integer> slotIds, String category);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/request/SlotMeasurementRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/SlotMeasurementRequest.java
@@ -2,8 +2,10 @@ package uk.ac.sanger.sccp.stan.request;
 
 import uk.ac.sanger.sccp.stan.model.Address;
 
+import java.util.List;
 import java.util.Objects;
 
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullToEmpty;
 import static uk.ac.sanger.sccp.utils.BasicUtils.repr;
 
 /**
@@ -14,20 +16,20 @@ public class SlotMeasurementRequest {
     private Address address;
     private String name;
     private String value;
-    private Integer commentId;
+    private List<Integer> commentIds = List.of();
 
     public SlotMeasurementRequest() {}
 
-    public SlotMeasurementRequest(Address address, String name, String value, Integer commentId) {
+    public SlotMeasurementRequest(Address address, String name, String value, List<Integer> commentIds) {
         this.address = address;
         this.name = name;
         this.value = value;
-        this.commentId = commentId;
+        this.commentIds = nullToEmpty(commentIds);
     }
 
     /** Copy constructor */
     public SlotMeasurementRequest(SlotMeasurementRequest other) {
-        this(other.getAddress(), other.getName(), other.getValue(), other.getCommentId());
+        this(other.getAddress(), other.getName(), other.getValue(), other.getCommentIds());
     }
 
     public Address getAddress() {
@@ -54,12 +56,12 @@ public class SlotMeasurementRequest {
         this.value = value;
     }
 
-    public Integer getCommentId() {
-        return this.commentId;
+    public List<Integer> getCommentIds() {
+        return this.commentIds;
     }
 
-    public void setCommentId(Integer commentId) {
-        this.commentId = commentId;
+    public void setCommentIds(List<Integer> commentIds) {
+        this.commentIds = nullToEmpty(commentIds);
     }
 
     /**
@@ -83,7 +85,7 @@ public class SlotMeasurementRequest {
         return (Objects.equals(this.address, that.address)
                 && Objects.equals(this.name, that.name)
                 && Objects.equals(this.value, that.value)
-                && Objects.equals(this.commentId, that.commentId)
+                && Objects.equals(this.commentIds, that.commentIds)
         );
     }
 
@@ -94,7 +96,7 @@ public class SlotMeasurementRequest {
 
     @Override
     public String toString() {
-        return String.format("SlotMeasurementRequest(%s, %s, %s, commentId=%s)", address, repr(name), repr(value),
-                commentId);
+        return String.format("SlotMeasurementRequest(%s, %s, %s, commentIds=%s)", address, repr(name), repr(value),
+                commentIds);
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseColumn.java
@@ -51,6 +51,7 @@ public enum ReleaseColumn implements TsvColumn<ReleaseEntry> {
     Number_of_amplification_cycles(ReleaseEntry::getAmplificationCycles, ReleaseFileOption.Visium),
     Visium_concentration(ReleaseEntry::getVisiumConcentration, ReleaseFileOption.Visium),
     Visium_concentration_type(ReleaseEntry::getVisiumConcentrationType, ReleaseFileOption.Visium),
+    Size_range(ReleaseEntry::getSizeRange, ReleaseFileOption.Visium),
     Dual_index_plate_type(ReleaseEntry::getReagentPlateType, ReleaseFileOption.Visium),
     Dual_index_plate_name(ReleaseEntry::getReagentSource, ReleaseFileOption.Visium),
     // tag columns go here for visium

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/releasefile/ReleaseEntry.java
@@ -33,6 +33,7 @@ public class ReleaseEntry {
     private String cq;
     private String visiumConcentration;
     private String visiumConcentrationType;
+    private String sizeRange;
     private Integer rnascopePlex;
     private Integer ihcPlex;
     private LocalDate sectionDate;
@@ -199,6 +200,14 @@ public class ReleaseEntry {
 
     public void setVisiumConcentrationType(String visiumConcentrationType) {
         this.visiumConcentrationType = visiumConcentrationType;
+    }
+
+    public String getSizeRange() {
+        return this.sizeRange;
+    }
+
+    public void setSizeRange(String sizeRange) {
+        this.sizeRange = sizeRange;
     }
 
     public Integer getRnascopePlex() {
@@ -458,6 +467,7 @@ public class ReleaseEntry {
                 && Objects.equals(this.cq, that.cq)
                 && Objects.equals(this.visiumConcentration, that.visiumConcentration)
                 && Objects.equals(this.visiumConcentrationType, that.visiumConcentrationType)
+                && Objects.equals(this.sizeRange, that.sizeRange)
                 && Objects.equals(this.rnascopePlex, that.rnascopePlex)
                 && Objects.equals(this.ihcPlex, that.ihcPlex)
                 && Objects.equals(this.sectionDate, that.sectionDate)
@@ -516,6 +526,7 @@ public class ReleaseEntry {
                 .add("cq", cq)
                 .add("visiumConcentration", visiumConcentration)
                 .add("visiumConcentrationType", visiumConcentrationType)
+                .add("sizeRange", sizeRange)
                 .add("rnascopePlex", rnascopePlex)
                 .add("ihcPlex", ihcPlex)
                 .add("sectionDate", sectionDate)

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -1611,8 +1611,8 @@ input SlotMeasurementRequest {
     name: String!
     """The value of the measurement."""
     value: String!
-    """An optional comment id."""
-    commentId: Int
+    """Optional comment ids."""
+    commentIds: [Int!]
 }
 
 """A request to record an operation in place with measurements in slots."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestOperationCommentRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestOperationCommentRepo.java
@@ -81,4 +81,27 @@ public class TestOperationCommentRepo {
         assertThat(opCommentRepo.findAllBySlotAndOpType(List.of(slotIds[0]), baking)).containsExactly(oc4);
     }
 
+    @Test
+    @Transactional
+    void testFindAllBySlotIdInAndCommentCategory() {
+        Sample sample = entityCreator.createSample(null, 1);
+        Integer sampleId = sample.getId();
+        OperationType opType = entityCreator.createOpType("Frying", null);
+        User user = entityCreator.createUser("dr6");
+        Integer opId = opRepo.save(new Operation(null, opType, null, List.of(), user)).getId();
+        Comment com1 = commentRepo.save(new Comment(null, "Alabama", "A"));
+        Comment com2 = commentRepo.save(new Comment(null, "Alaska", "A"));
+        Comment com3 = commentRepo.save(new Comment(null, "Birmingham", "B"));
+        LabwareType lt = entityCreator.createLabwareType("lt", 1, 3);
+        Labware lw = entityCreator.createLabware("STAN-A1", lt, sample, sample, sample);
+        List<Slot> slots = lw.getSlots();
+        Integer[] slotIds = slots.stream().map(Slot::getId).toArray(Integer[]::new);
+        OperationComment oc1 = opCommentRepo.save(new OperationComment(null, com1, opId, sampleId, slotIds[0], null));
+        OperationComment oc2 = opCommentRepo.save(new OperationComment(null, com2, opId, sampleId, slotIds[1], null));
+        opCommentRepo.save(new OperationComment(null, com1, opId, sampleId, slotIds[2], null));
+        opCommentRepo.save(new OperationComment(null, com3, opId, sampleId, slotIds[0], null));
+        assertThat(opCommentRepo.findAllBySlotIdInAndCommentCategory(List.of(slotIds[0], slotIds[1]), "A"))
+                .containsExactlyInAnyOrder(oc1, oc2);
+    }
+
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepService.java
@@ -177,7 +177,7 @@ class TestLibraryPrepService {
         data.reagentPlates = UCMap.from(ReagentPlate::getBarcode, EntityFactory.makeReagentPlate("RP1"));
         data.ampOpType = EntityFactory.makeOperationType("Amplify", null);
         data.comments = List.of(new Comment(1, "com1", "cat1"));
-        data.sanitisedMeasurements = List.of(new SlotMeasurementRequest(new Address(1,1), "name", "value", 1));
+        data.sanitisedMeasurements = List.of(new SlotMeasurementRequest(new Address(1,1), "name", "value", List.of(1)));
 
         OperationResult opres = service.record(data);
         assertThat(opres.getOperations()).containsExactly(ops);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepValidationService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestLibraryPrepValidationService.java
@@ -165,7 +165,7 @@ class TestLibraryPrepValidationService {
 
         OperationType opType = EntityFactory.makeOperationType("Amplification", null);
         List<Comment> validatedComments = List.of(new Comment(1, "Bananas", "custard"));
-        List<SlotMeasurementRequest> sanitisedMeasurements = List.of(new SlotMeasurementRequest(A1, "Alpha", "Beta", 1));
+        List<SlotMeasurementRequest> sanitisedMeasurements = List.of(new SlotMeasurementRequest(A1, "Alpha", "Beta", List.of(1)));
 
         mayAddProblem("Bad address").when(mockOwsmService).validateAddresses(any(), any(), any(), any());
         when(mockOwsmService.loadOpType(any(), any())).thenReturn(opType);

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestOpWithSlotMeasurementsService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestOpWithSlotMeasurementsService.java
@@ -410,10 +410,10 @@ public class TestOpWithSlotMeasurementsService {
     public void testValidateComments() {
         Address A1 = new Address(1,1);
         List<SlotMeasurementRequest> sms = List.of(
-                new SlotMeasurementRequest(A1, "Alpha", "Beta", 1),
-                new SlotMeasurementRequest(A1, "Alpha", "Beta", 2),
+                new SlotMeasurementRequest(A1, "Alpha", "Beta", List.of(1)),
+                new SlotMeasurementRequest(A1, "Alpha", "Beta", List.of(2)),
                 new SlotMeasurementRequest(A1, "Alpha", "Beta", null),
-                new SlotMeasurementRequest(A1, "Alpha", "Beta", -1)
+                new SlotMeasurementRequest(A1, "Alpha", "Beta", List.of(-1))
         );
         //noinspection unchecked
         ArgumentCaptor<Stream<Integer>> commentIdStreamCaptor = ArgumentCaptor.forClass(Stream.class);
@@ -641,7 +641,8 @@ public class TestOpWithSlotMeasurementsService {
         Integer opId = 300;
         List<Comment> comments = List.of(
                 new Comment(1, "Banana", "custard"),
-                new Comment(2, "Rhubarb", "custard")
+                new Comment(2, "Rhubarb", "custard"),
+                new Comment(3, "Jelly", "ice cream")
         );
         LabwareType lt = EntityFactory.makeLabwareType(1, 2);
         Sample sam1 = EntityFactory.getSample();
@@ -651,8 +652,8 @@ public class TestOpWithSlotMeasurementsService {
         Address A1 = new Address(1,1);
         Address A2 = new Address(1,2);
         List<SlotMeasurementRequest> sms = List.of(
-                new SlotMeasurementRequest(A1, "A", "B", 1),
-                new SlotMeasurementRequest(A2, "A", "B", 2)
+                new SlotMeasurementRequest(A1, "A", "B", List.of(1)),
+                new SlotMeasurementRequest(A2, "A", "B", List.of(2,3))
         );
 
         when(mockOpComRepo.saveAll(any())).then(Matchers.returnArgument());
@@ -662,7 +663,8 @@ public class TestOpWithSlotMeasurementsService {
         verify(mockOpComRepo).saveAll(List.of(
                 new OperationComment(null, comments.get(0), opId, sam1.getId(), lw.getSlot(A1).getId(), null),
                 new OperationComment(null, comments.get(0), opId, sam2.getId(), lw.getSlot(A1).getId(), null),
-                new OperationComment(null, comments.get(1), opId, sam2.getId(), lw.getSlot(A2).getId(), null)
+                new OperationComment(null, comments.get(1), opId, sam2.getId(), lw.getSlot(A2).getId(), null),
+                new OperationComment(null, comments.get(2), opId, sam2.getId(), lw.getSlot(A2).getId(), null)
         ));
     }
 

--- a/src/test/resources/graphql/libraryprep.graphql
+++ b/src/test/resources/graphql/libraryprep.graphql
@@ -30,12 +30,12 @@ mutation {
         }
         slotMeasurements: [{
             address: "A1"
-            commentId: 1
+            commentIds: 1
             name: "Cq value"
             value: "10"
         },{
             address: "A2"
-            commentId: 2
+            commentIds: 2
             name: "Cq value"
             value: "20"
         }]

--- a/src/test/resources/graphql/libraryprepexistant.graphql
+++ b/src/test/resources/graphql/libraryprepexistant.graphql
@@ -30,12 +30,12 @@ mutation {
         }
         slotMeasurements: [{
             address: "A1"
-            commentId: 1
+            commentIds: 1
             name: "Cq value"
             value: "10"
         },{
             address: "A2"
-            commentId: 2
+            commentIds: 2
             name: "Cq value"
             value: "20"
         }]


### PR DESCRIPTION
This supports the size range comments required for library concentration.

For #552 

See also [static/x1279_size_range.sql](https://github.com/sanger/stan-sql/blob/devel/static/x1279_size_range.sql)