### PR TITLE
x1463 Add graphql query to look up if an operation exists on a given lw

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLDataFetchers.java
@@ -21,8 +21,7 @@ import uk.ac.sanger.sccp.stan.service.flag.FlagLookupService;
 import uk.ac.sanger.sccp.stan.service.graph.GraphService;
 import uk.ac.sanger.sccp.stan.service.history.HistoryService;
 import uk.ac.sanger.sccp.stan.service.label.print.LabelPrintService;
-import uk.ac.sanger.sccp.stan.service.operation.AnalyserServiceImp;
-import uk.ac.sanger.sccp.stan.service.operation.RecentOpService;
+import uk.ac.sanger.sccp.stan.service.operation.*;
 import uk.ac.sanger.sccp.stan.service.operation.plan.PlanService;
 import uk.ac.sanger.sccp.stan.service.work.WorkService;
 import uk.ac.sanger.sccp.stan.service.work.WorkSummaryService;
@@ -93,6 +92,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
     final LabwareNoteService lwNoteService;
     final SlotCopyRecordService slotCopyRecordService;
     final CompletionService completionService;
+    final OpLookupService opLookupService;
 
     @Autowired
     public GraphQLDataFetchers(ObjectMapper objectMapper, AuthenticationComponent authComp, UserRepo userRepo,
@@ -119,7 +119,8 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
                                FlagLookupService flagLookupService, MeasurementService measurementService,
                                GraphService graphService, CommentRepo commentRepo,
                                AnalyserScanDataService analyserScanDataService, LabwareNoteService lwNoteService,
-                               SlotCopyRecordService slotCopyRecordService, CompletionService completionService) {
+                               SlotCopyRecordService slotCopyRecordService, CompletionService completionService,
+                               OpLookupService opLookupService) {
         super(objectMapper, authComp, userRepo);
         this.sessionConfig = sessionConfig;
         this.versionInfo = versionInfo;
@@ -174,6 +175,7 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         this.lwNoteService = lwNoteService;
         this.slotCopyRecordService = slotCopyRecordService;
         this.completionService = completionService;
+        this.opLookupService = opLookupService;
     }
 
     public DataFetcher<User> getUser() {
@@ -552,6 +554,17 @@ public class GraphQLDataFetchers extends BaseGraphQLResource {
         return dfe -> {
             String barcode = dfe.getArgument("barcode");
             return lwNoteService.findNoteValuesForBarcode(barcode, AnalyserServiceImp.RUN_NAME);
+        };
+    }
+
+    public DataFetcher<Boolean> opExists() {
+        return dfe -> {
+            String barcode = dfe.getArgument("barcode");
+            String opName = dfe.getArgument("operationType");
+            String run = dfe.getArgument("run");
+            String workNumber = dfe.getArgument("workNumber");
+            List<Operation> ops = opLookupService.findOps(opName, barcode, run, workNumber);
+            return !ops.isEmpty();
         };
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/GraphQLProvider.java
@@ -137,6 +137,7 @@ public class GraphQLProvider {
                         .dataFetcher("workProgress", graphQLDataFetchers.workProgress())
                         .dataFetcher("analyserScanData", graphQLDataFetchers.analyserScanData())
                         .dataFetcher("runNames", graphQLDataFetchers.runNames())
+                        .dataFetcher("opExists", graphQLDataFetchers.opExists())
                         .dataFetcher("labwareBioRiskCodes", graphQLDataFetchers.labwareBioRiskCodes())
                         .dataFetcher("reloadSlotCopy", graphQLDataFetchers.reloadSlotCopy())
                         .dataFetcher("probeHybSlots", graphQLDataFetchers.getProbeHybSlots())

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpLookupService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpLookupService.java
@@ -1,0 +1,18 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import uk.ac.sanger.sccp.stan.model.Operation;
+
+import java.util.List;
+
+/** Service to look up prior op directly on specified labware */
+public interface OpLookupService {
+    /**
+     * Returns operations matching the given fields.
+     * @param opName name of operation type
+     * @param barcode labware barcode
+     * @param run run name (optional)
+     * @param workNumber work number (optional)
+     * @return the operation found, may be empty
+     */
+    List<Operation> findOps(String opName, String barcode, String run, String workNumber);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpLookupServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/operation/OpLookupServiceImp.java
@@ -1,0 +1,69 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * @author dr6
+ */
+@Service
+public class OpLookupServiceImp implements OpLookupService {
+    private final OperationTypeRepo opTypeRepo;
+    private final LabwareRepo lwRepo;
+    private final WorkRepo workRepo;
+    private final OperationRepo opRepo;
+    private final LabwareNoteRepo lwNoteRepo;
+
+    @Autowired
+    public OpLookupServiceImp(OperationTypeRepo opTypeRepo, LabwareRepo lwRepo, WorkRepo workRepo,
+                              OperationRepo opRepo, LabwareNoteRepo lwNoteRepo) {
+        this.opTypeRepo = opTypeRepo;
+        this.lwRepo = lwRepo;
+        this.workRepo = workRepo;
+        this.opRepo = opRepo;
+        this.lwNoteRepo = lwNoteRepo;
+    }
+
+    @Override
+    public List<Operation> findOps(String opName, String barcode, String run, String workNumber) {
+        OperationType opType = opTypeRepo.findByName(opName).orElse(null);
+        if (opType==null) {
+            return List.of();
+        }
+        Labware lw = lwRepo.findByBarcode(barcode).orElse(null);
+        if (lw==null) {
+            return List.of();
+        }
+        Work work;
+        if (workNumber!=null) {
+            work = workRepo.findByWorkNumber(workNumber).orElse(null);
+            if (work==null) {
+                return List.of();
+            }
+        } else {
+            work = null;
+        }
+        List<Operation> ops = opRepo.findAllByOperationTypeAndDestinationLabwareIdIn(opType, List.of(lw.getId()));
+        if (work != null) {
+            ops = ops.stream().filter(op -> work.getOperationIds().contains(op.getId())).toList();
+        }
+        if (!ops.isEmpty() && run != null) {
+            List<LabwareNote> lwNotes = lwNoteRepo.findAllByLabwareIdInAndName(List.of(lw.getId()), "run");
+            Set<Integer> runOpIds = lwNotes.stream()
+                    .filter(note -> note.getValue().equalsIgnoreCase(run))
+                    .map(LabwareNote::getOperationId)
+                    .collect(toSet());
+            ops = ops.stream()
+                    .filter(op -> runOpIds.contains(op.getId()))
+                    .toList();
+        }
+        return ops;
+    }
+}

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -2349,6 +2349,11 @@ type Query {
     analyserScanData(barcode: String!): AnalyserScanData!
     """Run names recorded for the specified labware."""
     runNames(barcode: String!): [String!]!
+    """
+    Does the specified operation exist on the specified labware?
+    With the specified run name, work number if provided.
+    """
+    opExists(operationType: String!, barcode: String!, run: String, workNumber: String): Boolean!
     """Bio risk codes for samples in the specified labware."""
     labwareBioRiskCodes(barcode: String!): [SampleBioRisk!]!
     """Reloads saved slot copy information."""

--- a/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestOpExistsQuery.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/integrationtest/TestOpExistsQuery.java
@@ -1,0 +1,64 @@
+package uk.ac.sanger.sccp.stan.integrationtest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.ac.sanger.sccp.stan.EntityCreator;
+import uk.ac.sanger.sccp.stan.GraphQLTester;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.LabwareNoteRepo;
+import uk.ac.sanger.sccp.stan.repo.WorkRepo;
+
+import javax.transaction.Transactional;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.ac.sanger.sccp.stan.integrationtest.IntegrationTestUtils.chainGet;
+
+/**
+ * @author dr6
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import({GraphQLTester.class, EntityCreator.class})
+public class TestOpExistsQuery {
+    @Autowired
+    private LabwareNoteRepo noteRepo;
+    @Autowired
+    private WorkRepo workRepo;
+    @Autowired
+    private EntityCreator entityCreator;
+    @Autowired
+    private GraphQLTester tester;
+
+    @Test
+    @Transactional
+    public void testOpExists() throws Exception {
+        OperationType opType = entityCreator.createOpType("opname", null, OperationTypeFlag.IN_PLACE);
+        User user = entityCreator.createUser("user1");
+        Sample sample = entityCreator.createSample(null, null);
+        Labware lw = entityCreator.createLabware("STAN-1", entityCreator.getTubeType(), sample);
+        Operation op = entityCreator.simpleOp(opType, user, lw, lw);
+        noteRepo.save(new LabwareNote(null, lw.getId(), op.getId(), "run", "RUN1"));
+        Work work = entityCreator.createWork(null, null, null, null, null);
+        work.setOperationIds(new HashSet<>(Set.of(op.getId())));
+        work = workRepo.save(work);
+
+        String fullQuery = "query { opExists(barcode:\"STAN-1\", operationType:\"opname\", run:\"%s\", workNumber:\"%s\") }";
+
+        assertTrue(queryResult("query { opExists(barcode:\"STAN-1\", operationType:\"opname\") }"));
+        assertTrue(queryResult(String.format(fullQuery, "RUN1", work.getWorkNumber())));
+        assertFalse(queryResult(String.format(fullQuery, "RUN1", "SGPX")));
+        assertFalse(queryResult(String.format(fullQuery, "RUNX", work.getWorkNumber())));
+    }
+
+    private boolean queryResult(String query) throws Exception {
+        return chainGet(tester.post(query), "data", "opExists");
+    }
+}

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestOpLookupService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/operation/TestOpLookupService.java
@@ -1,0 +1,168 @@
+package uk.ac.sanger.sccp.stan.service.operation;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/** Test {@link OpLookupServiceImp} */
+class TestOpLookupService {
+    @Mock
+    OperationTypeRepo mockOpTypeRepo;
+    @Mock
+    LabwareRepo mockLwRepo;
+    @Mock
+    WorkRepo mockWorkRepo;
+    @Mock
+    OperationRepo mockOpRepo;
+    @Mock
+    LabwareNoteRepo mockLwNoteRepo;
+
+    @InjectMocks
+    OpLookupServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    private OperationType mockOpType() {
+        OperationType opType = EntityFactory.makeOperationType("Fry", null);
+        when(mockOpTypeRepo.findByName(opType.getName())).thenReturn(Optional.of(opType));
+        return opType;
+    }
+
+    private Labware mockLw() {
+        Labware lw = EntityFactory.getTube();
+        when(mockLwRepo.findByBarcode(lw.getBarcode())).thenReturn(Optional.of(lw));
+        return lw;
+    }
+
+    private Work mockWork() {
+        Work work = EntityFactory.makeWork("SGP1");
+        when(mockWorkRepo.findByWorkNumber(work.getWorkNumber())).thenReturn(Optional.of(work));
+        return work;
+    }
+
+    private List<Operation> mockOps(int num) {
+        final LocalDateTime now = LocalDateTime.now();
+        List<Operation> ops = IntStream.range(100, 100+num).mapToObj(i -> {
+            Operation op = new Operation();
+            op.setId(i);
+            op.setPerformed(now);
+            return op;
+        }).toList();
+        when(mockOpRepo.findAllByOperationTypeAndDestinationLabwareIdIn(any(), any())).thenReturn(ops);
+        return ops;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "null", "Bananas"})
+    void testFindOpsNoOpType(String opName) {
+        if ("null".equals(opName)) {
+            opName = null;
+        }
+        assertThat(service.findOps(opName, "bc", null, null)).isEmpty();
+        verifyNoInteractions(mockLwRepo, mockWorkRepo, mockOpRepo, mockLwNoteRepo);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "null", "STAN-404"})
+    void testFindOpsNoLabware(String barcode) {
+        if ("null".equals(barcode)) {
+            barcode = null;
+        }
+        OperationType opType = mockOpType();
+        assertThat(service.findOps(opType.getName(), barcode, null, null)).isEmpty();
+        verifyNoInteractions(mockWorkRepo, mockOpRepo, mockLwNoteRepo);
+    }
+
+    @Test
+    void testFindOpsNoSuchWork() {
+        Labware lw = mockLw();
+        OperationType opType = mockOpType();
+        assertThat(service.findOps(opType.getName(), lw.getBarcode(), null, "SGP404")).isEmpty();
+        verifyNoInteractions(mockOpRepo, mockLwNoteRepo);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true,false", "false,true", "false,false", "true,true"})
+    void testFindOpsNoSuchOps(boolean hasRun, boolean hasWork) {
+        Labware lw = mockLw();
+        OperationType opType = mockOpType();
+        String run = (hasRun ? "RUN1" : null);
+        Work work = hasWork ? mockWork() : null;
+        String workNumber = work!=null ? work.getWorkNumber() : null;
+        when(mockOpRepo.findAllByOperationTypeAndDestinationLabwareIdIn(any(), any())).thenReturn(List.of());
+        assertThat(service.findOps(opType.getName(), lw.getBarcode(), run, workNumber)).isEmpty();
+        verifyNoInteractions(mockLwNoteRepo);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testFindOpsWrongWork(boolean hasRun) {
+        Labware lw = mockLw();
+        OperationType opType = mockOpType();
+        Work work = mockWork();
+        String run = (hasRun ? "RUN1" : null);
+        mockOps(2);
+        work.setOperationIds(Set.of());
+        assertThat(service.findOps(opType.getName(), lw.getBarcode(), run, work.getWorkNumber())).isEmpty();
+        verify(mockOpRepo).findAllByOperationTypeAndDestinationLabwareIdIn(opType, List.of(lw.getId()));
+        verifyNoInteractions(mockLwNoteRepo);
+    }
+
+    @Test
+    void testFindOps_simple() {
+        Labware lw = mockLw();
+        OperationType opType = mockOpType();
+        List<Operation> ops = mockOps(2);
+        assertThat(service.findOps(opType.getName(), lw.getBarcode(), null, null)).containsExactlyElementsOf(ops);
+        verify(mockOpTypeRepo).findByName(opType.getName());
+        verify(mockLwRepo).findByBarcode(lw.getBarcode());
+        verify(mockOpRepo).findAllByOperationTypeAndDestinationLabwareIdIn(opType, List.of(lw.getId()));
+        verifyNoInteractions(mockWorkRepo, mockLwNoteRepo);
+    }
+
+    @Test
+    void testFindOps_full() {
+        Labware lw = mockLw();
+        OperationType opType = mockOpType();
+        Work work = mockWork();
+        String run = "RUN1";
+        List<Operation> ops = mockOps(5);
+        work.setOperationIds(Set.of(ops.get(0).getId(), ops.get(1).getId(), ops.get(2).getId(), ops.get(3).getId()));
+        List<LabwareNote> lwNotes = IntStream.of(1,2,3,4)
+                .mapToObj(i -> new LabwareNote(200+i, lw.getId(), ops.get(i).getId(), "run", (i < 3 ? run : "RUN2")))
+                .toList();
+        when(mockLwNoteRepo.findAllByLabwareIdInAndName(List.of(lw.getId()), "run")).thenReturn(lwNotes);
+
+        assertThat(service.findOps(opType.getName(), lw.getBarcode(), run, work.getWorkNumber()))
+                .containsExactlyInAnyOrder(ops.get(1), ops.get(2));
+
+        verify(mockOpTypeRepo).findByName(opType.getName());
+        verify(mockLwRepo).findByBarcode(lw.getBarcode());
+        verify(mockWorkRepo).findByWorkNumber(work.getWorkNumber());
+        verify(mockOpRepo).findAllByOperationTypeAndDestinationLabwareIdIn(opType, List.of(lw.getId()));
+        verify(mockLwNoteRepo).findAllByLabwareIdInAndName(List.of(lw.getId()), "run");
+    }
+}


### PR DESCRIPTION
Specify op type, lw barcode, run name (optional) and work (optional).
Returns true if a matching operation exists.
This is here to support client validation for x1463 and similar requirements.