### PR TITLE
x1419 Block Xenium metrics unless it follows Xenium analyser QC

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareNoteRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/LabwareNoteRepo.java
@@ -1,7 +1,9 @@
 package uk.ac.sanger.sccp.stan.repo;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.sanger.sccp.stan.model.LabwareNote;
+import uk.ac.sanger.sccp.stan.model.OperationType;
 
 import java.util.Collection;
 import java.util.List;
@@ -15,4 +17,9 @@ public interface LabwareNoteRepo extends CrudRepository<LabwareNote, Integer> {
     List<LabwareNote> findAllByPlanIdIn(Collection<Integer> planIds);
     List<LabwareNote> findAllByLabwareIdInAndName(Collection<Integer> labwareIds, String name);
     boolean existsByNameAndValue(String name, String value);
+    @Query("select ln from LabwareNote ln " +
+            "join Operation op on (ln.operationId=op.id) " +
+            "where ln.name=?1 and op.operationType=?3 " +
+            "and ln.labwareId in (?2)")
+    List<LabwareNote> findAllByNameAndLabwareIdInAndOperationType(String name, Collection<Integer> labwareIds, OperationType opType);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteService.java
@@ -4,8 +4,7 @@ import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.utils.UCMap;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.Collection;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Service helping with {@link uk.ac.sanger.sccp.stan.model.LabwareNote labware notes}
@@ -19,6 +18,15 @@ public interface LabwareNoteService {
      * @exception EntityNotFoundException no such labware is found
      */
     Set<String> findNoteValuesForBarcode(String barcode, String name) throws EntityNotFoundException;
+
+    /**
+     * Finds notes with a specified name on specified labware for a specified operation type
+     * @param name the name of the note
+     * @param lw the noted labware
+     * @param opType the type of operation the note was recorded for
+     * @return matching labware notes (may be empty)
+     */
+    List<LabwareNote> findNamedNotesForLabwareAndOperationType(String name, Labware lw, OperationType opType);
 
     /**
      * Gets the values of notes for multiple labware and one note name

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/LabwareNoteServiceImp.java
@@ -34,6 +34,11 @@ public class LabwareNoteServiceImp implements LabwareNoteService {
     }
 
     @Override
+    public List<LabwareNote> findNamedNotesForLabwareAndOperationType(String name, Labware lw, OperationType opType) {
+        return lwNoteRepo.findAllByNameAndLabwareIdInAndOperationType(name, List.of(lw.getId()), opType);
+    }
+
+    @Override
     public UCMap<Set<String>> findNoteValuesForLabware(Collection<Labware> labware, String name) {
         if (labware.isEmpty()) {
             return new UCMap<>(0);

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkService.java
@@ -274,6 +274,13 @@ public interface WorkService {
     Map<SlotIdSampleId, Set<Work>> loadWorksForSlotsIn(Collection<Labware> labware);
 
     /**
+     * Gets the work numbers linked to each of the given operation ids
+     * @param opIds operation ids
+     * @return the corresponding works
+     */
+    Map<Integer, Set<String>> loadWorkNumbersForOpIds(Collection<Integer> opIds);
+
+    /**
      * struct-like container for a work and an operation
      */
     record WorkOp(Work work, Operation op) {

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/work/WorkServiceImp.java
@@ -552,6 +552,11 @@ public class WorkServiceImp implements WorkService {
                 .flatMap(lw -> lw.getSlots().stream()));
     }
 
+    @Override
+    public Map<Integer, Set<String>> loadWorkNumbersForOpIds(Collection<Integer> opIds) {
+        return workRepo.findWorkNumbersForOpIds(opIds);
+    }
+
     public Map<SlotIdSampleId, Set<Work>> loadWorksForSlots(Stream<Slot> slots) {
         List<Integer> slotIds = slots.map(Slot::getId).toList();
         return workRepo.slotSampleWorksForSlotIds(slotIds);

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestProbeOperationMutation.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestProbeOperationMutation.java
@@ -106,6 +106,7 @@ public class TestProbeOperationMutation {
         assertEquals("123456", noteValues.get("reagent lot"));
         testCompletion(lw, work, sample);
         testAnalyser(lw, work, sample);
+        recordXeniumAnalyserQC(lw, work);
         testSampleMetrics(lw, work);
     }
 
@@ -161,6 +162,15 @@ public class TestProbeOperationMutation {
         String runNamesQuery = String.format("query { runNames(barcode: \"%s\") }", lw.getBarcode());
         Object queryResult = tester.post(runNamesQuery);
         assertThat(chainGetList(queryResult, "data", "runNames")).containsExactly("RUN1");
+    }
+
+    private void recordXeniumAnalyserQC(Labware lw, Work work) throws Exception {
+        entityCreator.createOpType("Xenium analyser QC", null, OperationTypeFlag.IN_PLACE);
+        String mutation = tester.readGraphQL("recordxeniumanalyserqc.graphql")
+                .replace("[WORK]", work.getWorkNumber())
+                .replace("[BC]",  lw.getBarcode());
+        Object result = tester.post(mutation);
+        assertNotNull(chainGet(result, "data", "recordQCLabware", "operations", 0, "id"));
     }
 
     private void testSampleMetrics(Labware lw, Work work) throws Exception {

--- a/src/test/java/uk/ac/sanger/sccp/stan/repo/TestLabwareNoteRepo.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/repo/TestLabwareNoteRepo.java
@@ -35,6 +35,7 @@ public class TestLabwareNoteRepo {
     @Transactional
     public void testFindByOperationId() {
         OperationType opType = entityCreator.createOpType("Stir", null, OperationTypeFlag.IN_PLACE);
+        OperationType opType2 = entityCreator.createOpType("Stir2", null, OperationTypeFlag.IN_PLACE);
         User user = entityCreator.createUser("user1");
         Integer op1id = opRepo.save(new Operation(null, opType, null, null, user)).getId();
         Integer op2id = opRepo.save(new Operation(null, opType, null, null, user)).getId();
@@ -52,6 +53,13 @@ public class TestLabwareNoteRepo {
         assertThat(labwareNoteRepo.findAllByOperationIdIn(List.of(op1id))).containsExactlyInAnyOrder(note1, note2, note3);
         assertThat(labwareNoteRepo.findAllByOperationIdIn(List.of(op2id))).containsExactly(note4);
         assertThat(labwareNoteRepo.findAllByOperationIdIn(List.of(op1id, op2id))).containsExactlyInAnyOrder(note1, note2, note3, note4);
+
+        assertThat(labwareNoteRepo.findAllByNameAndLabwareIdInAndOperationType("Alpha", List.of(lw.getId()), opType))
+                .containsExactlyInAnyOrder(note1, note2);
+        assertThat(labwareNoteRepo.findAllByNameAndLabwareIdInAndOperationType("Alpha", List.of(lw.getId()), opType2))
+                .isEmpty();
+        assertThat(labwareNoteRepo.findAllByNameAndLabwareIdInAndOperationType("Alpha", List.of(-1), opType))
+                .isEmpty();
     }
 
     @Test

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/TestLabwareNoteService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/TestLabwareNoteService.java
@@ -57,6 +57,18 @@ class TestLabwareNoteService {
     }
 
     @Test
+    void testFindNamedNotesForLabwareAndOperationType() {
+        Labware lw = EntityFactory.getTube();
+        OperationType opType = EntityFactory.makeOperationType("opname", null);
+        String name = "Bananas";
+        List<LabwareNote> notes = List.of(
+                new LabwareNote(10, lw.getId(), 100, name, "Custard")
+        );
+        when(mockLwNoteRepo.findAllByNameAndLabwareIdInAndOperationType(name, List.of(lw.getId()), opType)).thenReturn(notes);
+        assertSame(notes, service.findNamedNotesForLabwareAndOperationType(name, lw,  opType));
+    }
+
+    @Test
     void testFindNoteValuesForLabware_single() {
         Labware lw = EntityFactory.getTube();
         String name = "Bananas";

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/work/TestWorkService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/work/TestWorkService.java
@@ -1236,6 +1236,14 @@ public class TestWorkService {
     }
 
     @Test
+    public void testLoadWorkNumbersForOpIds() {
+        Map<Integer, Set<String>> map = Map.of(2, Set.of("Alpha", "Beta"));
+        Set<Integer> opIds = Set.of(2,3);
+        when(mockWorkRepo.findWorkNumbersForOpIds(opIds)).thenReturn(map);
+        assertSame(map, workService.loadWorkNumbersForOpIds(opIds));
+    }
+
+    @Test
     public void testLoadWorksForSlotsIn() {
         Sample sample = EntityFactory.getSample();
         LabwareType lt = EntityFactory.makeLabwareType(3,1);

--- a/src/test/resources/graphql/recordxeniumanalyserqc.graphql
+++ b/src/test/resources/graphql/recordxeniumanalyserqc.graphql
@@ -1,0 +1,15 @@
+mutation {
+    recordQCLabware(request: {
+        operationType: "Xenium analyser QC"
+        labware: [
+            {
+                barcode: "[BC]"
+                runName: "RUN1"
+                comments: []
+                workNumber: "[WORK]"
+            }
+        ]
+    }) {
+        operations { id }
+    }
+}


### PR DESCRIPTION
When trying to perform Xenium metrics op, there must already be a Xenium analyser QC operation on the same labware, run name and work number.

For #554 