### PR TITLE
x1520 support downloading a file of data about imaging qc op

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/ImageDataFileController.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/ImageDataFileController.java
@@ -1,0 +1,41 @@
+package uk.ac.sanger.sccp.stan;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import uk.ac.sanger.sccp.stan.model.Operation;
+import uk.ac.sanger.sccp.stan.repo.OperationRepo;
+import uk.ac.sanger.sccp.stan.service.imagedatafile.ImageDataFileService;
+import uk.ac.sanger.sccp.utils.tsv.TsvFile;
+
+import javax.persistence.EntityNotFoundException;
+
+/**
+ * Controller for delivering image data files (excel).
+ * @author dr6
+ */
+@Controller
+public class ImageDataFileController {
+    public static final String IMAGING_QC_OP_NAME = "Imaging QC";
+
+    private final OperationRepo opRepo;
+    private final ImageDataFileService imageDataFileService;
+
+    @Autowired
+    public ImageDataFileController(OperationRepo opRepo, ImageDataFileService imageDataFileService) {
+        this.opRepo = opRepo;
+        this.imageDataFileService = imageDataFileService;
+    }
+
+    @RequestMapping(value="/imageqc", method=RequestMethod.GET,
+                    produces="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    @ResponseBody
+    public TsvFile<?> getImageDataFile(@RequestParam(name="id") Integer id) {
+        Operation op = opRepo.findById(id).orElseThrow(() -> new EntityNotFoundException("No operation found with id " + id+"."));
+        if (!op.getOperationType().getName().equalsIgnoreCase(IMAGING_QC_OP_NAME)) {
+            throw new IllegalArgumentException("Operation " + id + " is not an imaging QC operation");
+        }
+        return imageDataFileService.generateFile(op);
+        // TsvFileConverter will convert the data to an excel file
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/repo/WorkRepo.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/repo/WorkRepo.java
@@ -13,8 +13,7 @@ import java.util.function.Function;
 
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
-import static uk.ac.sanger.sccp.utils.BasicUtils.inMap;
-import static uk.ac.sanger.sccp.utils.BasicUtils.stream;
+import static uk.ac.sanger.sccp.utils.BasicUtils.*;
 
 public interface WorkRepo extends CrudRepository<Work, Integer> {
     Optional<Work> findByWorkNumber(String workNumber);
@@ -81,6 +80,15 @@ public interface WorkRepo extends CrudRepository<Work, Integer> {
             opWork.get((Integer) opIdWorkNumber[0]).add((String) opIdWorkNumber[1]);
         }
         return opWork;
+    }
+
+    @Query(value = "select work_id from work_op where operation_id=?1", nativeQuery = true)
+    List<Integer> findWorkIdsForOperationId(Integer opId);
+
+    /** Gets list of works linked to the given operation id. */
+    default List<Work> findWorksForOperationId(Integer opId) {
+        List<Integer> workIds = findWorkIdsForOperationId(opId);
+        return (workIds.isEmpty() ? List.of() : asList(findAllById(workIds)));
     }
 
     @Query(value="select release_id as releaseId, work_number as workNumber from work_release join work on (work_id=work.id) where release_id IN (?1)", nativeQuery=true)

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataColumn.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataColumn.java
@@ -1,0 +1,30 @@
+package uk.ac.sanger.sccp.stan.service.imagedatafile;
+
+import uk.ac.sanger.sccp.utils.tsv.TsvColumn;
+
+import java.util.function.Function;
+
+/** Columns in the image data file */
+public enum ImageDataColumn implements TsvColumn<ImageDataRow> {
+    location(null),
+    filename(ImageDataRow::getBarcode),
+    omero_name(ImageDataRow::getExternalName),
+    omero_group(ImageDataRow::getOmeroProject),
+    omero_project(ImageDataRow::getWorkNumber),
+    omero_dataset(ImageDataRow::getExternalName),
+    omero_username(ImageDataRow::getUserName),
+    tags(null),
+    comments(ImageDataRow::getComments),
+    ;
+
+    private final Function<ImageDataRow, String> dataGetter;
+
+    ImageDataColumn(Function<ImageDataRow, String> dataGetter) {
+        this.dataGetter = dataGetter;
+    }
+
+    @Override
+    public String get(ImageDataRow entry) {
+        return (dataGetter==null ? null : dataGetter.apply(entry));
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileService.java
@@ -1,0 +1,14 @@
+package uk.ac.sanger.sccp.stan.service.imagedatafile;
+
+import uk.ac.sanger.sccp.stan.model.Operation;
+import uk.ac.sanger.sccp.utils.tsv.TsvFile;
+
+/** Service for generating file data for image qc ops */
+public interface ImageDataFileService {
+    /**
+     * Generate file data containing the image data for the given operation.
+     * @param op the operation
+     * @return the file data
+     */
+    TsvFile<?> generateFile(Operation op);
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileServiceImp.java
@@ -1,0 +1,119 @@
+package uk.ac.sanger.sccp.stan.service.imagedatafile;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.utils.tsv.TsvColumn;
+import uk.ac.sanger.sccp.utils.tsv.TsvFile;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+import static uk.ac.sanger.sccp.utils.BasicUtils.*;
+
+/**
+ * @author dr6
+ */
+@Service
+public class ImageDataFileServiceImp implements ImageDataFileService {
+    private final WorkRepo workRepo;
+    private final OperationCommentRepo opComRepo;
+    private final LabwareRepo lwRepo;
+
+    @Autowired
+    public ImageDataFileServiceImp(WorkRepo workRepo, OperationCommentRepo opComRepo, LabwareRepo lwRepo) {
+        this.workRepo = workRepo;
+        this.opComRepo = opComRepo;
+        this.lwRepo = lwRepo;
+    }
+
+    @Override
+    public TsvFile<?> generateFile(Operation op) {
+        String filename = getFilename(op);
+        List<? extends TsvColumn<ImageDataRow>> columns = getColumns();
+        List<ImageDataRow> rows = getRows(op);
+        return new TsvFile<>(filename, rows, columns);
+    }
+
+    /** Filename for the given operation */
+    public String getFilename(Operation op) {
+        return "imaging-qc-" + op.getId() + ".xlsx";
+    }
+
+    /** The columns in the file */
+    public List<ImageDataColumn> getColumns() {
+        return Arrays.asList(ImageDataColumn.values());
+    }
+
+    /** Gets the comments for the operation, mapped from slot/sample id */
+    public Map<Integer, List<Comment>> compileCommentMap(Integer opId) {
+        List<OperationComment> opcoms = opComRepo.findAllByOperationIdIn(List.of(opId));
+        if (opcoms.isEmpty()) {
+            return Map.of();
+        }
+        Map<Integer, List<Comment>> map = new HashMap<>();
+        for (OperationComment opCom : opcoms) {
+            map.computeIfAbsent(opCom.getSampleId(), k -> new ArrayList<>())
+                    .add(opCom.getComment());
+        }
+        map.replaceAll((k, v) -> v.stream().sorted(Comparator.comparingInt(Comment::getId)).distinct().toList());
+        return map;
+    }
+
+    /** Gets the labware for the operation, mapped from their ids */
+    public Map<Integer, Labware> compileLabwareMap(Operation op) {
+        Set<Integer> labwareIds = op.getActions().stream()
+                .map(ac -> ac.getDestination().getLabwareId())
+                .collect(toSet());
+        return lwRepo.findAllByIdIn(labwareIds).stream()
+                .collect(inMap(Labware::getId));
+    }
+
+    /** Gets the rows for the operation */
+    public List<ImageDataRow> getRows(Operation op) {
+        List<Work> works = workRepo.findWorksForOperationId(op.getId());
+        String workNumber = works.stream().map(Work::getWorkNumber).collect(joining(", "));
+        String omeroProject = works.stream()
+                .map(Work::getOmeroProject)
+                .filter(Objects::nonNull)
+                .distinct()
+                .map(OmeroProject::getName)
+                .collect(joining(", "));
+        Map<Integer, List<Comment>> sampleComments = compileCommentMap(op.getId());
+        Map<Integer, Labware> lwMap = compileLabwareMap(op);
+        return compileRows(op, omeroProject, workNumber, op.getUser().getUsername(), lwMap, sampleComments);
+    }
+
+    /** Puts together rows given various data. One row per sample */
+    public List<ImageDataRow> compileRows(Operation op, String omeroProject, String workNumber, String user,
+                                          Map<Integer, Labware> lwMap, Map<Integer, List<Comment>> sampleComments) {
+        return op.getActions().stream()
+                .filter(distinctBySerial(ac -> ac.getSample().getId()))
+                .map(ac -> makeRow(ac, omeroProject, workNumber, user, lwMap, sampleComments))
+                .distinct()
+                .toList();
+    }
+
+    /** Converts an action to a row */
+    public ImageDataRow makeRow(Action ac, String omeroProject, String workNumber, String user,
+                                Map<Integer, Labware> lwMap, Map<Integer, List<Comment>> slotSampleComments) {
+        Slot slot = ac.getDestination();
+        Sample sample = ac.getSample();
+        Labware lw = lwMap.get(slot.getLabwareId());
+        List<Comment> comments = slotSampleComments.get(sample.getId());
+        String commentString;
+        if (nullOrEmpty(comments)) {
+            commentString = null;
+        } else {
+            commentString = comments.stream()
+                    .map(Comment::getText)
+                    .map(s -> s.endsWith(".") ? s : (s + "."))
+                    .collect(joining(" "));
+        }
+        return new ImageDataRow(lw.getBarcode(), sample.getTissue().getExternalName(), omeroProject, workNumber, user,
+                commentString);
+    }
+
+}

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataRow.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataRow.java
@@ -1,0 +1,105 @@
+package uk.ac.sanger.sccp.stan.service.imagedatafile;
+
+import java.util.Objects;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.describe;
+
+/**
+ * @author dr6
+ */
+public class ImageDataRow {
+    private String barcode;
+    private String externalName;
+    private String omeroProject;
+    private String workNumber;
+    private String userName;
+    private String comments;
+
+    public ImageDataRow(String barcode, String externalName, String omeroProject, String workNumber, String userName,
+                        String comments) {
+        this.barcode = barcode;
+        this.externalName = externalName;
+        this.omeroProject = omeroProject;
+        this.workNumber = workNumber;
+        this.userName = userName;
+        this.comments = comments;
+    }
+
+    public String getBarcode() {
+        return this.barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    public String getExternalName() {
+        return this.externalName;
+    }
+
+    public void setExternalName(String externalName) {
+        this.externalName = externalName;
+    }
+
+    public String getOmeroProject() {
+        return this.omeroProject;
+    }
+
+    public void setOmeroProject(String omeroProject) {
+        this.omeroProject = omeroProject;
+    }
+
+    public String getWorkNumber() {
+        return this.workNumber;
+    }
+
+    public void setWorkNumber(String workNumber) {
+        this.workNumber = workNumber;
+    }
+
+    public String getUserName() {
+        return this.userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getComments() {
+        return this.comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ImageDataRow that = (ImageDataRow) o;
+        return (Objects.equals(this.barcode, that.barcode)
+                && Objects.equals(this.externalName, that.externalName)
+                && Objects.equals(this.omeroProject, that.omeroProject)
+                && Objects.equals(this.workNumber, that.workNumber)
+                && Objects.equals(this.userName, that.userName)
+                && Objects.equals(this.comments, that.comments));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(barcode, externalName, omeroProject, workNumber, userName, comments);
+    }
+
+    @Override
+    public String toString() {
+        return describe(this)
+                .add("barcode", barcode)
+                .add("externalName", externalName)
+                .add("omeroProject", omeroProject)
+                .add("workNumber", workNumber)
+                .add("userName", userName)
+                .add("comments", comments)
+                .reprStringValues()
+                .toString();
+    }
+}

--- a/src/main/java/uk/ac/sanger/sccp/utils/tsv/TsvData.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/tsv/TsvData.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 /**
  * The data required for a tsv file
+ * @param <C> the type of the columns
+ * @param <E> the type of the data
  * @author dr6
  */
 public interface TsvData<C, E> {

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/imagedatafile/TestImageDataFileService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/imagedatafile/TestImageDataFileService.java
@@ -1,0 +1,194 @@
+package uk.ac.sanger.sccp.stan.service.imagedatafile;
+
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import uk.ac.sanger.sccp.stan.EntityFactory;
+import uk.ac.sanger.sccp.stan.model.*;
+import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.utils.Zip;
+import uk.ac.sanger.sccp.utils.tsv.TsvFile;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+/** Test {@link ImageDataFileServiceImp} */
+class TestImageDataFileService {
+    @Mock
+    WorkRepo mockWorkRepo;
+    @Mock
+    OperationCommentRepo mockOpComRepo;
+    @Mock
+    LabwareRepo mockLwRepo;
+
+    @InjectMocks
+    ImageDataFileServiceImp service;
+
+    private AutoCloseable mocking;
+
+    @BeforeEach
+    void setup() {
+        mocking = MockitoAnnotations.openMocks(this);
+        service = spy(service);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        mocking.close();
+    }
+
+    @Test
+    void testGenerateFile() {
+        Operation op = new Operation();
+        op.setId(10);
+        String filename = "filename.xlsx";
+        doReturn(filename).when(service).getFilename(op);
+        List<ImageDataColumn> columns = List.of(ImageDataColumn.filename, ImageDataColumn.omero_name);
+        doReturn(columns).when(service).getColumns();
+        List<ImageDataRow> rows = List.of(new ImageDataRow("bc1", "xn1", "op1", "SGP1", "user1", "com1"));
+        doReturn(rows).when(service).getRows(op);
+
+        TsvFile<?> tsvFile = service.generateFile(op);
+
+        verify(service).getFilename(op);
+        verify(service).getColumns();
+        verify(service).getRows(op);
+
+        assertEquals(filename, tsvFile.getFilename());
+        assertEquals(columns, tsvFile.getColumns());
+        assertEquals(rows.size(), tsvFile.getNumRows());
+    }
+
+    @Test
+    void testGetFilename() {
+        Operation op = new Operation();
+        op.setId(17);
+        assertEquals("imaging-qc-17.xlsx", service.getFilename(op));
+    }
+
+    @Test
+    void testGetColumns() {
+        assertThat(service.getColumns()).containsExactly(ImageDataColumn.values());
+    }
+
+    @Test
+    void testCompileCommentMap() {
+        Comment com1 = new Comment(1, "Alpha", "a");
+        Comment com2 = new Comment(2, "Beta", "a");
+        Operation op = new Operation();
+        op.setId(10);
+        List<OperationComment> opcoms = List.of(
+                new OperationComment(1, com2, 10, 50, 60, null),
+                new OperationComment(2, com1, 10, 50, 61, null),
+                new OperationComment(3, com1, 10, 51, 61, null)
+        );
+        when(mockOpComRepo.findAllByOperationIdIn(any())).thenReturn(opcoms);
+
+        Map<Integer, List<Comment>> map = service.compileCommentMap(op.getId());
+
+        verify(mockOpComRepo).findAllByOperationIdIn(List.of(op.getId()));
+
+        assertThat(map).hasSize(2);
+        assertThat(map.get(50)).containsExactly(com1, com2);
+        assertThat(map.get(51)).containsExactly(com1);
+    }
+
+    @Test
+    void testCompileLabwareMap() {
+        Sample sample = EntityFactory.getSample();
+        Labware lw = EntityFactory.makeLabware(EntityFactory.makeLabwareType(1, 2), sample, sample);
+        List<Labware> lws = List.of(lw);
+        OperationType opType = EntityFactory.makeOperationType("OpType", null);
+        Operation op = EntityFactory.makeOpForLabware(opType, lws, lws);
+        when(mockLwRepo.findAllByIdIn(any())).thenReturn(lws);
+
+        Map<Integer, Labware> map = service.compileLabwareMap(op);
+
+        verify(mockLwRepo).findAllByIdIn(Set.of(lw.getId()));
+
+        assertThat(map).hasSize(1);
+        assertSame(lw, map.get(lw.getId()));
+    }
+
+    @Test
+    void testGetRows() {
+        Operation op = new Operation();
+        op.setId(10);
+        User user = EntityFactory.getUser();
+        op.setUser(user);
+        Work work = EntityFactory.makeWork("SGP1");
+        work.setOmeroProject(new OmeroProject(1, "omero1"));
+        when(mockWorkRepo.findWorksForOperationId(any())).thenReturn(List.of(work));
+        Map<Integer, List<Comment>> commentMap = Map.of(2, List.of(new Comment(1, "Alpha", "a")));
+        Map<Integer, Labware> lwMap = Map.of(1, EntityFactory.getTube());
+        doReturn(commentMap).when(service).compileCommentMap(any());
+        doReturn(lwMap).when(service).compileLabwareMap(any());
+
+        List<ImageDataRow> rows = List.of(new ImageDataRow("bc1", "xn1", "op1", "SGP1", "user1", "com1"));
+        doReturn(rows).when(service).compileRows(any(), any(), any(), any(), any(), any());
+
+        assertSame(rows, service.getRows(op));
+
+        verify(mockWorkRepo).findWorksForOperationId(op.getId());
+        verify(service).compileCommentMap(op.getId());
+        verify(service).compileLabwareMap(op);
+        verify(service).compileRows(op, "omero1", "SGP1", user.getUsername(), lwMap, commentMap);
+    }
+
+    @Test
+    void testCompileRows() {
+        Operation op = new Operation();
+        op.setId(1);
+        String omeroProject = "omero1";
+        String workNumber = "SGP1";
+        String username = "user1";
+        Map<Integer, Labware> lwMap = Map.of(1, EntityFactory.getTube());
+        Map<Integer, List<Comment>> commentMap = Map.of(2, List.of(new Comment(1, "Alpha", "a")));
+
+        Sample[] samples = EntityFactory.makeSamples(2);
+        List<Action> actions = List.of(new Action(), new Action(), new Action());
+        actions.get(0).setId(10);
+        actions.get(1).setId(11);
+        actions.get(2).setId(12);
+        Zip.of(Stream.of(samples[0], samples[1], samples[1]), actions.stream()).forEach((sam, ac) -> ac.setSample(sam));
+        op.setActions(actions);
+
+        ImageDataRow row = new ImageDataRow("bc1", "xn1", "op1", "SGP1", "user1", "com1");
+        doReturn(row).when(service).makeRow(any(), any(), any(), any(), any(), any());
+
+        List<ImageDataRow> rows = service.compileRows(op, omeroProject, workNumber, username, lwMap, commentMap);
+
+        verify(service, times(2)).makeRow(any(), any(), any(), any(), any(), any());
+        actions.subList(0,2).forEach(ac -> verify(service).makeRow(same(ac), eq(omeroProject), eq(workNumber), eq(username), same(lwMap), same(commentMap)));
+
+        assertThat(rows).containsExactly(row);
+    }
+
+    @Test
+    void testMakeRow() {
+        Action ac = new Action();
+        Labware lw = EntityFactory.getTube();
+        Slot slot = lw.getFirstSlot();
+        Sample sample = slot.getSamples().getFirst();
+        ac.setDestination(slot);
+        ac.setSample(sample);
+        Map<Integer, Labware> lwMap = Map.of(lw.getId(), lw);
+        String workNumber = "SGP1";
+        String username = "user1";
+        String omeroProject = "omero1";
+        Map<Integer, List<Comment>> commentMap = Map.of(sample.getId(),
+                List.of(new Comment(1, "Alpha", "a"),
+                        new Comment(2, "Beta.", "a")));
+        ImageDataRow row = service.makeRow(ac, omeroProject, workNumber, username, lwMap, commentMap);
+        assertEquals(lw.getBarcode(), row.getBarcode());
+        assertEquals(sample.getTissue().getExternalName(), row.getExternalName());
+        assertEquals(workNumber, row.getWorkNumber());
+        assertEquals(omeroProject, row.getOmeroProject());
+        assertEquals(username, row.getUserName());
+        assertEquals("Alpha. Beta.", row.getComments());
+    }
+}


### PR DESCRIPTION
For #624

New download url is at `imageqc?id=` supplying an image qc operation id.
Generates an Excel `.xlsx` file on demand.