### PR TITLE
x1520 UAT change: Support generating an image qc file for multiple ops

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/ImageDataFileController.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/ImageDataFileController.java
@@ -9,6 +9,10 @@ import uk.ac.sanger.sccp.stan.service.imagedatafile.ImageDataFileService;
 import uk.ac.sanger.sccp.utils.tsv.TsvFile;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
+
+import static uk.ac.sanger.sccp.utils.BasicUtils.asList;
+import static uk.ac.sanger.sccp.utils.BasicUtils.nullOrEmpty;
 
 /**
  * Controller for delivering image data files (excel).
@@ -30,12 +34,22 @@ public class ImageDataFileController {
     @RequestMapping(value="/imageqc", method=RequestMethod.GET,
                     produces="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @ResponseBody
-    public TsvFile<?> getImageDataFile(@RequestParam(name="id") Integer id) {
-        Operation op = opRepo.findById(id).orElseThrow(() -> new EntityNotFoundException("No operation found with id " + id+"."));
-        if (!op.getOperationType().getName().equalsIgnoreCase(IMAGING_QC_OP_NAME)) {
-            throw new IllegalArgumentException("Operation " + id + " is not an imaging QC operation");
+    public TsvFile<?> getImageDataFile(@RequestParam(name="id") List<Integer> ids) {
+        if (nullOrEmpty(ids)) {
+            throw new IllegalArgumentException("No operation IDs provided.");
         }
-        return imageDataFileService.generateFile(op);
+        List<Operation> ops = asList(opRepo.findAllById(ids));
+        if (ops.isEmpty()) {
+            throw new EntityNotFoundException("No operations found with IDs " + ids);
+        }
+        List<Integer> wrongOpTypeIds = ops.stream()
+                .filter(op -> !op.getOperationType().getName().equalsIgnoreCase(IMAGING_QC_OP_NAME))
+                .map(Operation::getId)
+                .toList();
+        if (!wrongOpTypeIds.isEmpty()) {
+            throw new IllegalArgumentException("Not an imaging QC operation: "+wrongOpTypeIds);
+        }
+        return imageDataFileService.generateFile(ops);
         // TsvFileConverter will convert the data to an excel file
     }
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileService.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileService.java
@@ -3,12 +3,14 @@ package uk.ac.sanger.sccp.stan.service.imagedatafile;
 import uk.ac.sanger.sccp.stan.model.Operation;
 import uk.ac.sanger.sccp.utils.tsv.TsvFile;
 
+import java.util.Collection;
+
 /** Service for generating file data for image qc ops */
 public interface ImageDataFileService {
     /**
-     * Generate file data containing the image data for the given operation.
-     * @param op the operation
+     * Generate file data containing the image data for the given operations.
+     * @param ops the operations
      * @return the file data
      */
-    TsvFile<?> generateFile(Operation op);
+    TsvFile<?> generateFile(Collection<Operation> ops);
 }

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileServiceImp.java
@@ -8,9 +8,10 @@ import uk.ac.sanger.sccp.utils.tsv.TsvColumn;
 import uk.ac.sanger.sccp.utils.tsv.TsvFile;
 
 import java.util.*;
