### PR TITLE
x1538 add main peak size to cytassist overview

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/model/CytassistOverview.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/model/CytassistOverview.java
@@ -41,6 +41,7 @@ public class CytassistOverview {
     private String visiumConcentrationType;
     private String visiumConcentrationValue;
     private String visiumConcentrationAverageSize;
+    private String visiumConcentrationMainPeakSize;
     private String visiumConcentrationRange;
     private LocalDateTime visiumConcentrationPerformed;
     private String latestBarcode;
@@ -282,6 +283,14 @@ public class CytassistOverview {
         this.visiumConcentrationAverageSize = visiumConcentrationAverageSize;
     }
 
+    public String getVisiumConcentrationMainPeakSize() {
+        return this.visiumConcentrationMainPeakSize;
+    }
+
+    public void setVisiumConcentrationMainPeakSize(String visiumConcentrationMainPeakSize) {
+        this.visiumConcentrationMainPeakSize = visiumConcentrationMainPeakSize;
+    }
+
     public String getVisiumConcentrationRange() {
         return this.visiumConcentrationRange;
     }
@@ -378,6 +387,7 @@ public class CytassistOverview {
                 .add("visiumConcentrationType", visiumConcentrationType)
                 .add("visiumConcentrationValue", visiumConcentrationValue)
                 .add("visiumConcentrationAverageSize", visiumConcentrationAverageSize)
+                .add("visiumConcentrationMainPeakSize", visiumConcentrationMainPeakSize)
                 .add("visiumConcentrationRange", visiumConcentrationRange)
                 .add("visiumConcentrationPerformed", visiumConcentrationPerformed)
                 .add("latestBarcode", latestBarcode)

--- a/src/main/java/uk/ac/sanger/sccp/stan/service/cytassistoverview/CytassistOverviewDataCompilerImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/cytassistoverview/CytassistOverviewDataCompilerImp.java
@@ -402,11 +402,13 @@ public class CytassistOverviewDataCompilerImp implements CytassistOverviewDataCo
                         if (measurementApplies(meas, foundSsIds)) {
                             String name = meas.getName();
                             if (name.equalsIgnoreCase("cDNA concentration")
-                                || name.equalsIgnoreCase("Library concentration")) {
+                                    || name.equalsIgnoreCase("Library concentration")) {
                                 d.row.setVisiumConcentrationType(name);
                                 d.row.setVisiumConcentrationValue(meas.getValue());
                             } else if (name.equalsIgnoreCase("Average size")) {
                                 d.row.setVisiumConcentrationAverageSize(meas.getValue());
+                            } else if (name.equalsIgnoreCase("Main peak size")) {
+                                d.row.setVisiumConcentrationMainPeakSize(meas.getValue());
                             }
                         }
                     }

--- a/src/main/resources/db/changelog/changelog-3.14.xml
+++ b/src/main/resources/db/changelog/changelog-3.14.xml
@@ -103,6 +103,9 @@
             <column name="visium_concentration_average_size" type="VARCHAR(16)">
                 <constraints nullable="true"/>
             </column>
+            <column name="visium_concentration_main_peak_size" type="VARCHAR(16)">
+                <constraints nullable="true"/>
+            </column>
             <column name="visium_concentration_range" type="VARCHAR(16)">
                 <constraints nullable="true"/>
             </column>

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/cytassistoverview/TestCytassistOverviewDataCompiler.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/cytassistoverview/TestCytassistOverviewDataCompiler.java
@@ -636,7 +636,8 @@ class TestCytassistOverviewDataCompiler {
         List<Measurement> measurements = List.of(
                 new Measurement(101, "cDNA concentration", "50", futureSamples[0].getId(), 1, futureSlots.get(0).getId()),
                 new Measurement(102, "Library concentration", "60", futureSamples[1].getId(), 2, futureSlots.get(1).getId()),
-                new Measurement(103, "Average size", "15", futureSamples[0].getId(), 1, futureSlots.get(0).getId())
+                new Measurement(103, "Average size", "15", futureSamples[0].getId(), 1, futureSlots.get(0).getId()),
+                new Measurement(104, "Main peak size", "22", futureSamples[0].getId(), 1, futureSlots.get(0).getId())
         );
         Comment com = new Comment(1, "10-20", "size range");
         OperationComment opcom = new OperationComment(21, com, ops.getFirst().getId(), futureSamples[0].getId(), futureSlots.getFirst().getId(), com.getId());
@@ -660,6 +661,7 @@ class TestCytassistOverviewDataCompiler {
         assertEquals("cDNA concentration", d.row.getVisiumConcentrationType());
         assertEquals("50", d.row.getVisiumConcentrationValue());
         assertEquals("15", d.row.getVisiumConcentrationAverageSize());
+        assertEquals("22", d.row.getVisiumConcentrationMainPeakSize());
         assertEquals("10-20", d.row.getVisiumConcentrationRange());
         assertEquals(ops.get(0).getPerformed(), d.row.getVisiumConcentrationPerformed());
         assertThat(d.users).containsExactly(user);
@@ -667,6 +669,7 @@ class TestCytassistOverviewDataCompiler {
         assertEquals("Library concentration", d.row.getVisiumConcentrationType());
         assertEquals("60", d.row.getVisiumConcentrationValue());
         assertNull(d.row.getVisiumConcentrationAverageSize());
+        assertNull(d.row.getVisiumConcentrationMainPeakSize());
         assertNull(d.row.getVisiumConcentrationRange());
         assertThat(d.users).containsExactly(user);
     }


### PR DESCRIPTION
For #647

_Main peak size_ is a measurement recorded in the _visium concentration_ op.