### PR TITLE
Use a shorter filename for image files with lots of ids.

### DIFF
--- a/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileServiceImp.java
+++ b/src/main/java/uk/ac/sanger/sccp/stan/service/imagedatafile/ImageDataFileServiceImp.java
@@ -47,7 +47,10 @@ public class ImageDataFileServiceImp implements ImageDataFileService {
 
     /** Filename for the given operations */
     public String getFilename(Collection<Operation> ops) {
-        String idsJoined = ops.stream().map(Operation::getId).map(Object::toString).collect(joining("-"));
+        List<int[]> ranges = ranges(ops.stream().mapToInt(Operation::getId));
+        String idsJoined = ranges.stream()
+                .map(arr -> arr.length==1 ? String.valueOf(arr[0]) : arr[0]+"to"+arr[1])
+                .collect(joining("-"));
         return "imaging-qc-" + idsJoined + ".xlsx";
     }
 

--- a/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sccp/utils/BasicUtils.java
@@ -644,6 +644,36 @@ public class BasicUtils {
     }
 
     /**
+     * Combines numbers into ranges. Each array in the result is either
+     * <ul>
+     *     <li><code>{lower,upper}</code> — indicating a range (inclusive)</li>
+     *     <li><code>{value}</code> — indicating a single value that is not part of a range</li>
+     * </ul>
+     * @param values int-stream of values
+     * @return a list of int arrays
+     */
+    public static List<int[]> ranges(IntStream values) {
+        int[] arr = values.sorted().distinct().toArray();
+        if (arr.length==0) {
+            return List.of();
+        }
+        List<int[]> ranges = new ArrayList<>();
+        int lower = arr[0];
+        int upper = lower;
+        for (int i = 1; i<arr.length; i++) {
+            int value = arr[i];
+            if (value==upper + 1) {
+                upper = value;
+            } else {
+                ranges.add(lower == upper ? new int[]{lower} : new int[]{lower, upper});
+                lower = upper = value;
+            }
+        }
+        ranges.add(lower == upper ? new int[]{lower} : new int[]{lower, upper});
+        return ranges;
+    }
+
+    /**
      * Streams pairs of items from the given list.
      * Each combination of items will be emitted once, via the given mapper function,
      * with the order of the items used as arguments consistent with the order they

--- a/src/test/java/uk/ac/sanger/sccp/stan/service/imagedatafile/TestImageDataFileService.java
+++ b/src/test/java/uk/ac/sanger/sccp/stan/service/imagedatafile/TestImageDataFileService.java
@@ -79,8 +79,8 @@ public class TestImageDataFileService {
 
     @Test
     void testGetFilename() {
-        List<Operation> ops = opsWithId(11,10,12);
-        assertEquals("imaging-qc-11-10-12.xlsx", service.getFilename(ops));
+        List<Operation> ops = opsWithId(11,10,12,9,14);
+        assertEquals("imaging-qc-9to12-14.xlsx", service.getFilename(ops));
     }
 
 

--- a/src/test/java/uk/ac/sanger/sccp/utils/TestBasicUtils.java
+++ b/src/test/java/uk/ac/sanger/sccp/utils/TestBasicUtils.java
@@ -416,6 +416,16 @@ public class TestBasicUtils {
     }
 
     @Test
+    public void testRanges() {
+        assertThat(ranges(IntStream.empty())).isEmpty();
+        assertThat(ranges(IntStream.of(3,1,2))).containsExactly(new int[]{1,3});
+        assertThat(ranges(IntStream.of(5))).containsExactly(new int[]{5});
+        assertThat(ranges(IntStream.of(10, 6, 8, 2, 4, 15, 0, 3, 9, 11))).containsExactly(
+                new int[][] {{0}, {2,4}, {6}, {8,11}, {15}}
+        );
+    }
+
+    @Test
     public void testStreamPairs() {
         assertThat(streamPairs(List.of(11,22,303,44), (a,b) -> new Integer[] {a,b}))
                 .containsExactly(new Integer[][] {


### PR DESCRIPTION
E.g. use `"imaging-qc-110to115.xslx"`
instead of `"imaging-qc-110-111-112-113-114-115.xlsx"`

For #673