+import java.util.function.Function;
 
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toMap;
 import static uk.ac.sanger.sccp.utils.BasicUtils.*;
 
 /**
@@ -30,16 +31,24 @@ public class ImageDataFileServiceImp implements ImageDataFileService {
     }
 
     @Override
-    public TsvFile<?> generateFile(Operation op) {
-        String filename = getFilename(op);
+    public TsvFile<?> generateFile(Collection<Operation> ops) {
+        String filename = getFilename(ops);
         List<? extends TsvColumn<ImageDataRow>> columns = getColumns();
-        List<ImageDataRow> rows = getRows(op);
+        List<ImageDataRow> rows = getRows(ops);
         return new TsvFile<>(filename, rows, columns);
     }
 
-    /** Filename for the given operation */
-    public String getFilename(Operation op) {
-        return "imaging-qc-" + op.getId() + ".xlsx";
+    /** An op id and a sample id */
+    record OpIdSampleId(int opId, int sampleId) {
+        OpIdSampleId(OperationComment opcom) {
+            this(opcom.getOperationId(), opcom.getSampleId());
+        }
+    }
+
+    /** Filename for the given operations */
+    public String getFilename(Collection<Operation> ops) {
+        String idsJoined = ops.stream().map(Operation::getId).map(Object::toString).collect(joining("-"));
+        return "imaging-qc-" + idsJoined + ".xlsx";
     }
 
     /** The columns in the file */
@@ -47,48 +56,74 @@ public class ImageDataFileServiceImp implements ImageDataFileService {
         return Arrays.asList(ImageDataColumn.values());
     }
 
-    /** Gets the comments for the operation, mapped from slot/sample id */
-    public Map<Integer, List<Comment>> compileCommentMap(Integer opId) {
-        List<OperationComment> opcoms = opComRepo.findAllByOperationIdIn(List.of(opId));
+    /** Gets comments from the specified ops, mapped from op id and sample id */
+    Map<OpIdSampleId, List<Comment>> compileCommentMap(Collection<Integer> opIds) {
+        List<OperationComment> opcoms = opComRepo.findAllByOperationIdIn(opIds);
         if (opcoms.isEmpty()) {
             return Map.of();
         }
-        Map<Integer, List<Comment>> map = new HashMap<>();
-        for (OperationComment opCom : opcoms) {
-            map.computeIfAbsent(opCom.getSampleId(), k -> new ArrayList<>())
-                    .add(opCom.getComment());
+        Map<OpIdSampleId, List<Comment>> map = new HashMap<>();
+        for (OperationComment opcom : opcoms) {
+            map.computeIfAbsent(new OpIdSampleId(opcom), k -> new ArrayList<>())
+                    .add(opcom.getComment());
         }
         map.replaceAll((k, v) -> v.stream().sorted(Comparator.comparingInt(Comment::getId)).distinct().toList());
         return map;
     }
 
-    /** Gets the labware for the operation, mapped from their ids */
-    public Map<Integer, Labware> compileLabwareMap(Operation op) {
-        Set<Integer> labwareIds = op.getActions().stream()
+    /** Gets the labware for the operations, mapped from their ids */
+    public Map<Integer, Labware> compileLabwareMap(Collection<Operation> ops) {
+        Set<Integer> labwareIds = ops.stream()
+                .flatMap(op -> op.getActions().stream())
                 .map(ac -> ac.getDestination().getLabwareId())
                 .collect(toSet());
         return lwRepo.findAllByIdIn(labwareIds).stream()
                 .collect(inMap(Labware::getId));
     }
 
-    /** Gets the rows for the operation */
-    public List<ImageDataRow> getRows(Operation op) {
-        List<Work> works = workRepo.findWorksForOperationId(op.getId());
-        String workNumber = works.stream().map(Work::getWorkNumber).collect(joining(", "));
-        String omeroProject = works.stream()
+    /** Loads the works linked to each operation id */
+    public Map<Integer, List<Work>> loadOpWorks(List<Integer> opIds) {
+        Map<Integer, List<Integer>> opWorkIds = opIds.stream()
+                .collect(toMap(Function.identity(), workRepo::findWorkIdsForOperationId));
+        Set<Integer> workIds = opWorkIds.values().stream().flatMap(List::stream).collect(toSet());
+        Map<Integer, Work> workIdMap = stream(workRepo.findAllById(workIds)).collect(inMap(Work::getId));
+        return opWorkIds.entrySet().stream().collect(toMap(Map.Entry::getKey,
+                e -> e.getValue().stream().map(workIdMap::get).toList()));
+    }
+
+    /** Gets a string describing the omero project for the given works */
+    public String getOmeroString(Collection<Work> works) {
+        return works.stream()
                 .map(Work::getOmeroProject)
                 .filter(Objects::nonNull)
                 .distinct()
                 .map(OmeroProject::getName)
                 .collect(joining(", "));
-        Map<Integer, List<Comment>> sampleComments = compileCommentMap(op.getId());
-        Map<Integer, Labware> lwMap = compileLabwareMap(op);
-        return compileRows(op, omeroProject, workNumber, op.getUser().getUsername(), lwMap, sampleComments);
+    }
+
+    /** Gets a string of work numbers from the given works */
+    public String getWorkString(Collection<Work> works) {
+        return works.stream()
+                .map(Work::getWorkNumber)
+                .collect(joining(", "));
+    }
+
+    /** Gets data rows for all the given operations */
+    public List<ImageDataRow> getRows(Collection<Operation> ops) {
+        List<Integer> opIds = ops.stream().map(Operation::getId).toList();
+        Map<Integer, List<Work>> opWorks = loadOpWorks(opIds);
+        Map<Integer, String> opWorkNumber = opWorks.entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, e -> getWorkString(opWorks.get(e.getKey()))));
+        Map<Integer, String> opOmero = opWorks.entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, e -> getOmeroString(opWorks.get(e.getKey()))));
+        Map<OpIdSampleId, List<Comment>> opSampleComments = compileCommentMap(opIds);
+        Map<Integer, Labware> lwMap = compileLabwareMap(ops);
+        return compileAllRows(ops, opOmero, opWorkNumber, lwMap, opSampleComments);
     }
 
     /** Puts together rows given various data. One row per sample */
-    public List<ImageDataRow> compileRows(Operation op, String omeroProject, String workNumber, String user,
-                                          Map<Integer, Labware> lwMap, Map<Integer, List<Comment>> sampleComments) {
+    List<ImageDataRow> compileRows(Operation op, String omeroProject, String workNumber, String user,
+                                   Map<Integer, Labware> lwMap, Map<OpIdSampleId, List<Comment>> sampleComments) {
         return op.getActions().stream()
                 .filter(distinctBySerial(ac -> ac.getSample().getId()))
                 .map(ac -> makeRow(ac, omeroProject, workNumber, user, lwMap, sampleComments))
@@ -96,13 +131,23 @@ public class ImageDataFileServiceImp implements ImageDataFileService {
                 .toList();
     }
 
+    /** Compiles rows from multiple operations and various compiled data. One row per sample, per op. */
+    List<ImageDataRow> compileAllRows(Collection<Operation> ops, Map<Integer, String> opOmero,
+                                          Map<Integer, String> opWorkNumber, Map<Integer, Labware> lwMap,
+                                          Map<OpIdSampleId, List<Comment>> opSampleComments) {
+        return ops.stream()
+                .flatMap(op -> compileRows(op, opOmero.get(op.getId()), opWorkNumber.get(op.getId()),
+                        op.getUser().getUsername(), lwMap, opSampleComments).stream())
+                .toList();
+    }
+
     /** Converts an action to a row */
-    public ImageDataRow makeRow(Action ac, String omeroProject, String workNumber, String user,
-                                Map<Integer, Labware> lwMap, Map<Integer, List<Comment>> slotSampleComments) {
+    ImageDataRow makeRow(Action ac, String omeroProject, String workNumber, String user,
+                                Map<Integer, Labware> lwMap, Map<OpIdSampleId, List<Comment>> slotSampleComments) {
         Slot slot = ac.getDestination();
         Sample sample = ac.getSample();
         Labware lw = lwMap.get(slot.getLabwareId());
-        List<Comment> comments = slotSampleComments.get(sample.getId());
+        List<Comment> comments = slotSampleComments.get(new OpIdSampleId(ac.getOperationId(), sample.getId()));
         String commentString;
         if (nullOrEmpty(comments)) {
             commentString = null;
@@ -115,5 +160,4 @@ public class ImageDataFileServiceImp implements ImageDataFileService {
         return new ImageDataRow(lw.getBarcode(), sample.getTissue().getExternalName(), omeroProject, workNumber, user,
                 commentString);
     }
-
 }

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/imagedatafile/TestImageDataFileService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/imagedatafile/TestImageDataFileService.java
@@ -5,19 +5,26 @@ import org.mockito.*;
 import uk.ac.sanger.sccp.stan.EntityFactory;
 import uk.ac.sanger.sccp.stan.model.*;
 import uk.ac.sanger.sccp.stan.repo.*;
+import uk.ac.sanger.sccp.stan.service.imagedatafile.ImageDataFileServiceImp.OpIdSampleId;
 import uk.ac.sanger.sccp.utils.Zip;
 import uk.ac.sanger.sccp.utils.tsv.TsvFile;
 
 import java.util.*;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-/** Test {@link ImageDataFileServiceImp} */
-class TestImageDataFileService {
+/**
+ * Tests {@link ImageDataFileServiceImp}
+ * @author dr6
+ */
+public class TestImageDataFileService {
     @Mock
     WorkRepo mockWorkRepo;
     @Mock
@@ -41,23 +48,30 @@ class TestImageDataFileService {
         mocking.close();
     }
 
+    private Operation opWithId(int id) {
+        Operation op = new Operation();
+        op.setId(id);
+        return op;
+    }
+
+    private List<Operation> opsWithId(int... ids) {
+        return IntStream.of(ids).mapToObj(this::opWithId).toList();
+    }
+
     @Test
     void testGenerateFile() {
-        Operation op = new Operation();
-        op.setId(10);
-        String filename = "filename.xlsx";
-        doReturn(filename).when(service).getFilename(op);
+        List<Operation> ops = opsWithId(10,11,12);
+        String filename = "returnedFilename";
+        doReturn(filename).when(service).getFilename(any());
         List<ImageDataColumn> columns = List.of(ImageDataColumn.filename, ImageDataColumn.omero_name);
         doReturn(columns).when(service).getColumns();
         List<ImageDataRow> rows = List.of(new ImageDataRow("bc1", "xn1", "op1", "SGP1", "user1", "com1"));
-        doReturn(rows).when(service).getRows(op);
+        doReturn(rows).when(service).getRows(any());
 
-        TsvFile<?> tsvFile = service.generateFile(op);
-
-        verify(service).getFilename(op);
+        TsvFile<?> tsvFile = service.generateFile(ops);
+        verify(service).getFilename(ops);
         verify(service).getColumns();
-        verify(service).getRows(op);
-
+        verify(service).getRows(ops);
         assertEquals(filename, tsvFile.getFilename());
         assertEquals(columns, tsvFile.getColumns());
         assertEquals(rows.size(), tsvFile.getNumRows());
@@ -65,10 +79,10 @@ class TestImageDataFileService {
 
     @Test
     void testGetFilename() {
-        Operation op = new Operation();
-        op.setId(17);
-        assertEquals("imaging-qc-17.xlsx", service.getFilename(op));
+        List<Operation> ops = opsWithId(11,10,12);
+        assertEquals("imaging-qc-11-10-12.xlsx", service.getFilename(ops));
     }
+
 
     @Test
     void testGetColumns() {
@@ -77,66 +91,78 @@ class TestImageDataFileService {
 
     @Test
     void testCompileCommentMap() {
-        Comment com1 = new Comment(1, "Alpha", "a");
-        Comment com2 = new Comment(2, "Beta", "a");
-        Operation op = new Operation();
-        op.setId(10);
+        List<Comment> comments = IntStream.of(20,21)
+                .mapToObj(i -> new Comment(i, "com"+i, "cat"))
+                .toList();
+        List<Integer> opIds = List.of(10,11);
         List<OperationComment> opcoms = List.of(
-                new OperationComment(1, com2, 10, 50, 60, null),
-                new OperationComment(2, com1, 10, 50, 61, null),
-                new OperationComment(3, com1, 10, 51, 61, null)
+                new OperationComment(1, comments.get(0), 10, 30, null, null),
+                new OperationComment(2, comments.get(1), 10, 30, null, null),
+                new OperationComment(3, comments.get(0), 10, 31, null, null),
+                new OperationComment(4, comments.get(0), 11, 30, null, null)
         );
         when(mockOpComRepo.findAllByOperationIdIn(any())).thenReturn(opcoms);
-
-        Map<Integer, List<Comment>> map = service.compileCommentMap(op.getId());
-
-        verify(mockOpComRepo).findAllByOperationIdIn(List.of(op.getId()));
-
-        assertThat(map).hasSize(2);
-        assertThat(map.get(50)).containsExactly(com1, com2);
-        assertThat(map.get(51)).containsExactly(com1);
+        Map<OpIdSampleId, List<Comment>> commentMap = service.compileCommentMap(opIds);
+        verify(mockOpComRepo).findAllByOperationIdIn(opIds);
+        assertThat(commentMap).hasSize(3);
+        assertThat(commentMap.get(new OpIdSampleId(10, 30))).containsExactlyInAnyOrderElementsOf(comments);
+        assertThat(commentMap.get(new OpIdSampleId(10, 31))).containsExactly(comments.getFirst());
+        assertThat(commentMap.get(new OpIdSampleId(11, 30))).containsExactly(comments.getFirst());
     }
+
 
     @Test
     void testCompileLabwareMap() {
         Sample sample = EntityFactory.getSample();
-        Labware lw = EntityFactory.makeLabware(EntityFactory.makeLabwareType(1, 2), sample, sample);
-        List<Labware> lws = List.of(lw);
+        final LabwareType lt = EntityFactory.makeLabwareType(1, 2);
+        Labware[] lws = {
+                EntityFactory.makeLabware(lt, sample, sample),
+                EntityFactory.makeLabware(lt, sample, sample)
+        };
+        Set<Integer> lwIds = Arrays.stream(lws).map(Labware::getId).collect(toSet());
         OperationType opType = EntityFactory.makeOperationType("OpType", null);
-        Operation op = EntityFactory.makeOpForLabware(opType, lws, lws);
-        when(mockLwRepo.findAllByIdIn(any())).thenReturn(lws);
+        List<Operation> ops = Arrays.stream(lws)
+                .map(List::of)
+                .map(list -> EntityFactory.makeOpForLabware(opType, list, list))
+                .toList();
+        when(mockLwRepo.findAllByIdIn(any())).thenReturn(Arrays.asList(lws));
 
-        Map<Integer, Labware> map = service.compileLabwareMap(op);
+        Map<Integer, Labware> map = service.compileLabwareMap(ops);
 
-        verify(mockLwRepo).findAllByIdIn(Set.of(lw.getId()));
+        verify(mockLwRepo).findAllByIdIn(lwIds);
 
-        assertThat(map).hasSize(1);
-        assertSame(lw, map.get(lw.getId()));
+        assertThat(map).hasSize(2);
+        for (Labware lw : lws) {
+            assertSame(lw, map.get(lw.getId()));
+        }
     }
 
     @Test
     void testGetRows() {
-        Operation op = new Operation();
-        op.setId(10);
-        User user = EntityFactory.getUser();
-        op.setUser(user);
-        Work work = EntityFactory.makeWork("SGP1");
-        work.setOmeroProject(new OmeroProject(1, "omero1"));
-        when(mockWorkRepo.findWorksForOperationId(any())).thenReturn(List.of(work));
-        Map<Integer, List<Comment>> commentMap = Map.of(2, List.of(new Comment(1, "Alpha", "a")));
-        Map<Integer, Labware> lwMap = Map.of(1, EntityFactory.getTube());
-        doReturn(commentMap).when(service).compileCommentMap(any());
+        List<Operation> ops = opsWithId(10,11);
+        List<Work> works = Stream.of("SGP1", "SGP2").map(EntityFactory::makeWork).toList();
+        works.get(0).setOmeroProject(new OmeroProject(80, "om80"));
+        works.get(1).setOmeroProject(new OmeroProject(81, "om81"));
+        Map<Integer, List<Work>> opWorks = Map.of(10, works, 11, List.of(works.getFirst()));
+        doReturn(opWorks).when(service).loadOpWorks(any());
+        Map<OpIdSampleId, List<Comment>> opSampleComments = Map.of(
+                new OpIdSampleId(10, 20), List.of(new Comment(1, "com1", "cat")),
+                new OpIdSampleId(11, 21), List.of(new Comment(2, "com2", "cat"))
+        );
+        doReturn(opSampleComments).when(service).compileCommentMap(any());
+        Map<Integer, Labware> lwMap = Map.of(40, EntityFactory.getTube());
         doReturn(lwMap).when(service).compileLabwareMap(any());
+        List<ImageDataRow> rows = List.of(new ImageDataRow("BC", "XN", "OM", "WN", "UN", "com"));
+        doReturn(rows).when(service).compileAllRows(anyCollection(), anyMap(), anyMap(), anyMap(), anyMap());
 
-        List<ImageDataRow> rows = List.of(new ImageDataRow("bc1", "xn1", "op1", "SGP1", "user1", "com1"));
-        doReturn(rows).when(service).compileRows(any(), any(), any(), any(), any(), any());
-
-        assertSame(rows, service.getRows(op));
-
-        verify(mockWorkRepo).findWorksForOperationId(op.getId());
-        verify(service).compileCommentMap(op.getId());
-        verify(service).compileLabwareMap(op);
-        verify(service).compileRows(op, "omero1", "SGP1", user.getUsername(), lwMap, commentMap);
+        assertSame(rows, service.getRows(ops));
+        final List<Integer> opIds = List.of(10, 11);
+        verify(service).loadOpWorks(opIds);
+        verify(service).compileCommentMap(opIds);
+        verify(service).compileLabwareMap(ops);
+        Map<Integer, String> opOmero = Map.of(10, "om80, om81", 11, "om80");
+        Map<Integer, String> opWorkNumber = Map.of(10, "SGP1, SGP2", 11, "SGP1");
+        verify(service).compileAllRows(ops, opOmero, opWorkNumber, lwMap, opSampleComments);
     }
 
     @Test
@@ -147,7 +173,7 @@ class TestImageDataFileService {
         String workNumber = "SGP1";
         String username = "user1";
         Map<Integer, Labware> lwMap = Map.of(1, EntityFactory.getTube());
-        Map<Integer, List<Comment>> commentMap = Map.of(2, List.of(new Comment(1, "Alpha", "a")));
+        Map<OpIdSampleId, List<Comment>> commentMap = Map.of(new OpIdSampleId(1, 2), List.of(new Comment(1, "Alpha", "a")));
 
         Sample[] samples = EntityFactory.makeSamples(2);
         List<Action> actions = List.of(new Action(), new Action(), new Action());
@@ -169,8 +195,33 @@ class TestImageDataFileService {
     }
 
     @Test
+    void testCompileAllRows() {
+        List<Operation> ops = opsWithId(10, 11);
+        List<User> users = IntStream.of(1,2).mapToObj(i -> new User(i, "user"+i, null)).toList();
+        Zip.of(ops.stream(), users.stream()).forEach(Operation::setUser);
+        Map<Integer, String> opOmero = Map.of(10, "om10");
+        Map<Integer, String> opWork = Map.of(10, "SGP10");
+        Map<Integer, Labware> lwMap = Map.of(50, EntityFactory.getTube());
+        Map<OpIdSampleId, List<Comment>> opSampleComments = Map.of(
+                new OpIdSampleId(10, 20), List.of(new Comment(1, "Alpha", "a"))
+        );
+        List<ImageDataRow> rows = List.of(
+                new ImageDataRow("BC1", "XN1", "OM1", "SGP1", "UN", "com1"),
+                new ImageDataRow("BC1", "XN2", "OM1", "SGP2", "UN", "com2"),
+                new ImageDataRow("BC2", "XN1", null, null, "UN", "com1")
+        );
+        doReturn(rows.subList(0,2)).when(service).compileRows(same(ops.getFirst()), any(), any(), any(), any(), any());
+        doReturn(rows.subList(2,3)).when(service).compileRows(same(ops.getLast()), any(), any(), any(), any(), any());
+
+        assertEquals(rows, service.compileAllRows(ops, opOmero, opWork, lwMap, opSampleComments));
+        verify(service).compileRows(ops.getFirst(), "om10", "SGP10", "user1", lwMap, opSampleComments);
+        verify(service).compileRows(ops.get(1), null, null, "user2", lwMap, opSampleComments);
+    }
+
+    @Test
     void testMakeRow() {
         Action ac = new Action();
+        ac.setOperationId(400);
         Labware lw = EntityFactory.getTube();
         Slot slot = lw.getFirstSlot();
         Sample sample = slot.getSamples().getFirst();
@@ -180,7 +231,7 @@ class TestImageDataFileService {
         String workNumber = "SGP1";
         String username = "user1";
         String omeroProject = "omero1";
-        Map<Integer, List<Comment>> commentMap = Map.of(sample.getId(),
+        Map<OpIdSampleId, List<Comment>> commentMap = Map.of(new OpIdSampleId(400, sample.getId()),
                 List.of(new Comment(1, "Alpha", "a"),
                         new Comment(2, "Beta.", "a")));
         ImageDataRow row = service.makeRow(ac, omeroProject, workNumber, username, lwMap, commentMap);
@@ -190,5 +241,25 @@ class TestImageDataFileService {
         assertEquals(omeroProject, row.getOmeroProject());
         assertEquals(username, row.getUserName());
         assertEquals("Alpha. Beta.", row.getComments());
+    }
+
+    @Test
+    void testLoadOpWorks() {
+        List<Integer> opIds = List.of(10,11,12);
+        List<Work> works = Arrays.stream(EntityFactory.makeWorks("SGP1", "SGP2", "SGP3")).toList();
+        List<Integer> workIds = works.stream().map(Work::getId).toList();
+        when(mockWorkRepo.findWorkIdsForOperationId(10)).thenReturn(workIds.subList(0,2));
+        when(mockWorkRepo.findWorkIdsForOperationId(11)).thenReturn(workIds.subList(1,3));
+        when(mockWorkRepo.findWorkIdsForOperationId(12)).thenReturn(List.of());
+        when(mockWorkRepo.findAllById(any())).thenReturn(works);
+
+        Map<Integer, List<Work>> opWorks = service.loadOpWorks(opIds);
+
+        opIds.forEach(id -> verify(mockWorkRepo).findWorkIdsForOperationId(id));
+        verify(mockWorkRepo).findAllById(new HashSet<>(workIds));
+        assertThat(opWorks.keySet()).containsExactlyInAnyOrderElementsOf(opIds);
+        assertThat(opWorks.get(10)).containsExactlyInAnyOrderElementsOf(works.subList(0,2));
+        assertThat(opWorks.get(11)).containsExactlyInAnyOrderElementsOf(works.subList(1,3));
+        assertThat(opWorks.get(12)).isEmpty();
     }
 }


### PR DESCRIPTION
For #648 

URL `imageqc?id=` now accepts multiple ids and generates a file combined for all of them.
