### PR TITLE
x1465 record whether a qc op was terminated early

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/request/QCLabwareRequest.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/request/QCLabwareRequest.java
@@ -196,12 +196,14 @@ public class QCLabwareRequest {
 
     private String operationType;
     private List<QCLabware> labware = List.of();
+    private boolean terminated = false;
 
     public QCLabwareRequest() {}
 
-    public QCLabwareRequest(String operationType, List<QCLabware> labware) {
+    public QCLabwareRequest(String operationType, List<QCLabware> labware, boolean terminated) {
         setOperationType(operationType);
         setLabware(labware);
+        setTerminated(terminated);
     }
 
     /**
@@ -226,6 +228,14 @@ public class QCLabwareRequest {
         this.labware = nullToEmpty(labware);
     }
 
+    public boolean isTerminated() {
+        return this.terminated;
+    }
+
+    public void setTerminated(boolean terminated) {
+        this.terminated = terminated;
+    }
+
     @Override
     public String toString() {
         return String.format("QCLabwareRequest(%s, %s)", repr(operationType), labware);
@@ -237,7 +247,8 @@ public class QCLabwareRequest {
         if (o == null || getClass() != o.getClass()) return false;
         QCLabwareRequest that = (QCLabwareRequest) o;
         return (Objects.equals(this.operationType, that.operationType)
-                && Objects.equals(this.labware, that.labware));
+                && Objects.equals(this.labware, that.labware)
+                && this.terminated == that.terminated);
     }
 
     @Override

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -2035,6 +2035,8 @@ input QCLabwareRequest {
     operationType: String!
     """The specifications of labware to QC."""
     labware: [QCLabware!]!
+    """Was it terminated early?"""
+    terminated: Boolean
 }
 
 """Raise a flag on a piece of labware."""


### PR DESCRIPTION
New boolean terminated in QCLabwareRequest.
If terminated, record a "terminated early" comment against each op/lw.
Requires a suitable comment to exist in the database.
